### PR TITLE
Adjust initial cuboid window position

### DIFF
--- a/libzen-compositor/virtual-object.c
+++ b/libzen-compositor/virtual-object.c
@@ -127,8 +127,6 @@ zen_virtual_object_create(
   virtual_object->role_object = NULL;
 
   glm_mat4_copy(identity, virtual_object->model_matrix);
-  glm_translate_z(virtual_object->model_matrix, -1);
-  glm_translate_y(virtual_object->model_matrix, 1.5);
 
   wl_signal_init(&virtual_object->commit_signal);
   wl_signal_init(&virtual_object->destroy_signal);

--- a/zen-shell/shell.c
+++ b/zen-shell/shell.c
@@ -55,6 +55,10 @@ zen_shell_protocol_get_cuboid_window(struct wl_client* client,
     return;
   }
 
+  vec3 initial_position = {
+      0, 1.5, -(half_size[0] + half_size[1] + half_size[2])};
+  glm_translate(cuboid_window->virtual_object->model_matrix, initial_position);
+
   zen_cuboid_window_configure(cuboid_window, half_size, quaternion);
 }
 


### PR DESCRIPTION
** merge into main**

cuboid windowの初期位置を、大きいobjectは奥に、小さいオブジェクトは手前になるようにした。
初期位置で自信が覆われてしまうことがなくなる。