### PR TITLE
Hide cursor on glfw window

### DIFF
--- a/include/libzen-compositor/libzen-compositor.h
+++ b/include/libzen-compositor/libzen-compositor.h
@@ -24,6 +24,7 @@ extern "C" {
 
 struct zen_config {
   bool fullscreen_preview;
+  bool hidden_cursor;
   char* seat;
 };
 

--- a/libzen-compositor/config.c
+++ b/libzen-compositor/config.c
@@ -62,7 +62,7 @@ create_env_name(const char *name)
 {
   int prefix_len = ARRAY_LENGTH(env_prefix) - 1;
   int len = strlen(name);
-  char *env_name = malloc(len + prefix_len);
+  char *env_name = malloc(prefix_len + len + 1);
   strcpy(env_name, env_prefix);
   for (int i = 0; i < len; i++) {
     switch (name[i]) {
@@ -74,6 +74,7 @@ create_env_name(const char *name)
         env_name[prefix_len + i] = toupper(name[i]);
     }
   }
+  env_name[prefix_len + len] = '\0';
   return env_name;
 }
 

--- a/tests/load-backend.c
+++ b/tests/load-backend.c
@@ -6,6 +6,7 @@
 
 struct zen_config config = {
     .fullscreen_preview = false,
+    .hidden_cursor = false,
     .seat = "seat0",
 };
 

--- a/zen-backend/glfw/output.c
+++ b/zen-backend/glfw/output.c
@@ -167,7 +167,9 @@ zen_output_create(struct zen_compositor* compositor)
   }
 
   glfwMakeContextCurrent(window);
-  glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+
+  if (compositor->config->hidden_cursor)
+    glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 
   GLenum glewError = glewInit();
   if (glewError != GLEW_OK) {

--- a/zen-backend/glfw/output.c
+++ b/zen-backend/glfw/output.c
@@ -167,6 +167,7 @@ zen_output_create(struct zen_compositor* compositor)
   }
 
   glfwMakeContextCurrent(window);
+  glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 
   GLenum glewError = glewInit();
   if (glewError != GLEW_OK) {

--- a/zen-backend/openvr/gl-window.cc
+++ b/zen-backend/openvr/gl-window.cc
@@ -13,7 +13,7 @@ GlfwErrorCallback(int code, const char* description)
 GlWindow::GlWindow() {}
 
 bool
-GlWindow::Init(bool fullscreen)
+GlWindow::Init(bool fullscreen, bool hidden_cursor)
 {
   // primary_monitor & mode will be freed by glfw
   GLFWmonitor* primary_monitor;
@@ -58,8 +58,10 @@ GlWindow::Init(bool fullscreen)
   }
 
   glfwMakeContextCurrent(glfw_window_);
-  glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
   glfwSwapInterval(0);
+
+  if (hidden_cursor)
+    glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
 
   glewError = glewInit();
   if (glewError != GLEW_OK) {

--- a/zen-backend/openvr/gl-window.cc
+++ b/zen-backend/openvr/gl-window.cc
@@ -58,6 +58,7 @@ GlWindow::Init(bool fullscreen)
   }
 
   glfwMakeContextCurrent(glfw_window_);
+  glfwSetInputMode(glfw_window_, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
   glfwSwapInterval(0);
 
   glewError = glewInit();

--- a/zen-backend/openvr/gl-window.h
+++ b/zen-backend/openvr/gl-window.h
@@ -9,7 +9,7 @@ class GlWindow
 {
  public:
   GlWindow();
-  bool Init(bool fullscreen);
+  bool Init(bool fullscreen, bool hidden_cursor);
   ~GlWindow();
   void Swap();
   bool Poll();

--- a/zen-backend/openvr/output.cc
+++ b/zen-backend/openvr/output.cc
@@ -56,7 +56,8 @@ zen_output_create(struct zen_compositor* compositor)
   }
 
   window = new GlWindow();
-  if (!window->Init(compositor->config->fullscreen_preview)) {
+  if (!window->Init(compositor->config->fullscreen_preview,
+          compositor->config->hidden_cursor)) {
     zen_log("openvr output: failed to initialize GlWindow\n");
     goto err_window;
   }

--- a/zen/main.c
+++ b/zen/main.c
@@ -3,11 +3,13 @@
 
 static struct zen_config config = {
     .fullscreen_preview = false,
+    .hidden_cursor = false,
     .seat = "seat0",
 };
 
 static const struct zen_option options[] = {
     {ZEN_OPTION_BOOLEAN, "fullscreen preview", &config.fullscreen_preview},
+    {ZEN_OPTION_BOOLEAN, "hidden cursor", &config.hidden_cursor},
     {ZEN_OPTION_STRING, "seat", &config.seat},
 };
 


### PR DESCRIPTION
デモやる時とか、zenのpreview見てる時も、glfwのwindow上にマウスカーソルがあるの邪魔だな & 混乱を招くなと思ったのでこのPR。
Ubuntu Desktopのwindowを閉じるmenu barのバツとかを押す時はカーソルが表示される。
逆にcursorを表示させたいケースが思い浮かばなかったのでoptionにはしてません。
