### PR TITLE
fix for demo

### DIFF
--- a/zen-renderer/opengl/cuboid-window-render-item.c
+++ b/zen-renderer/opengl/cuboid-window-render-item.c
@@ -8,7 +8,7 @@
 #include "shader-compiler.h"
 
 #define FOCUS_LINE_WIDTH 4
-#define DEFAULT_LINE_WIDTH 1
+#define DEFAULT_LINE_WIDTH 0
 
 static void update_vertex_buffer(
     struct zen_opengl_cuboid_window_render_item* render_item);
@@ -49,6 +49,7 @@ zen_opengl_cuboid_window_render_item_render(
     struct zen_opengl_cuboid_window_render_item* render_item,
     struct zen_opengl_renderer_camera* camera)
 {
+  if (render_item->line_width == 0) return;
   glLineWidth(render_item->line_width);
   mat4 mvp, rotate;
   glm_quat_mat4(render_item->cuboid_window->quaternion, rotate);


### PR DESCRIPTION
**merge into demo**

3点修正しました。

- cuboid window の枠をfocusが当たってない時は出さない
- better preview の視野角をy方向に-3° ずらした
- cuboid_windwo.movedイベントから送られる視線方向のvec3がずれてて、zmonitorsとかがちゃんとこっち向かない問題を解消。