### PR TITLE
Session

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update &&
-          sudo apt-get install libwayland-dev
+          sudo apt-get install libwayland-dev libsystemd-dev
 
       - uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update &&
-          sudo apt-get install libwayland-dev libsystemd-dev
+          sudo apt-get install libwayland-dev libsystemd-dev libdbus-1-dev
 
       - uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update &&
-          sudo apt-get install libwayland-dev libsystemd-dev libdbus-1-dev
+          sudo apt-get install \
+            libwayland-dev libsystemd-dev libdbus-1-dev libudev-dev \
+            libinput-dev
 
       - uses: actions/setup-python@v1
         with:

--- a/meson.build
+++ b/meson.build
@@ -24,13 +24,17 @@ add_project_arguments(global_args, language: 'c')
 # generic version requirements
 
 dbus_req = '>= 1.12'
+libinput_req = '>= 1.7'
 systemd_req = '>= 209'
+udev_req = '>= 228'
 wayland_server_req = '>= 1.18.0'
 
 # dependencies
 
 dbus_dep = dependency('dbus-1', version: dbus_req)
+libinput_dep = dependency('libinput', version: libinput_req)
 systemd_dep = dependency('libsystemd', version: systemd_req)
+udev_dep = dependency('libudev', version: udev_req)
 wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
 
 subdir('zen-util')

--- a/meson.build
+++ b/meson.build
@@ -10,10 +10,12 @@ add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
 # generic version requirements
 
+systemd_req = '>= 209'
 wayland_server_req = '>= 1.18.0'
 
 # dependencies
 
+systemd_dep = dependency('libsystemd', version: systemd_req)
 wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
 
 subdir('zen-util')

--- a/meson.build
+++ b/meson.build
@@ -10,11 +10,13 @@ add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
 # generic version requirements
 
+dbus_req = '>= 1.12'
 systemd_req = '>= 209'
 wayland_server_req = '>= 1.18.0'
 
 # dependencies
 
+dbus_dep = dependency('dbus-1', version: dbus_req)
 systemd_dep = dependency('libsystemd', version: systemd_req)
 wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
 

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,20 @@ project(
   default_options: [ 'warning_level=3', 'werror=true', 'optimization=2', 'c_std=gnu11' ],
 )
 
-add_project_arguments('-D_GNU_SOURCE', language: 'c')
+cc = meson.get_compiler('c')
+
+global_args = []
+global_args_maybe = [
+  '-D_GNU_SOURCE',
+  '-fvisibility=hidden',
+]
+
+foreach arg : global_args_maybe
+  if cc.has_argument(arg)
+    global_args += arg
+  endif
+endforeach
+add_project_arguments(global_args, language: 'c')
 
 # generic version requirements
 

--- a/src/backend/drm/backend.c
+++ b/src/backend/drm/backend.c
@@ -8,7 +8,7 @@ struct zn_drm_backend {
   struct zn_session *session;
 };
 
-struct zn_backend *
+ZN_EXPORT struct zn_backend *
 zn_backend_create(struct wl_display *display)
 {
   struct zn_drm_backend *self;
@@ -41,7 +41,7 @@ err:
   return NULL;
 }
 
-void
+ZN_EXPORT void
 zn_backend_destroy(struct zn_backend *parent)
 {
   struct zn_drm_backend *self = zn_container_of(parent, self, base);

--- a/src/backend/drm/backend.c
+++ b/src/backend/drm/backend.c
@@ -38,7 +38,7 @@ zn_backend_create(struct wl_display *display)
     goto err_session;
   }
 
-  self->input = zn_libinput_create(self->udev, self->session);
+  self->input = zn_libinput_create(self->udev, self->session, seat_id);
   if (self->input == NULL) {
     zn_log("drm backend: failed to create input devices\n");
     goto err_udev;

--- a/src/backend/drm/backend.c
+++ b/src/backend/drm/backend.c
@@ -1,0 +1,51 @@
+#include <zen-backend.h>
+#include <zen-session.h>
+#include <zen-util.h>
+
+struct zn_drm_backend {
+  struct zn_backend base;
+
+  struct zn_session *session;
+};
+
+struct zn_backend *
+zn_backend_create(struct wl_display *display)
+{
+  struct zn_drm_backend *self;
+  struct zn_session *session;
+  const char seat_id[] = "seat0";  // FIXME: enable to configure
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) goto err;
+
+  session = zn_session_create(display);
+  if (session == NULL) {
+    zn_log("drm backend: failed to create a session\n");
+    goto err_free;
+  }
+
+  if (zn_session_connect(session, seat_id) != 0) {
+    zn_log("drm backend: session connection failed\n");
+    goto err_session;
+  }
+
+  return &self->base;
+
+err_session:
+  zn_session_destroy(session);
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+void
+zn_backend_destroy(struct zn_backend *parent)
+{
+  struct zn_drm_backend *self = zn_container_of(parent, self, base);
+
+  zn_session_destroy(self->session);
+  free(self);
+}

--- a/src/backend/drm/backend.c
+++ b/src/backend/drm/backend.c
@@ -27,6 +27,8 @@ zn_backend_create(struct wl_display *display)
     goto err_free;
   }
 
+  zn_log("Press Q to exit...\n");  // FIXME: for dev only, remove this later...
+
   if (zn_session_connect(self->session, seat_id) != 0) {
     zn_log("drm backend: session connection failed\n");
     goto err_session;
@@ -38,7 +40,7 @@ zn_backend_create(struct wl_display *display)
     goto err_session;
   }
 
