### PR TITLE
uniform variable

### DIFF
--- a/clients/include/zukou.h
+++ b/clients/include/zukou.h
@@ -264,6 +264,9 @@ class OpenGLShaderProgram
  public:
   OpenGLShaderProgram(App *app);
   ~OpenGLShaderProgram();
+  void SetUniformVariable(const char *location, glm::mat4 mat);
+  void SetUniformVariable(const char *location, glm::vec4 vec);
+  void SetUniformVariable(const char *location, glm::vec3 vec);
   bool SetVertexShader(const char *source, size_t len);
   bool SetFragmentShader(const char *source, size_t len);
   void Link();
@@ -319,6 +322,10 @@ OpenGLComponent::component()
 glm::vec3 glm_vec3_from_wl_array(struct wl_array *array);
 
 void glm_vec3_to_wl_array(glm::vec3 v, struct wl_array *array);
+
+void glm_vec4_to_wl_array(glm::vec4 v, struct wl_array *array);
+
+void glm_mat4_to_wl_array(glm::mat4 m, struct wl_array *array);
 
 }  // namespace zukou
 

--- a/clients/simple-box/box.h
+++ b/clients/simple-box/box.h
@@ -35,10 +35,9 @@ class Box : public zukou::CuboidWindow
   zukou::OpenGLTexture *texture_;
 
   float length_;
-  float theta_;
-  float phi_;
   float delta_theta_;
   float delta_phi_;
+  glm::mat4 rotate_;
   Vertex points_[8];
 
   uint8_t blue_;

--- a/clients/zukou/glm-helper.cc
+++ b/clients/zukou/glm-helper.cc
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <zukou.h>
 
 #include <glm/glm.hpp>
@@ -14,10 +15,25 @@ glm_vec3_from_wl_array(struct wl_array *array)
 void
 glm_vec3_to_wl_array(glm::vec3 v, struct wl_array *array)
 {
-  float *data = (float *)wl_array_add(array, sizeof(float) * 3);
-  data[0] = v.x;
-  data[1] = v.y;
-  data[2] = v.z;
+  size_t size = sizeof(float) * 3;
+  float *data = (float *)wl_array_add(array, size);
+  memcpy(data, &v, size);
+}
+
+void
+glm_vec4_to_wl_array(glm::vec4 v, struct wl_array *array)
+{
+  size_t size = sizeof(float) * 4;
+  float *data = (float *)wl_array_add(array, size);
+  memcpy(data, &v, size);
+}
+
+void
+glm_mat4_to_wl_array(glm::mat4 m, struct wl_array *array)
+{
+  size_t size = sizeof(float) * 16;
+  float *data = (float *)wl_array_add(array, size);
+  memcpy(data, &m, size);
 }
 
 }  // namespace zukou

--- a/clients/zukou/opengl-shader-program.cc
+++ b/clients/zukou/opengl-shader-program.cc
@@ -35,6 +35,39 @@ OpenGLShaderProgram::~OpenGLShaderProgram()
   zgn_opengl_shader_program_destroy(shader_);
 }
 
