### PR TITLE
Fix opengl error max size

### DIFF
--- a/zen-renderer/opengl/opengl-shader-program.c
+++ b/zen-renderer/opengl/opengl-shader-program.c
@@ -136,13 +136,14 @@ zen_opengl_shader_program_protocol_set_vertex_shader(struct wl_client* client,
   GLint vertex_shader_compiled = GL_FALSE;
   glGetShaderiv(vertex_shader_id, GL_COMPILE_STATUS, &vertex_shader_compiled);
   if (vertex_shader_compiled != GL_TRUE) {
-    int error_message_length = 512;
-    char error_message[error_message_length];
-
+    int error_message_length = 0;
     glGetShaderiv(vertex_shader_id, GL_INFO_LOG_LENGTH, &error_message_length);
+
+    char error_message[error_message_length];
     glGetShaderInfoLog(
         vertex_shader_id, error_message_length, NULL, error_message);
     glDeleteShader(vertex_shader_id);
+
     wl_resource_post_error(resource,
         ZGN_OPENGL_SHADER_PROGRAM_ERROR_COMPILATION_ERROR,
         "failed to compile vertex shader\n%s", error_message);
@@ -183,18 +184,19 @@ zen_opengl_shader_program_protocol_set_fragment_shader(struct wl_client* client,
   glGetShaderiv(
       fragment_shader_id, GL_COMPILE_STATUS, &fragment_shader_compiled);
   if (fragment_shader_compiled != GL_TRUE) {
-    int error_message_length = 512;
-    char error_message[error_message_length];
-
+    int error_message_length = 0;
     glGetShaderiv(
         fragment_shader_id, GL_INFO_LOG_LENGTH, &error_message_length);
+
+    char error_message[error_message_length];
     glGetShaderInfoLog(
         fragment_shader_id, error_message_length, NULL, error_message);
 
     glDeleteShader(fragment_shader_id);
     wl_resource_post_error(resource,
         ZGN_OPENGL_SHADER_PROGRAM_ERROR_COMPILATION_ERROR,
-        "failed to compile fragment shader\n%s", error_message);
+        "failed to compile fragment shader\n%s[%d]", error_message,
+        error_message_length);
     return;
   }
 
@@ -225,14 +227,13 @@ zen_opengl_shader_program_protocol_link(
   GLint link_success = GL_FALSE;
   glGetProgramiv(shader->program_id, GL_LINK_STATUS, &link_success);
   if (link_success != GL_TRUE) {
-    int error_message_length = 512;
-    char error_message[error_message_length];
-
+    int error_message_length = 0;
     glGetProgramiv(
         shader->program_id, GL_INFO_LOG_LENGTH, &error_message_length);
+
+    char error_message[error_message_length];
     glGetProgramInfoLog(
         shader->program_id, error_message_length, NULL, error_message);
-
     wl_resource_post_error(resource,
         ZGN_OPENGL_SHADER_PROGRAM_ERROR_LINKAGE_ERROR,
         "failed to link shader programs\n%s", error_message);


### PR DESCRIPTION
OpenGLのエラーが512文字を超えるとzenが落ちてしまう問題を見つけたので解決