-  self->input = zn_libinput_create(self->udev, self->session, seat_id);
+  self->input = zn_libinput_create(self->udev, self->session, display, seat_id);
   if (self->input == NULL) {
     zn_log("drm backend: failed to create input devices\n");
     goto err_udev;

--- a/src/backend/drm/backend.c
+++ b/src/backend/drm/backend.c
@@ -1,4 +1,6 @@
+#include <libudev.h>
 #include <zen-backend.h>
+#include <zen-libinput.h>
 #include <zen-session.h>
 #include <zen-util.h>
 
@@ -6,33 +8,49 @@ struct zn_drm_backend {
   struct zn_backend base;
 
   struct zn_session *session;
+  struct udev *udev;
+  struct zn_libinput *input;
 };
 
 ZN_EXPORT struct zn_backend *
 zn_backend_create(struct wl_display *display)
 {
   struct zn_drm_backend *self;
-  struct zn_session *session;
   const char seat_id[] = "seat0";  // FIXME: enable to configure
 
   self = zalloc(sizeof *self);
   if (self == NULL) goto err;
 
-  session = zn_session_create(display);
-  if (session == NULL) {
+  self->session = zn_session_create(display);
+  if (self->session == NULL) {
     zn_log("drm backend: failed to create a session\n");
     goto err_free;
   }
 
-  if (zn_session_connect(session, seat_id) != 0) {
+  if (zn_session_connect(self->session, seat_id) != 0) {
     zn_log("drm backend: session connection failed\n");
     goto err_session;
   }
 
+  self->udev = udev_new();
+  if (self->udev == NULL) {
+    zn_log("drm backend: failed to initialize udev context\n");
+    goto err_session;
+  }
+
+  self->input = zn_libinput_create(self->udev);
+  if (self->input == NULL) {
+    zn_log("drm backend: failed to create input devices\n");
+    goto err_udev;
+  }
+
   return &self->base;
 
+err_udev:
+  udev_unref(self->udev);
+
 err_session:
-  zn_session_destroy(session);
+  zn_session_destroy(self->session);
 
 err_free:
   free(self);
@@ -46,6 +64,8 @@ zn_backend_destroy(struct zn_backend *parent)
 {
   struct zn_drm_backend *self = zn_container_of(parent, self, base);
 
+  zn_libinput_destroy(self->input);
+  udev_unref(self->udev);
   zn_session_destroy(self->session);
   free(self);
 }

--- a/src/backend/drm/backend.c
+++ b/src/backend/drm/backend.c
@@ -38,7 +38,7 @@ zn_backend_create(struct wl_display *display)
     goto err_session;
   }
 
-  self->input = zn_libinput_create(self->udev);
+  self->input = zn_libinput_create(self->udev, self->session);
   if (self->input == NULL) {
     zn_log("drm backend: failed to create input devices\n");
     goto err_udev;

--- a/src/backend/drm/meson.build
+++ b/src/backend/drm/meson.build
@@ -1,0 +1,21 @@
+zen_drm_backend_srcs = [
+  'backend.c'
+]
+
+zen_drm_backend_deps = [
+  zen_session_dep,
+  zen_util_dep,
+]
+
+zen_drm_backend_lib = static_library(
+  'zen-drm-backend',
+  zen_drm_backend_srcs,
+  include_directories: zen_backend_inc,
+  dependencies: zen_drm_backend_deps,
+  install: false,
+)
+
+zen_drm_backend_dep = declare_dependency(
+  link_with: zen_drm_backend_lib,
+  include_directories: zen_backend_inc,
+)

--- a/src/backend/drm/meson.build
+++ b/src/backend/drm/meson.build
@@ -3,6 +3,8 @@ zen_drm_backend_srcs = [
 ]
 
 zen_drm_backend_deps = [
+  udev_dep,
+  zen_backend_libinput_dep,
   zen_session_dep,
   zen_util_dep,
 ]

--- a/src/backend/include/zen-backend.h
+++ b/src/backend/include/zen-backend.h
@@ -1,0 +1,15 @@
+#ifndef ZEN_BACKEND_H
+#define ZEN_BACKEND_H
+
+#include <wayland-server.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zn_backend {};
+#pragma GCC diagnostic pop
+
+struct zn_backend *zn_backend_create(struct wl_display *display);
+
+void zn_backend_destroy(struct zn_backend *self);
+
+#endif  //  ZEN_BACKEND_H

--- a/src/backend/libinput/include/zen-libinput.h
+++ b/src/backend/libinput/include/zen-libinput.h
@@ -7,7 +7,7 @@
 struct zn_libinput;
 
 struct zn_libinput *zn_libinput_create(
-    struct udev *udev, struct zn_session *session);
+    struct udev *udev, struct zn_session *session, const char *seat_id);
 
 void zn_libinput_destroy(struct zn_libinput *self);
 

--- a/src/backend/libinput/include/zen-libinput.h
+++ b/src/backend/libinput/include/zen-libinput.h
@@ -1,0 +1,12 @@
+#ifndef ZEN_BACKEND_LIBINPUT_H
+#define ZEN_BACKEND_LIBINPUT_H
+
+#include <libudev.h>
+
+struct zn_libinput;
+
+struct zn_libinput *zn_libinput_create(struct udev *udev);
+
+void zn_libinput_destroy(struct zn_libinput *self);
+
+#endif  //  ZEN_BACKEND_LIBINPUT_H

--- a/src/backend/libinput/include/zen-libinput.h
+++ b/src/backend/libinput/include/zen-libinput.h
@@ -2,12 +2,14 @@
 #define ZEN_BACKEND_LIBINPUT_H
 
 #include <libudev.h>
+#include <wayland-server.h>
 #include <zen-session.h>
 
 struct zn_libinput;
 
-struct zn_libinput *zn_libinput_create(
-    struct udev *udev, struct zn_session *session, const char *seat_id);
+struct zn_libinput *zn_libinput_create(struct udev *udev,
+    struct zn_session *session, struct wl_display *display,
+    const char *seat_id);
 
 void zn_libinput_destroy(struct zn_libinput *self);
 

--- a/src/backend/libinput/include/zen-libinput.h
+++ b/src/backend/libinput/include/zen-libinput.h
@@ -2,10 +2,12 @@
 #define ZEN_BACKEND_LIBINPUT_H
 
 #include <libudev.h>
+#include <zen-session.h>
 
 struct zn_libinput;
 
-struct zn_libinput *zn_libinput_create(struct udev *udev);
+struct zn_libinput *zn_libinput_create(
+    struct udev *udev, struct zn_session *session);
 
 void zn_libinput_destroy(struct zn_libinput *self);
 

--- a/src/backend/libinput/meson.build
+++ b/src/backend/libinput/meson.build
@@ -1,0 +1,24 @@
+zen_backend_libinput_inc = include_directories('include')
+
+zen_backend_libinput_srcs = [
+  'seat.c',
+]
+
+zen_backend_libinput_deps = [
+  libinput_dep,
+  udev_dep,
+  zen_util_dep,
+]
+
+zen_backend_libinput_lib = static_library(
+  'zen-backend-libinput',
+  zen_backend_libinput_srcs,
+  include_directories: zen_backend_libinput_inc,
+  dependencies: zen_backend_libinput_deps,
+  install: false,
+)
+
+zen_backend_libinput_dep = declare_dependency(
+  link_with: zen_backend_libinput_lib,
+  include_directories: zen_backend_libinput_inc,
+)

--- a/src/backend/libinput/meson.build
+++ b/src/backend/libinput/meson.build
@@ -7,6 +7,7 @@ zen_backend_libinput_srcs = [
 zen_backend_libinput_deps = [
   libinput_dep,
   udev_dep,
+  zen_session_dep,
   zen_util_dep,
 ]
 

--- a/src/backend/libinput/seat.c
+++ b/src/backend/libinput/seat.c
@@ -1,14 +1,36 @@
 #include <libinput.h>
 #include <zen-libinput.h>
+#include <zen-session.h>
 #include <zen-util.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-struct zn_libinput {};
-#pragma GCC diagnostic pop
+struct zn_libinput {
+  struct zn_session *session;  // nonnull
+  struct libinput *libinput;
+};
+
+static int
+zn_libinput_open_restricted(const char *path, int flags, void *user_data)
+{
+  struct zn_libinput *self = user_data;
+
+  return zn_session_open_file(self->session, path, flags);
+}
+
+static void
+zn_libinput_close_restricted(int fd, void *user_data)
+{
+  struct zn_libinput *self = user_data;
+
+  zn_session_close_file(self->session, fd);
+}
+
+static const struct libinput_interface libinput_interface = {
+    .open_restricted = zn_libinput_open_restricted,
+    .close_restricted = zn_libinput_close_restricted,
+};
 
 ZN_EXPORT struct zn_libinput *
-zn_libinput_create(struct udev *udev)
+zn_libinput_create(struct udev *udev, struct zn_session *session)
 {
   struct zn_libinput *self;
   UNUSED(udev);
@@ -16,7 +38,18 @@ zn_libinput_create(struct udev *udev)
   self = zalloc(sizeof *self);
   if (self == NULL) goto err;
 
+  self->libinput =
+      libinput_udev_create_context(&libinput_interface, self, udev);
+  if (self->libinput == NULL) goto err_free;
+
+  // TODO: There is more to be done
+
+  self->session = session;
+
   return self;
+
+err_free:
+  free(self);
 
 err:
   return NULL;
@@ -25,5 +58,6 @@ err:
 ZN_EXPORT void
 zn_libinput_destroy(struct zn_libinput *self)
 {
+  libinput_unref(self->libinput);
   free(self);
 }

--- a/src/backend/libinput/seat.c
+++ b/src/backend/libinput/seat.c
@@ -1,0 +1,29 @@
+#include <libinput.h>
+#include <zen-libinput.h>
+#include <zen-util.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zn_libinput {};
+#pragma GCC diagnostic pop
+
+ZN_EXPORT struct zn_libinput *
+zn_libinput_create(struct udev *udev)
+{
+  struct zn_libinput *self;
+  UNUSED(udev);
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) goto err;
+
+  return self;
+
+err:
+  return NULL;
+}
+
+ZN_EXPORT void
+zn_libinput_destroy(struct zn_libinput *self)
+{
+  free(self);
+}

--- a/src/backend/libinput/seat.c
+++ b/src/backend/libinput/seat.c
@@ -39,7 +39,8 @@ static const struct libinput_interface libinput_interface = {
 };
 
 ZN_EXPORT struct zn_libinput *
-zn_libinput_create(struct udev *udev, struct zn_session *session)
+zn_libinput_create(
+    struct udev *udev, struct zn_session *session, const char *seat_id)
 {
   struct zn_libinput *self;
   enum libinput_log_priority priority = LIBINPUT_LOG_PRIORITY_INFO;
@@ -56,11 +57,19 @@ zn_libinput_create(struct udev *udev, struct zn_session *session)
 
   libinput_log_set_priority(self->libinput, priority);
 
+  if (libinput_udev_assign_seat(self->libinput, seat_id) != 0) {
+    zn_log("libinput: failed to assign seat id: %s\n", seat_id);
+    goto err_unref;
+  }
+
   // TODO: There is more to be done
 
   self->session = session;
 
   return self;
+
+err_unref:
+  libinput_unref(self->libinput);
 
 err_free:
   free(self);

--- a/src/backend/libinput/seat.c
+++ b/src/backend/libinput/seat.c
@@ -1,11 +1,19 @@
 #include <libinput.h>
+#include <linux/input-event-codes.h>
+#include <stdbool.h>
+#include <wayland-server.h>
 #include <zen-libinput.h>
 #include <zen-session.h>
 #include <zen-util.h>
 
 struct zn_libinput {
+  struct wl_display *display;
   struct zn_session *session;  // nonnull
   struct libinput *libinput;
+
+  struct wl_event_source *libinput_source;
+
+  bool suspended;
 };
 
 static void
@@ -15,6 +23,42 @@ libinput_log_func(struct libinput *libinput,
   UNUSED(libinput);
   UNUSED(priority);
   zn_vlog(format, args);
+}
+
+static void
+zn_libinput_process_events(struct zn_libinput *self)
+{
+  struct libinput_event *event;
+
+  // FIXME: Here, Q key release is detected and the process is terminated.
+  while ((event = libinput_get_event(self->libinput))) {
+    if (libinput_event_get_type(event) == LIBINPUT_EVENT_KEYBOARD_KEY) {
+      struct libinput_event_keyboard *key_event =
+          libinput_event_get_keyboard_event(event);
+      enum libinput_key_state key_state =
+          libinput_event_keyboard_get_key_state(key_event);
+      uint32_t key = libinput_event_keyboard_get_key(key_event);
+
+      if (key_state == LIBINPUT_KEY_STATE_RELEASED && key == KEY_Q)
+        wl_display_terminate(self->display);
+    }
+    libinput_event_destroy(event);
+  }
+}
+
+static int
+zn_libinput_source_dispatch(int fd, uint32_t mask, void *data)
+{
+  struct zn_libinput *self = data;
+  UNUSED(fd);
+  UNUSED(mask);
+
+  if (libinput_dispatch(self->libinput) != 0)
+    zn_log("libinput: failed to dispatch libinput\n");
+
+  zn_libinput_process_events(self);
+
+  return 0;
 }
 
 static int
@@ -38,16 +82,49 @@ static const struct libinput_interface libinput_interface = {
     .close_restricted = zn_libinput_close_restricted,
 };
 
+static int
+zn_libinput_enable(struct zn_libinput *self)
+{
+  struct wl_event_loop *loop;
+  int fd;
+
+  loop = wl_display_get_event_loop(self->display);
+  fd = libinput_get_fd(self->libinput);
+  self->libinput_source = wl_event_loop_add_fd(
+      loop, fd, WL_EVENT_READABLE, zn_libinput_source_dispatch, self);
+  if (self->libinput_source == NULL) return -1;
+
+  if (self->suspended) {
+    if (libinput_resume(self->libinput) != 0) {
+      wl_event_source_remove(self->libinput_source);
+      self->libinput_source = NULL;
+      return -1;
+    }
+    self->suspended = true;
+    zn_libinput_process_events(self);
+  }
+
+  // TODO: notify keyboard focus again
+
+  // TODO: check device existence
+
+  return 0;
+}
+
+// TODO: void zn_libinput_disable(struct zn_libinput *self);
+
 ZN_EXPORT struct zn_libinput *
-zn_libinput_create(
-    struct udev *udev, struct zn_session *session, const char *seat_id)
+zn_libinput_create(struct udev *udev, struct zn_session *session,
+    struct wl_display *display, const char *seat_id)
 {
   struct zn_libinput *self;
   enum libinput_log_priority priority = LIBINPUT_LOG_PRIORITY_INFO;
-  UNUSED(udev);
 
   self = zalloc(sizeof *self);
   if (self == NULL) goto err;
+
+  self->session = session;
+  self->display = display;
 
   self->libinput =
       libinput_udev_create_context(&libinput_interface, self, udev);
@@ -62,9 +139,9 @@ zn_libinput_create(
     goto err_unref;
   }
 
-  // TODO: There is more to be done
+  zn_libinput_process_events(self);
 
-  self->session = session;
+  zn_libinput_enable(self);
 
   return self;
 
@@ -81,6 +158,7 @@ err:
 ZN_EXPORT void
 zn_libinput_destroy(struct zn_libinput *self)
 {
+  if (self->libinput_source) wl_event_source_remove(self->libinput_source);
   libinput_unref(self->libinput);
   free(self);
 }

--- a/src/backend/libinput/seat.c
+++ b/src/backend/libinput/seat.c
@@ -8,6 +8,15 @@ struct zn_libinput {
   struct libinput *libinput;
 };
 
+static void
+libinput_log_func(struct libinput *libinput,
+    enum libinput_log_priority priority, const char *format, va_list args)
+{
+  UNUSED(libinput);
+  UNUSED(priority);
+  zn_vlog(format, args);
+}
+
 static int
 zn_libinput_open_restricted(const char *path, int flags, void *user_data)
 {
@@ -33,6 +42,7 @@ ZN_EXPORT struct zn_libinput *
 zn_libinput_create(struct udev *udev, struct zn_session *session)
 {
   struct zn_libinput *self;
+  enum libinput_log_priority priority = LIBINPUT_LOG_PRIORITY_INFO;
   UNUSED(udev);
 
   self = zalloc(sizeof *self);
@@ -41,6 +51,10 @@ zn_libinput_create(struct udev *udev, struct zn_session *session)
   self->libinput =
       libinput_udev_create_context(&libinput_interface, self, udev);
   if (self->libinput == NULL) goto err_free;
+
+  libinput_log_set_handler(self->libinput, &libinput_log_func);
+
+  libinput_log_set_priority(self->libinput, priority);
 
   // TODO: There is more to be done
 

--- a/src/backend/meson.build
+++ b/src/backend/meson.build
@@ -1,3 +1,4 @@
 zen_backend_inc = include_directories('include')
 
+subdir('libinput')
 subdir('drm')

--- a/src/backend/meson.build
+++ b/src/backend/meson.build
@@ -1,0 +1,3 @@
+zen_backend_inc = include_directories('include')
+
+subdir('drm')

--- a/src/main.c
+++ b/src/main.c
@@ -1,7 +1,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <wayland-server.h>
-#include <zen-session.h>
+#include <zen-backend.h>
 #include <zen-util.h>
 
 static int
@@ -21,8 +21,7 @@ main()
   struct wl_display *display;
   struct wl_event_loop *loop;
   struct wl_event_source *signal_sources[3];
-  struct zn_session *session;
-  const char seat_id[] = "seat0";  // FIXME: enable to configure
+  struct zn_backend *backend;
   int i, status = EXIT_FAILURE;
 
   display = wl_display_create();
@@ -44,23 +43,17 @@ main()
     goto err_signal;
   }
 
-  session = zn_session_create(display);
-  if (session == NULL) {
-    zn_log("main: failed to create a session\n");
+  backend = zn_backend_create(display);
+  if (backend == NULL) {
+    zn_log("main: failed to create a backend\n");
     goto err_signal;
-  }
-
-  if (zn_session_connect(session, seat_id) != 0) {
-    zn_log("main: session connection failed\n");
-    goto err_session;
   }
 
   wl_display_run(display);
 
   status = EXIT_SUCCESS;
 
-err_session:
-  zn_session_destroy(session);
+  zn_backend_destroy(backend);
 
 err_signal:
   for (i = ARRAY_LENGTH(signal_sources) - 1; i >= 0; i--)

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <wayland-server.h>
+#include <zen-session.h>
 #include <zen-util.h>
 
 static int
@@ -20,6 +21,7 @@ main()
   struct wl_display *display;
   struct wl_event_loop *loop;
   struct wl_event_source *signal_sources[3];
+  struct zn_session *session;
   int i, status = EXIT_FAILURE;
 
   display = wl_display_create();
@@ -41,9 +43,23 @@ main()
     goto err_signal;
   }
 
+  session = zn_session_create();
+  if (session == NULL) {
+    zn_log("main: failed to create a session\n");
+    goto err_signal;
+  }
+
+  if (zn_session_connect(session) != 0) {
+    zn_log("main: session connection failed\n");
+    goto err_session;
+  }
+
   wl_display_run(display);
 
   status = EXIT_SUCCESS;
+
+err_session:
+  zn_session_destroy(session);
 
 err_signal:
   for (i = ARRAY_LENGTH(signal_sources) - 1; i >= 0; i--)

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@ main()
   struct wl_event_loop *loop;
   struct wl_event_source *signal_sources[3];
   struct zn_session *session;
+  const char seat_id[] = "seat0";  // FIXME: enable to configure
   int i, status = EXIT_FAILURE;
 
   display = wl_display_create();
@@ -43,13 +44,13 @@ main()
     goto err_signal;
   }
 
-  session = zn_session_create();
+  session = zn_session_create(display);
   if (session == NULL) {
     zn_log("main: failed to create a session\n");
     goto err_signal;
   }
 
-  if (zn_session_connect(session) != 0) {
+  if (zn_session_connect(session, seat_id) != 0) {
     zn_log("main: session connection failed\n");
     goto err_session;
   }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,10 +1,11 @@
 subdir('session')
+subdir('backend')
 
 zen_desktop_srcs = [ 'main.c' ]
 
 zen_desktop_deps = [
   wayland_server_dep,
-  zen_session_dep,
+  zen_drm_backend_dep,
   zen_util_dep,
 ]
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,10 @@
+subdir('session')
+
 zen_desktop_srcs = [ 'main.c' ]
 
 zen_desktop_deps = [
   wayland_server_dep,
+  zen_session_dep,
   zen_util_dep,
 ]
 

--- a/src/session/dbus.c
+++ b/src/session/dbus.c
@@ -206,7 +206,7 @@ zn_dbus_connection_add_match(
   return 0;
 }
 
-ZN_EXPORT int
+int
 zn_dbus_connection_add_match_signal(DBusConnection* connection,
     const char* sender, const char* interface, const char* member,
     const char* path)
@@ -220,7 +220,7 @@ zn_dbus_connection_add_match_signal(DBusConnection* connection,
       sender, interface, member, path);
 }
 
-ZN_EXPORT struct wl_event_source*
+struct wl_event_source*
 zn_dbus_connection_bind(DBusConnection* connection, struct wl_event_loop* loop)
 {
   struct wl_event_source* event_source;
@@ -273,7 +273,7 @@ zn_dbus_connection_unbind(
   if (event_source) wl_event_source_remove(event_source);
 }
 
-ZN_EXPORT DBusConnection*
+DBusConnection*
 zn_dbus_connection_create(DBusBusType type)
 {
   DBusConnection* connection;
@@ -301,7 +301,7 @@ err:
   return NULL;
 }
 
-ZN_EXPORT void
+void
 zn_dbus_connection_destroy(
     DBusConnection* connection, struct wl_event_source* event_source)
 {

--- a/src/session/dbus.c
+++ b/src/session/dbus.c
@@ -1,0 +1,269 @@
+#include "dbus.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <sys/eventfd.h>
+#include <unistd.h>
+#include <zen-util.h>
+
+static int
+zn_dbus_connection_dispatch(int fd, uint32_t mask, void* data)
+{
+  DBusConnection* connection = data;
+  DBusDispatchStatus status;
+  (void)fd;
+  (void)mask;
+
+  do {
+    status = dbus_connection_dispatch(connection);
+    switch (status) {
+      case DBUS_DISPATCH_COMPLETE:
+        return 0;
+
+      case DBUS_DISPATCH_DATA_REMAINS:
+        break;
+
+      case DBUS_DISPATCH_NEED_MEMORY:
+        zn_log("dbus: cannot dispatch dbus event: no memory\n");
+        return 0;
+
+      default:
+        zn_log("dbus: cannot dispatch dbus event\n");
+        return 0;
+    }
+  } while (true);
+}
+
+static int
+zn_dbus_connection_dispatch_watch(int fd, uint32_t mask, void* data)
+{
+  DBusWatch* watch = data;
+  uint32_t flags = 0;
+  (void)fd;
+
+  if (dbus_watch_get_enabled(watch)) {
+    if (mask & WL_EVENT_READABLE) flags |= DBUS_WATCH_READABLE;
+    if (mask & WL_EVENT_WRITABLE) flags |= DBUS_WATCH_WRITABLE;
+    if (mask & WL_EVENT_HANGUP) flags |= DBUS_WATCH_HANGUP;
+    if (mask & WL_EVENT_ERROR) flags |= DBUS_WATCH_ERROR;
+
+    dbus_watch_handle(watch, flags);
+  }
+
+  return 0;
+}
+
+static dbus_bool_t
+zn_dbus_connection_add_watch(DBusWatch* watch, void* data)
+{
+  struct wl_event_loop* loop = data;
+  struct wl_event_source* event_source;
+  int fd;
+  uint32_t mask = 0, flags;
+
+  if (dbus_watch_get_enabled(watch)) {
+    flags = dbus_watch_get_flags(watch);
+    if (flags & DBUS_WATCH_READABLE) mask |= WL_EVENT_READABLE;
+    if (flags & DBUS_WATCH_WRITABLE) mask |= WL_EVENT_WRITABLE;
+  }
+
+  fd = dbus_watch_get_unix_fd(watch);
+  event_source = wl_event_loop_add_fd(
+      loop, fd, mask, zn_dbus_connection_dispatch_watch, watch);
+
+  if (event_source == NULL) return FALSE;
+
+  dbus_watch_set_data(watch, event_source, NULL);
+
+  return TRUE;
+}
+
+static void
+zn_dbus_connection_remove_watch(DBusWatch* watch, void* data)
+{
+  struct wl_event_source* event_source;
+  (void)data;
+
+  event_source = dbus_watch_get_data(watch);
+  if (event_source == NULL) return;
+
+  wl_event_source_remove(event_source);
+}
+
+static void
+zn_dbus_connection_toggle_watch(DBusWatch* watch, void* data)
+{
+  struct wl_event_source* event_source;
+  uint32_t mask = 0, flags;
+  (void)watch;
+  (void)data;
+
+  event_source = dbus_watch_get_data(watch);
+  if (!event_source) return;
+
+  if (dbus_watch_get_enabled(watch)) {
+    flags = dbus_watch_get_flags(watch);
+    if (flags & DBUS_WATCH_READABLE) mask |= WL_EVENT_READABLE;
+    if (flags & DBUS_WATCH_WRITABLE) mask |= WL_EVENT_WRITABLE;
+  }
+
+  wl_event_source_fd_update(event_source, mask);
+}
+
+static int
+zn_dbus_connection_dispatch_timeout(void* data)
+{
+  DBusTimeout* timeout = data;
+
+  if (dbus_timeout_get_enabled(timeout)) dbus_timeout_handle(timeout);
+
+  return 0;
+}
+
+static int
+zn_dbus_connection_adjust_timeout(
+    DBusTimeout* timeout, struct wl_event_source* event_source)
+{
+  int64_t t = 0;
+
+  if (dbus_timeout_get_enabled(timeout)) t = dbus_timeout_get_interval(timeout);
+
+  return wl_event_source_timer_update(event_source, t);
+}
+
+static dbus_bool_t
+zn_dbus_connection_add_timeout(DBusTimeout* timeout, void* data)
+{
+  struct wl_event_loop* loop = data;
+  struct wl_event_source* event_source;
+  int ret;
+
+  event_source = wl_event_loop_add_timer(
+      loop, zn_dbus_connection_dispatch_timeout, timeout);
+
+  if (event_source == NULL) return FALSE;
+
+  ret = zn_dbus_connection_adjust_timeout(timeout, event_source);
+  if (ret < 0) {
+    wl_event_source_remove(event_source);
+    return FALSE;
+  }
+
+  dbus_timeout_set_data(timeout, event_source, NULL);
+
+  return TRUE;
+}
+
+static void
+zn_dbus_connection_remove_timeout(DBusTimeout* timeout, void* data)
+{
+  struct wl_event_source* event_source;
+  (void)data;
+
+  event_source = dbus_timeout_get_data(timeout);
+  if (!event_source) return;
+
+  wl_event_source_remove(event_source);
+}
+
+static void
+zn_dbus_connection_toggle_timeout(DBusTimeout* timeout, void* data)
+{
+  struct wl_event_source* event_source;
+  (void)data;
+
+  event_source = dbus_timeout_get_data(timeout);
+  if (!event_source) return;
+
+  zn_dbus_connection_adjust_timeout(timeout, event_source);
+}
+
+ZN_EXPORT struct wl_event_source*
+zn_dbus_connection_bind(DBusConnection* connection, struct wl_event_loop* loop)
+{
+  struct wl_event_source* event_source;
+  bool ret;
+  int fd;
+
+  fd = eventfd(0, EFD_CLOEXEC);
+  if (fd < 0) goto err;
+
+  event_source = wl_event_loop_add_fd(
+      loop, fd, 0, zn_dbus_connection_dispatch, connection);
+  close(fd);
+
+  if (event_source == NULL) goto err;
+
+  wl_event_source_check(event_source);
+
+  ret = dbus_connection_set_watch_functions(connection,
+      zn_dbus_connection_add_watch, zn_dbus_connection_remove_watch,
+      zn_dbus_connection_toggle_watch, loop, NULL);
+
+  if (ret == false) goto err_source;
+
+  ret = dbus_connection_set_timeout_functions(connection,
+      zn_dbus_connection_add_timeout, zn_dbus_connection_remove_timeout,
+      zn_dbus_connection_toggle_timeout, loop, NULL);
+
+  if (ret == false) goto err_source;
+
+  return event_source;
+
+err_source:
+  dbus_connection_set_timeout_functions(
+      connection, NULL, NULL, NULL, NULL, NULL);
+  dbus_connection_set_watch_functions(connection, NULL, NULL, NULL, NULL, NULL);
+  wl_event_source_remove(event_source);
+
+err:
+  return NULL;
+}
+
+static void
+zn_dbus_connection_unbind(
+    DBusConnection* connection, struct wl_event_source* event_source)
+{
+  dbus_connection_set_timeout_functions(
+      connection, NULL, NULL, NULL, NULL, NULL);
+  dbus_connection_set_watch_functions(connection, NULL, NULL, NULL, NULL, NULL);
+
+  if (event_source) wl_event_source_remove(event_source);
+}
+
+ZN_EXPORT DBusConnection*
+zn_dbus_connection_create(DBusBusType type)
+{
+  DBusConnection* connection;
+  DBusError err;
+
+  dbus_connection_set_change_sigpipe(FALSE);
+
+  dbus_error_init(&err);
+  connection = dbus_bus_get_private(type, &err);
+  if (connection == NULL) {
+    if (dbus_error_is_set(&err)) {
+      zn_log("dbus: failed to connect to dbus daemon: %s\n", err.message);
+      dbus_error_free(&err);
+    } else {
+      zn_log("dbus: failed to connect to dbus daemon\n");
+    }
+    goto err;
+  }
+
+  dbus_connection_set_exit_on_disconnect(connection, FALSE);
+
+  return connection;
+
+err:
+  return NULL;
+}
+
+ZN_EXPORT void
+zn_dbus_connection_destroy(
+    DBusConnection* connection, struct wl_event_source* event_source)
+{
+  zn_dbus_connection_unbind(connection, event_source);
+  dbus_connection_close(connection);
+  dbus_connection_unref(connection);
+}

--- a/src/session/dbus.h
+++ b/src/session/dbus.h
@@ -4,6 +4,10 @@
 #include <dbus/dbus.h>
 #include <wayland-server.h>
 
+int zn_dbus_connection_add_match_signal(DBusConnection* connection,
+    const char* sender, const char* interface, const char* member,
+    const char* path);
+
 /**
  * @return null on failure
  */

--- a/src/session/dbus.h
+++ b/src/session/dbus.h
@@ -1,0 +1,22 @@
+#ifndef ZEN_DBUS_H
+#define ZEN_DBUS_H
+
+#include <dbus/dbus.h>
+#include <wayland-server.h>
+
+/**
+ * @return null on failure
+ */
+struct wl_event_source* zn_dbus_connection_bind(
+    DBusConnection* connection, struct wl_event_loop* loop);
+
+DBusConnection* zn_dbus_connection_create(DBusBusType type);
+
+/**
+ * @param connection
+ * @param event_source nullable when not bound
+ */
+void zn_dbus_connection_destroy(
+    DBusConnection* connection, struct wl_event_source* event_source);
+
+#endif  //  ZEN_DBUS_H

--- a/src/session/include/zen-session.h
+++ b/src/session/include/zen-session.h
@@ -14,6 +14,10 @@ struct zn_session {
   struct wl_signal session_signal;  // data: bool*
 };
 
+int zn_session_open_file(struct zn_session* self, const char* path, int flags);
+
+void zn_session_close_file(struct zn_session* self, int fd);
+
 /**
  * @return 0 on success, -1 on failure
  */

--- a/src/session/include/zen-session.h
+++ b/src/session/include/zen-session.h
@@ -1,6 +1,8 @@
 #ifndef ZEN_SESSION_H
 #define ZEN_SESSION_H
 
+#include <wayland-server.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 struct zn_session {};
@@ -9,12 +11,12 @@ struct zn_session {};
 /**
  * @return 0 on success, -1 on failure
  */
-int zn_session_connect(struct zn_session* self);
+int zn_session_connect(struct zn_session* self, const char* seat_id);
 
 /**
  * @return return NULL on failure
  */
-struct zn_session* zn_session_create();
+struct zn_session* zn_session_create(struct wl_display* display);
 
 void zn_session_destroy(struct zn_session* self);
 

--- a/src/session/include/zen-session.h
+++ b/src/session/include/zen-session.h
@@ -3,10 +3,16 @@
 
 #include <wayland-server.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-struct zn_session {};
-#pragma GCC diagnostic pop
+struct zn_session_device_changed_signal_arg {
+  dev_t device;
+  bool added;
+};
+
+struct zn_session {
+  // data: struct zn_session_device_changed_signal_arg*
+  struct wl_signal device_changed_signal;
+  struct wl_signal session_signal;  // data: bool*
+};
 
 /**
  * @return 0 on success, -1 on failure

--- a/src/session/include/zen-session.h
+++ b/src/session/include/zen-session.h
@@ -1,0 +1,21 @@
+#ifndef ZEN_SESSION_H
+#define ZEN_SESSION_H
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zn_session {};
+#pragma GCC diagnostic pop
+
+/**
+ * @return 0 on success, -1 on failure
+ */
+int zn_session_connect(struct zn_session* self);
+
+/**
+ * @return return NULL on failure
+ */
+struct zn_session* zn_session_create();
+
+void zn_session_destroy(struct zn_session* self);
+
+#endif  //  ZEN_SESSION_H

--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -1,0 +1,23 @@
+zen_session_inc = include_directories('include')
+
+zen_session_srcs = [
+  'session-logind.c'
+]
+
+zen_session_deps = [
+  systemd_dep,
+  zen_util_dep,
+]
+
+zen_session_lib = static_library(
+  'zen-session',
+  zen_session_srcs,
+  include_directories: zen_session_inc,
+  dependencies: zen_session_deps,
+  install: false,
+)
+
+zen_session_dep = declare_dependency(
+  link_with: zen_session_lib,
+  include_directories: zen_session_inc,
+)

--- a/src/session/meson.build
+++ b/src/session/meson.build
@@ -1,11 +1,14 @@
 zen_session_inc = include_directories('include')
 
 zen_session_srcs = [
+  'dbus.c',
   'session-logind.c'
 ]
 
 zen_session_deps = [
+  dbus_dep,
   systemd_dep,
+  wayland_server_dep,
   zen_util_dep,
 ]
 

--- a/src/session/session-logind.c
+++ b/src/session/session-logind.c
@@ -1,44 +1,112 @@
+#include <dbus/dbus.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <systemd/sd-login.h>
 #include <unistd.h>
+#include <wayland-server.h>
 #include <zen-session.h>
 #include <zen-util.h>
+
+#include "dbus.h"
 
 struct zn_session_logind {
   struct zn_session base;
 
-  char* id;
+  struct wl_display* display;  // non null
+
+  char* session_id;
+  unsigned int vt_number;  // 0 for non vt
+
+  DBusConnection* dbus;
+  struct wl_event_source* dbus_event_source;
 };
 
+/**
+ * no side effect
+ * @return 0 if equal, < 0 otherwise
+ */
+static int
+seat_id_is_equal_to_session_seat_id(const char* seat_id, char* session_id)
+{
+  int ret;
+  char* session_seat_id = NULL;
+  ret = sd_session_get_seat(session_id, &session_seat_id);
+  if (ret < 0) {
+    zn_log("logind: failed to get session seat\n");
+  } else if (strcmp(seat_id, session_seat_id) != 0) {
+    zn_log("logind: zen's seat '%s' differs from session-seat '%s'\n", seat_id,
+        session_seat_id);
+    ret = -EINVAL;
+  } else {
+    ret = 0;
+  }
+
+  free(session_seat_id);
+
+  return ret;
+}
+
 ZN_EXPORT int
-zn_session_connect(struct zn_session* parent)
+zn_session_connect(struct zn_session* parent, const char* seat_id)
 {
   struct zn_session_logind* self = zn_container_of(parent, self, base);
+  struct wl_event_loop* loop;
   int ret;
 
-  ret = sd_pid_get_session(getpid(), &self->id);
+  ret = sd_pid_get_session(getpid(), &self->session_id);
   if (ret < 0) {
     zn_log("logind: not running in a systemd session\n");
     goto err;
   }
 
+  ret = seat_id_is_equal_to_session_seat_id(seat_id, self->session_id);
+  if (ret < 0) goto err_session;
+
+  ret = sd_seat_can_tty(seat_id);
+  if (ret > 0) {  // yes
+    ret = sd_session_get_vt(self->session_id, &self->vt_number);
+    if (ret < 0) {
+      zn_log("logind: session not running on a virtual terminal\n");
+      goto err_session;
+    }
+  } else if (ret < 0) {  // unkown
+    zn_log(
+        "logind: could not determine if seat '%s' has ttys or not\n", seat_id);
+    goto err_session;
+  }
+
+  self->dbus = zn_dbus_connection_create(DBUS_BUS_SYSTEM);
+  if (self->dbus == NULL) goto err_session;
+
+  loop = wl_display_get_event_loop(self->display);
+
+  self->dbus_event_source = zn_dbus_connection_bind(self->dbus, loop);
+  if (self->dbus_event_source == NULL) goto err_dbus;
+
   // TODO: There is more to be done
 
   return 0;
 
+err_dbus:
+  zn_dbus_connection_destroy(self->dbus, self->dbus_event_source);
+
+err_session:
+  free(self->session_id);
+
 err:
-  errno = -ret;
   return -1;
 }
 
 ZN_EXPORT struct zn_session*
-zn_session_create()
+zn_session_create(struct wl_display* display)
 {
   struct zn_session_logind* self;
 
   self = zalloc(sizeof *self);
   if (self == NULL) goto err;
+
+  self->display = display;
 
   return &self->base;
 
@@ -51,6 +119,7 @@ zn_session_destroy(struct zn_session* parent)
 {
   struct zn_session_logind* self = zn_container_of(parent, self, base);
 
-  free(self->id);
+  zn_dbus_connection_destroy(self->dbus, self->dbus_event_source);
+  free(self->session_id);
   free(self);
 }

--- a/src/session/session-logind.c
+++ b/src/session/session-logind.c
@@ -451,8 +451,7 @@ zn_session_logind_activate(struct zn_session_logind* self)
   return 0;
 }
 
-ZN_EXPORT
-int
+ZN_EXPORT int
 zn_session_connect(struct zn_session* parent, const char* seat_id)
 {
   struct zn_session_logind* self = zn_container_of(parent, self, base);

--- a/src/session/session-logind.c
+++ b/src/session/session-logind.c
@@ -640,6 +640,7 @@ err_dbus_cleanup:
 
 err_dbus:
   zn_dbus_connection_destroy(self->dbus, self->dbus_event_source);
+  self->dbus = NULL;
 
 err_session:
   free(self->session_id);
@@ -676,8 +677,10 @@ zn_session_destroy(struct zn_session* parent)
     dbus_pending_call_unref(self->pending_active);
   }
 
-  zn_session_logind_release_control(self);
-  zn_dbus_connection_destroy(self->dbus, self->dbus_event_source);
+  if (self->dbus) {
+    zn_session_logind_release_control(self);
+    zn_dbus_connection_destroy(self->dbus, self->dbus_event_source);
+  }
   zn_session_logind_teardown_dbus(self);
   free(self->session_id);
   free(self);

--- a/src/session/session-logind.c
+++ b/src/session/session-logind.c
@@ -1,7 +1,9 @@
 #include <dbus/dbus.h>
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/sysmacros.h>
 #include <systemd/sd-login.h>
 #include <unistd.h>
 #include <wayland-server.h>
@@ -17,10 +19,341 @@ struct zn_session_logind {
 
   char* session_id;
   unsigned int vt_number;  // 0 for non vt
+  char* session_path;
 
   DBusConnection* dbus;
   struct wl_event_source* dbus_event_source;
+  DBusPendingCall* pending_active;
 };
+
+static void
+zn_session_logind_active_prop_changed(
+    struct zn_session_logind* self, DBusMessage* message, DBusMessageIter* iter)
+{
+  DBusMessageIter sub;
+  dbus_bool_t active;
+  UNUSED(message);
+
+  if (dbus_message_iter_get_arg_type(iter) != DBUS_TYPE_VARIANT) return;
+
+  dbus_message_iter_recurse(iter, &sub);
+
+  if (dbus_message_iter_get_arg_type(&sub) != DBUS_TYPE_BOOLEAN) return;
+
+  dbus_message_iter_get_basic(&sub, &active);
+
+  wl_signal_emit(&self->base.session_signal, &active);
+}
+
+static void
+zn_session_logind_get_active_callback(DBusPendingCall* pending, void* data)
+{
+  struct zn_session_logind* self = data;
+  DBusMessageIter iter;
+  DBusMessage* message;
+  int type;
+
+  dbus_pending_call_unref(self->pending_active);
+  self->pending_active = NULL;
+
+  message = dbus_pending_call_steal_reply(pending);
+  if (message == NULL) return;
+
+  type = dbus_message_get_type(message);
+  if (type == DBUS_MESSAGE_TYPE_METHOD_RETURN &&
+      dbus_message_iter_init(message, &iter))
+    zn_session_logind_active_prop_changed(self, message, &iter);
+
+  dbus_message_unref(message);
+}
+
+static void
+zn_session_logind_get_active(struct zn_session_logind* self)
+{
+  DBusPendingCall* pending;
+  DBusMessage* message;
+  bool ret;
+  const char *interface, *name;
+
+  message = dbus_message_new_method_call("org.freedesktop.login1",
+      self->session_path, "org.freedesktop.DBus.Properties", "Get");
+  if (message == NULL) return;
+
+  interface = "org.freedesktop.login1.Session";
+  name = "Active";
+
+  ret = dbus_message_append_args(message, DBUS_TYPE_STRING, &interface,
+      DBUS_TYPE_STRING, &name, DBUS_TYPE_INVALID);
+  if (ret == false) goto err_unref;
+
+  ret = dbus_connection_send_with_reply(self->dbus, message, &pending, -1);
+  if (ret == false) goto err_unref;
+
+  ret = dbus_pending_call_set_notify(
+      pending, zn_session_logind_get_active_callback, self, NULL);
+  if (ret == false) {
+    dbus_pending_call_cancel(pending);
+    dbus_pending_call_unref(pending);
+    goto err_unref;
+  }
+
+  if (self->pending_active) {
+    dbus_pending_call_cancel(self->pending_active);
+    dbus_pending_call_unref(self->pending_active);
+  }
+
+  self->pending_active = pending;
+
+err_unref:
+  dbus_message_unref(message);
+}
+
+static void
+zn_session_logind_pause_device_complete(
+    struct zn_session_logind* self, uint32_t major, uint32_t minor)
+{
+  DBusMessage* message;
+  bool ret;
+
+  message =
+      dbus_message_new_method_call("org.freedesktop.login1", self->session_path,
+          "org.freedesktop.login1.Session", "PauseDeviceComplete");
+  if (message == NULL) return;
+
+  ret = dbus_message_append_args(message, DBUS_TYPE_UINT32, &major,
+      DBUS_TYPE_UINT32, &minor, DBUS_TYPE_INVALID);
+
+  if (ret) dbus_connection_send(self->dbus, message, NULL);
+  dbus_message_unref(message);
+}
+
+static void
+zn_session_logind_disconnected_dbus(struct zn_session_logind* self)
+{
+  UNUSED(self);
+  zn_log("logind: dbus connection lost, exiting..\n");
+  exit(-1);
+}
+
+static void
+zn_session_logind_session_removed(
+    struct zn_session_logind* self, DBusMessage* message)
+{
+  const char *name, *obj;
+  bool ret;
+
+  ret = dbus_message_get_args(message, NULL, DBUS_TYPE_STRING, &name,
+      DBUS_TYPE_STRING, &obj, DBUS_TYPE_INVALID);
+  if (ret == false) {
+    zn_log("logind: cannot parse SessionRemoved dbus signal\n");
+    return;
+  }
+
+  if (strcmp(name, self->session_id) == 0) {
+    zn_log("logind: out session got lost, exiting..\n");
+    exit(-1);
+  }
+}
+
+static void
+zn_session_logind_property_changed(
+    struct zn_session_logind* self, DBusMessage* message)
+{
+  DBusMessageIter iter, sub, entry;
+  const char *interface, *name;
+
+  // check interface_name
+  if (!dbus_message_iter_init(message, &iter) ||
+      dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_STRING)
+    goto error;
+
+  dbus_message_iter_get_basic(&iter, &interface);
+
+  // check changed_properties
+  if (!dbus_message_iter_next(&iter) ||
+      dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_ARRAY)
+    goto error;
+
+  dbus_message_iter_recurse(&iter, &sub);
+
+  while (dbus_message_iter_get_arg_type(&sub) == DBUS_TYPE_DICT_ENTRY) {
+    dbus_message_iter_recurse(&sub, &entry);
+
+    if (dbus_message_iter_get_arg_type(&entry) != DBUS_TYPE_STRING) goto error;
+
+    dbus_message_iter_get_basic(&entry, &name);
+    if (!dbus_message_iter_next(&entry)) goto error;
+
+    if (!strcmp(name, "Active")) {
+      zn_session_logind_active_prop_changed(self, message, &entry);
+      return;
+    }
+
+    dbus_message_iter_next(&sub);
+  }
+
+  // check invalidated_properties
+  if (!dbus_message_iter_next(&iter) ||
+      dbus_message_iter_get_arg_type(&iter) != DBUS_TYPE_ARRAY)
+    goto error;
+
+  dbus_message_iter_recurse(&iter, &sub);
+
+  while (dbus_message_iter_get_arg_type(&sub) == DBUS_TYPE_STRING) {
+    dbus_message_iter_get_basic(&sub, &name);
+
+    if (!strcmp(name, "Active")) {
+      zn_session_logind_get_active(self);
+      return;
+    }
+
+    dbus_message_iter_next(&sub);
+  }
+
+  return;
+
+error:
+  zn_log("logind: cannot parse PropertiesChanged dbus signal\n");
+}
+
+static void
+zn_session_logind_device_paused(
+    struct zn_session_logind* self, DBusMessage* message)
+{
+  struct zn_session_device_changed_signal_arg arg;
+  bool ret;
+  const char* type;
+  uint32_t major, minor;
+
+  ret = dbus_message_get_args(message, NULL, DBUS_TYPE_UINT32, &major,
+      DBUS_TYPE_UINT32, &minor, DBUS_TYPE_STRING, &type, DBUS_TYPE_INVALID);
+
+  if (ret == false) {
+    zn_log("logind: cannot parse PauseDevice dbus signal\n");
+    return;
+  }
+
+  if (strcmp(type, "pause") == 0)
+    zn_session_logind_pause_device_complete(self, major, minor);
+
+  arg.added = false;
+  arg.device = makedev(major, minor);
+  wl_signal_emit(&self->base.device_changed_signal, &arg);
+}
+
+static void
+zn_session_logind_device_resumed(
+    struct zn_session_logind* self, DBusMessage* message)
+{
+  struct zn_session_device_changed_signal_arg arg;
+  bool ret;
+  uint32_t major, minor;
+
+  ret = dbus_message_get_args(message, NULL, DBUS_TYPE_UINT32, &major,
+      DBUS_TYPE_UINT32, &minor, DBUS_TYPE_INVALID);
+
+  if (ret == false) {
+    zn_log("logind: cannot parse ResumeDevice dbus signal\n");
+    return;
+  }
+
+  arg.added = true;
+  arg.device = makedev(major, minor);
+  wl_signal_emit(&self->base.device_changed_signal, &arg);
+}
+
+static DBusHandlerResult
+zn_session_logind_filter_dbus(
+    DBusConnection* connection, DBusMessage* message, void* data)
+{
+  struct zn_session_logind* self = data;
+  UNUSED(connection);
+
+  if (dbus_message_is_signal(message, DBUS_INTERFACE_LOCAL, "Disconnected")) {
+    zn_session_logind_disconnected_dbus(self);
+  } else if (dbus_message_is_signal(
+                 message, "org.freedesktop.login1.Manager", "SessionRemoved")) {
+    zn_session_logind_session_removed(self, message);
+  } else if (dbus_message_is_signal(message, "org.freedesktop.DBus.Properties",
+                 "PropertiesChanged")) {
+    zn_session_logind_property_changed(self, message);
+  } else if (dbus_message_is_signal(
+                 message, "org.freedesktop.login1.Session", "PauseDevice")) {
+    zn_session_logind_device_paused(self, message);
+  } else if (dbus_message_is_signal(
+                 message, "org.freedesktop.login1.Session", "ResumeDevice")) {
+    zn_session_logind_device_resumed(self, message);
+  }
+
+  return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
+
+static int
+zn_session_logind_setup_dbus(struct zn_session_logind* self)
+{
+  bool ret_bool;
+  int ret;
+
+  ret = asprintf(&self->session_path, "/org/freedesktop/login1/session/%s",
+      self->session_id);
+  if (ret < 0) goto err;
+
+  ret_bool = dbus_connection_add_filter(
+      self->dbus, zn_session_logind_filter_dbus, self, NULL);
+  if (ret_bool == false) {
+    zn_log("logind: failed to add dbus filter\n");
+    goto err_session_path;
+  }
+
+  ret = zn_dbus_connection_add_match_signal(self->dbus,
+      "org.freedesktop.login1", "org.freedesktop.login1.Manager",
+      "SessionRemoved", "/org/freedesktop/login1");
+  if (ret < 0) {
+    zn_log("logind: failed to add dbus match\n");
+    goto err_session_path;
+  }
+
+  ret =
+      zn_dbus_connection_add_match_signal(self->dbus, "org.freedesktop.login1",
+          "org.freedesktop.login1.Session", "PauseDevice", self->session_path);
+  if (ret < 0) {
+    zn_log("logind: failed to add dbus match\n");
+    goto err_session_path;
+  }
+
+  ret =
+      zn_dbus_connection_add_match_signal(self->dbus, "org.freedesktop.login1",
+          "org.freedesktop.login1.Session", "ResumeDevice", self->session_path);
+  if (ret < 0) {
+    zn_log("logind: failed to add dbus match\n");
+    goto err_session_path;
+  }
+
+  ret = zn_dbus_connection_add_match_signal(self->dbus,
+      "org.freedesktop.login1", "org.freedesktop.DBus.Properties",
+      "PropertiesChanged", self->session_path);
+  if (ret < 0) {
+    zn_log("logind: failed to add dbus match\n");
+    goto err_session_path;
+  }
+
+  return 0;
+
+err_session_path:
+  /* don't need to remove match signals, the connection will be closed anyway */
+  free(self->session_path);
+  self->session_path = NULL;
+
+err:
+  return -1;
+}
+
+static void
+zn_session_logind_teardown_dbus(struct zn_session_logind* self)
+{
+  /* don't need to remove match signals, the connection will be closed anyway */
+  free(self->session_path);
+}
 
 /**
  * no side effect
@@ -84,6 +417,9 @@ zn_session_connect(struct zn_session* parent, const char* seat_id)
   self->dbus_event_source = zn_dbus_connection_bind(self->dbus, loop);
   if (self->dbus_event_source == NULL) goto err_dbus;
 
+  ret = zn_session_logind_setup_dbus(self);
+  if (ret < 0) goto err_dbus;
+
   // TODO: There is more to be done
 
   return 0;
@@ -107,6 +443,8 @@ zn_session_create(struct wl_display* display)
   if (self == NULL) goto err;
 
   self->display = display;
+  wl_signal_init(&self->base.device_changed_signal);
+  wl_signal_init(&self->base.session_signal);
 
   return &self->base;
 
@@ -119,7 +457,13 @@ zn_session_destroy(struct zn_session* parent)
 {
   struct zn_session_logind* self = zn_container_of(parent, self, base);
 
+  if (self->pending_active) {
+    dbus_pending_call_cancel(self->pending_active);
+    dbus_pending_call_unref(self->pending_active);
+  }
+
   zn_dbus_connection_destroy(self->dbus, self->dbus_event_source);
+  zn_session_logind_teardown_dbus(self);
   free(self->session_id);
   free(self);
 }

--- a/src/session/session-logind.c
+++ b/src/session/session-logind.c
@@ -1,0 +1,56 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <systemd/sd-login.h>
+#include <unistd.h>
+#include <zen-session.h>
+#include <zen-util.h>
+
+struct zn_session_logind {
+  struct zn_session base;
+
+  char* id;
+};
+
+ZN_EXPORT int
+zn_session_connect(struct zn_session* parent)
+{
+  struct zn_session_logind* self = zn_container_of(parent, self, base);
+  int ret;
+
+  ret = sd_pid_get_session(getpid(), &self->id);
+  if (ret < 0) {
+    zn_log("logind: not running in a systemd session\n");
+    goto err;
+  }
+
+  // TODO: There is more to be done
+
+  return 0;
+
+err:
+  errno = -ret;
+  return -1;
+}
+
+ZN_EXPORT struct zn_session*
+zn_session_create()
+{
+  struct zn_session_logind* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) goto err;
+
+  return &self->base;
+
+err:
+  return NULL;
+}
+
+ZN_EXPORT void
+zn_session_destroy(struct zn_session* parent)
+{
+  struct zn_session_logind* self = zn_container_of(parent, self, base);
+
+  free(self->id);
+  free(self);
+}

--- a/zen-util/include/zen-util.h
+++ b/zen-util/include/zen-util.h
@@ -1,6 +1,7 @@
 #ifndef ZEN_UTIL_H
 #define ZEN_UTIL_H
 
+#include <stdarg.h>
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -34,5 +35,8 @@ zalloc(size_t size)
 
 /** logger */
 int zn_log(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
+/* alternative logger api */
+int zn_vlog(const char *fmt, va_list ap);
 
 #endif  //  ZEN_UTIL_H

--- a/zen-util/include/zen-util.h
+++ b/zen-util/include/zen-util.h
@@ -1,6 +1,9 @@
 #ifndef ZEN_UTIL_H
 #define ZEN_UTIL_H
 
+#include <stddef.h>
+#include <stdlib.h>
+
 /** Visibility attribute */
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define ZN_EXPORT __attribute__((visibility("default")))
@@ -12,6 +15,22 @@
 #ifndef ARRAY_LENGTH
 #define ARRAY_LENGTH(a) (sizeof(a) / sizeof(a)[0])
 #endif
+
+/** Suppress compiler warnings for unused variables */
+#ifndef UNUSED
+#define UNUSED(x) ((void)x)
+#endif
+
+/** Allocate memory and set to zero */
+static inline void *
+zalloc(size_t size)
+{
+  return calloc(1, size);
+}
+
+/** Retrieve a pointer to a containing struct */
+#define zn_container_of(ptr, sample, member) \
+  (__typeof__(sample))((char *)(ptr)-offsetof(__typeof__(*sample), member))
 
 /** logger */
 int zn_log(const char *fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/zen-util/meson.build
+++ b/zen-util/meson.build
@@ -1,3 +1,3 @@
-zigen_util_inc = include_directories('include')
+zen_util_inc = include_directories('include')
 
 subdir('src')

--- a/zen-util/src/log.c
+++ b/zen-util/src/log.c
@@ -10,8 +10,14 @@ zn_log(const char *fmt, ...)
   va_list argp;
 
   va_start(argp, fmt);
-  l = vfprintf(stderr, fmt, argp);
+  l = zn_vlog(fmt, argp);
   va_end(argp);
 
   return l;
+}
+
+ZN_EXPORT int
+zn_vlog(const char *fmt, va_list ap)
+{
+  return vfprintf(stderr, fmt, ap);
 }

--- a/zen-util/src/meson.build
+++ b/zen-util/src/meson.build
@@ -1,15 +1,15 @@
-zigen_util_srcs = [
+zen_util_srcs = [
   'log.c'
 ]
 
 zen_util_lib = static_library(
   'zigen-util',
-  zigen_util_srcs,
-  include_directories: zigen_util_inc,
+  zen_util_srcs,
+  include_directories: zen_util_inc,
   install: false,
 )
 
 zen_util_dep = declare_dependency(
   link_with: zen_util_lib,
-  include_directories: zigen_util_inc,
+  include_directories: zen_util_inc,
 )


### PR DESCRIPTION
Handling logind session  & organize drm backend

## [8dfd3e5](https://github.com/zigen-project/zen/pull/62/commits/8dfd3e571acf88dc1d57859a690b3320273c1832)
- add skeleton for `session-logind`

## [2e006d8](https://github.com/zigen-project/zen/pull/62/commits/2e006d89e15a810dc63c3f15bded59e5528bbdaf)
- connect to dbus daemon
- bind dbus event handlers to wayland loop

## [efbb93e](https://github.com/zigen-project/zen/pull/62/commits/efbb93ec7c5ca16e791e2686a411b62ac2976d1b)
- register filters for some dbus match signals
- emit dbus signals as wayland signal

## [4601d64](https://github.com/zigen-project/zen/pull/62/commits/4601d646f6a481df1fff40446c147e6a45d86fee)
- take control and activate session

## [02a220e](https://github.com/zigen-project/zen/pull/62/commits/02a220e9539f0dd51b74ba56ee69364d5c66aacb)
- add skeleton for `drm-backend`

## [172e831](https://github.com/zigen-project/zen/pull/62/commits/172e83197cf606b5209083bbe18a08aef7949568)
- fix visibility attributes

## [06b513a](https://github.com/zigen-project/zen/pull/62/commits/06b513a3851f8e8356c34b55ddd9befdf357b353)
- add skeleton for `zen-libinput`

## [5115479](https://github.com/zigen-project/zen/pull/62/commits/5115479d50313aa820096c9dcd16f1eadeeaddd1)
- create libinput context

## [fd86d81](https://github.com/zigen-project/zen/pull/62/commits/fd86d81ced9de34d7f4277c9ed25a05d9124eb3f)
- set libinput log handler

## [09876ec](https://github.com/zigen-project/zen/pull/62/commits/09876ec8278b2c0a7d220d702eae7c047f85cac2)
- assign a seat to a libinput context
- [ref](https://wayland.freedesktop.org/libinput/doc/latest/api/group__base.html#ga71a60660b30cb476495e75766222d144)

## [88a69c8](https://github.com/zigen-project/zen/pull/62/commits/88a69c8370eaf153d3b4066f6a5e9866ae6a0c4b)
- bind libinput event to wayland loop