+void
+OpenGLShaderProgram::SetUniformVariable(const char *location, glm::mat4 mat)
+{
+  struct wl_array array;
+  wl_array_init(&array);
+  glm_mat4_to_wl_array(mat, &array);
+  zgn_opengl_shader_program_set_uniform_float_matrix(
+      shader(), location, 4, 4, false, 1, &array);
+  wl_array_release(&array);
+}
+
+void
+OpenGLShaderProgram::SetUniformVariable(const char *location, glm::vec4 vec)
+{
+  struct wl_array array;
+  wl_array_init(&array);
+  glm_vec4_to_wl_array(vec, &array);
+  zgn_opengl_shader_program_set_uniform_float_vector(
+      shader(), location, 4, 1, &array);
+  wl_array_release(&array);
+}
+
+void
+OpenGLShaderProgram::SetUniformVariable(const char *location, glm::vec3 vec)
+{
+  struct wl_array array;
+  wl_array_init(&array);
+  glm_vec3_to_wl_array(vec, &array);
+  zgn_opengl_shader_program_set_uniform_float_vector(
+      shader(), location, 3, 1, &array);
+  wl_array_release(&array);
+}
+
 bool
 OpenGLShaderProgram::SetVertexShader(const char *source, size_t len)
 {

--- a/zen-renderer/opengl/opengl-component.c
+++ b/zen-renderer/opengl/opengl-component.c
@@ -255,6 +255,7 @@ zen_opengl_component_virtual_object_commit_handler(
 
   shader = zen_weak_link_get_user_data(&component->pending.shader_program_link);
   if (shader) {
+    zen_opengl_shader_program_commit(shader);
     zen_weak_link_set(
         &component->current.shader_program_link, shader->resource);
   }

--- a/zen-renderer/opengl/opengl-shader-program.c
+++ b/zen-renderer/opengl/opengl-shader-program.c
@@ -1,15 +1,33 @@
+#define _GNU_SOURCE
+
 #include "opengl-shader-program.h"
 
 #include <GL/glew.h>
 #include <libzen-compositor/libzen-compositor.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <zigen-opengl-server-protocol.h>
 
 static void zen_opengl_shader_program_destroy(
     struct zen_opengl_shader_program* shader);
 
+enum uniform_variable_type {
+  UNIFORM_FLOAT = 0,
+};
+
+struct uniform_variable {
+  char* location;
+  uint32_t col;
+  uint32_t row;
+  uint32_t type;
+  uint32_t count;
+  uint32_t transpose;
+  void* data;
+  uint32_t size;
+};
+
 static void
-zgn_opengl_shader_program_handle_destroy(struct wl_resource* resource)
+zen_opengl_shader_program_handle_destroy(struct wl_resource* resource)
 {
   struct zen_opengl_shader_program* shader;
 
@@ -19,7 +37,7 @@ zgn_opengl_shader_program_handle_destroy(struct wl_resource* resource)
 }
 
 static void
-zgn_opengl_shader_program_protocol_destroy(
+zen_opengl_shader_program_protocol_destroy(
     struct wl_client* client, struct wl_resource* resource)
 {
   UNUSED(client);
@@ -28,7 +46,69 @@ zgn_opengl_shader_program_protocol_destroy(
 }
 
 static void
-zgn_opengl_shader_program_protocol_set_vertex_shader(struct wl_client* client,
+zen_opengl_shader_program_protocol_set_uniform_float_vector(
+    struct wl_client* client, struct wl_resource* resource,
+    const char* location, uint32_t size, uint32_t count, struct wl_array* value)
+{
+  UNUSED(client);
+  struct zen_opengl_shader_program* shader_program =
+      wl_resource_get_user_data(resource);
+  struct uniform_variable* variable;
+
+  if (size == 0 || size > 4 || sizeof(float) * size != value->size) {
+    wl_resource_post_error(resource,
+        ZGN_OPENGL_SHADER_PROGRAM_ERROR_INVALID_UNIFORM_VARIABLE,
+        "given uniform vector's size is invalid");
+    return;
+  }
+
+  variable = wl_array_add(
+      &shader_program->pending.uniform_variables, sizeof(*variable));
+  variable->location = strdup(location);
+  variable->col = 1;
+  variable->row = size;
+  variable->type = UNIFORM_FLOAT;
+  variable->count = count;
+  variable->transpose = 0;
+  variable->data = malloc(value->size);
+  memcpy(variable->data, value->data, value->size);
+  variable->size = value->size;
+}
+
+static void
+zen_opengl_shader_program_protocol_set_uniform_float_matrix(
+    struct wl_client* client, struct wl_resource* resource,
+    const char* location, uint32_t col, uint32_t row, uint32_t transpose,
+    uint32_t count, struct wl_array* value)
+{
+  UNUSED(client);
+  struct zen_opengl_shader_program* shader_program =
+      wl_resource_get_user_data(resource);
+  struct uniform_variable* variable;
+
+  if (col < 2 || col > 4 || row < 2 || row > 4 ||
+      sizeof(float) * col * row != value->size) {
+    wl_resource_post_error(resource,
+        ZGN_OPENGL_SHADER_PROGRAM_ERROR_INVALID_UNIFORM_VARIABLE,
+        "given uniform matrix's size is invalid");
+    return;
+  }
+
+  variable = wl_array_add(
+      &shader_program->pending.uniform_variables, sizeof(*variable));
+  variable->location = strdup(location);
+  variable->col = col;
+  variable->row = row;
+  variable->type = UNIFORM_FLOAT;
+  variable->count = count;
+  variable->transpose = transpose;
+  variable->data = malloc(value->size);
+  memcpy(variable->data, value->data, value->size);
+  variable->size = value->size;
+}
+
+static void
+zen_opengl_shader_program_protocol_set_vertex_shader(struct wl_client* client,
     struct wl_resource* resource, int32_t vertex_shader_source_fd,
     uint32_t vertex_shader_size)
 {
@@ -68,7 +148,7 @@ zgn_opengl_shader_program_protocol_set_vertex_shader(struct wl_client* client,
 }
 
 static void
-zgn_opengl_shader_program_protocol_set_fragment_shader(struct wl_client* client,
+zen_opengl_shader_program_protocol_set_fragment_shader(struct wl_client* client,
     struct wl_resource* resource, int32_t fragment_shader_source_fd,
     uint32_t fragment_shader_size)
 {
@@ -110,7 +190,7 @@ zgn_opengl_shader_program_protocol_set_fragment_shader(struct wl_client* client,
 }
 
 static void
-zgn_opengl_shader_program_protocol_link(
+zen_opengl_shader_program_protocol_link(
     struct wl_client* client, struct wl_resource* resource)
 {
   UNUSED(client);
@@ -143,13 +223,61 @@ zgn_opengl_shader_program_protocol_link(
 
 static const struct zgn_opengl_shader_program_interface
     shader_program_interface = {
-        .destroy = zgn_opengl_shader_program_protocol_destroy,
+        .destroy = zen_opengl_shader_program_protocol_destroy,
+        .set_uniform_float_vector =
+            zen_opengl_shader_program_protocol_set_uniform_float_vector,
+        .set_uniform_float_matrix =
+            zen_opengl_shader_program_protocol_set_uniform_float_matrix,
         .set_vertex_shader =
-            zgn_opengl_shader_program_protocol_set_vertex_shader,
+            zen_opengl_shader_program_protocol_set_vertex_shader,
         .set_fragment_shader =
-            zgn_opengl_shader_program_protocol_set_fragment_shader,
-        .link = zgn_opengl_shader_program_protocol_link,
+            zen_opengl_shader_program_protocol_set_fragment_shader,
+        .link = zen_opengl_shader_program_protocol_link,
 };
+
+WL_EXPORT void
+zen_opengl_shader_program_commit(
+    struct zen_opengl_shader_program* shader_program)
+{
+  struct uniform_variable* variable;
+
+  void (*uniform_matrix_funcs[3][3])(GLint location, GLsizei count,
+      GLboolean transpose, const GLfloat* value) = {
+      {glUniformMatrix2fv, glUniformMatrix2x3fv, glUniformMatrix2x4fv},
+      {glUniformMatrix3x2fv, glUniformMatrix3fv, glUniformMatrix3x4fv},
+      {glUniformMatrix4x2fv, glUniformMatrix4x3fv, glUniformMatrix4fv},
+  };
+
+  void (*uniform_vector_func[4])(
+      GLint location, GLsizei count, const GLfloat* value) = {
+      glUniform1fv,
+      glUniform2fv,
+      glUniform3fv,
+      glUniform4fv,
+  };
+
+  glUseProgram(shader_program->program_id);
+  wl_array_for_each(variable, &shader_program->pending.uniform_variables)
+  {
+    GLint location =
+        glGetUniformLocation(shader_program->program_id, variable->location);
+
+    if (variable->col == 1) {
+      uniform_vector_func[variable->row - 1](
+          location, variable->count, variable->data);
+    } else {
+      uniform_matrix_funcs[variable->col - 2][variable->row - 2](
+          location, variable->count, variable->transpose, variable->data);
+    }
+
+    free(variable->location);
+    free(variable->data);
+  }
+  glUseProgram(0);
+
+  wl_array_release(&shader_program->pending.uniform_variables);
+  wl_array_init(&shader_program->pending.uniform_variables);
+}
 
 WL_EXPORT struct zen_opengl_shader_program*
 zen_opengl_shader_program_create(struct wl_client* client, uint32_t id)
@@ -173,13 +301,14 @@ zen_opengl_shader_program_create(struct wl_client* client, uint32_t id)
   }
 
   wl_resource_set_implementation(resource, &shader_program_interface, shader,
-      zgn_opengl_shader_program_handle_destroy);
+      zen_opengl_shader_program_handle_destroy);
 
   shader->resource = resource;
   shader->program_id = glCreateProgram();
   shader->vertex_shader_id = 0;
   shader->fragment_shader_id = 0;
   shader->linked = false;
+  wl_array_init(&shader->pending.uniform_variables);
 
   return shader;
 
@@ -193,8 +322,16 @@ err:
 static void
 zen_opengl_shader_program_destroy(struct zen_opengl_shader_program* shader)
 {
+  struct uniform_variable* variable;
+  wl_array_for_each(variable, &shader->pending.uniform_variables)
+  {
+    free(variable->location);
+    free(variable->data);
+  }
+
   glDeleteProgram(shader->program_id);
   glDeleteShader(shader->vertex_shader_id);
   glDeleteShader(shader->fragment_shader_id);
+  wl_array_release(&shader->pending.uniform_variables);
   free(shader);
 }

--- a/zen-renderer/opengl/opengl-shader-program.h
+++ b/zen-renderer/opengl/opengl-shader-program.h
@@ -11,9 +11,16 @@ struct zen_opengl_shader_program {
   GLuint vertex_shader_id;
   GLuint fragment_shader_id;
   bool linked;
+
+  struct {
+    struct wl_array uniform_variables;
+  } pending;
 };
 
 struct zen_opengl_shader_program* zen_opengl_shader_program_create(
     struct wl_client* client, uint32_t id);
+
+void zen_opengl_shader_program_commit(
+    struct zen_opengl_shader_program* shader_program);
 
 #endif  //  ZEN_RENDERER_OPENGL_SHADER_PROGRAM_H


### PR DESCRIPTION
https://github.com/zigen-project/zigen/pull/14
↑ これを使って uniform 変数をクライアント側から渡せるようにした。
box の 回転情報を uniform変数で渡して、GPU内でrotationの計算をするようにした。

https://github.com/zigen-project/zigen/pull/14 をマージしないとtestが通らない

#13 とコンフリクトする可能性が高い
