### PR TITLE
start from window manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install \
-            libwayland-dev libwlroots-dev libpixman-1-dev
+            libwayland-dev libwlroots-dev libpixman-1-dev weston
 
       - uses: actions/setup-python@v1
         with:

--- a/README.adoc
+++ b/README.adoc
@@ -11,3 +11,25 @@ $ cd zen
 $ meson build
 $ ninja -C build install
 ----
+
+== Start ZEN Desktop
+
+[red]#***__caution__**# +
+If you are not used to switching virtual terminals or cannot connect via ssh
+from another PC, do not use zen-desktop yet. You may not know how to return to
+the original GUI other than a forced reboot.
+
+Select `ZEN` from your display manager.
+
+== Stop ZEN Desktop
+
+Since we have not yet implemented the input functionalities, the possible way to
+stop ZEN Desktop is to send a kill signal to the process from another terminal.
+
+
+From another terminal (another virtual terminal or ssh)
+
+[source, shell]
+----
+$ pkill zen-desktop
+----

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,8 @@ foreach arg : global_args_maybe
 endforeach
 add_project_arguments(global_args, language: 'c')
 
+datadir = get_option('datadir')
+
 # generic version requirements
 
 wayland_server_req = '>= 1.18.0'
@@ -40,3 +42,10 @@ subdir('protocols')
 subdir('common')
 subdir('scene')
 subdir('src')
+
+find_program('weston-terminal', required: true) # used in zen.desktop
+
+install_data(
+  'zen.desktop',
+  install_dir: join_paths(datadir, 'wayland-sessions')
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,6 @@ _zen_desktop_deps = [
 executable(
   'zen-desktop',
   _zen_desktop_srcs,
-  install: false,
+  install: true,
   dependencies: _zen_desktop_deps,
 )

--- a/zen.desktop
+++ b/zen.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=ZEN
+Comment=Wayland based XR windowing system
+Exec=zen-desktop -s weston-terminal
+Type=Application


### PR DESCRIPTION
- add `-s` `--startup-command` option
  - specify the startup command which is executed on startup
  - when the process of the startup command terminated, the display server will also be terminated
- Enable to start zen from window managers
  - with startup command `weston-terminal`