### PR TITLE
Add Xwayland support for drawing only

### DIFF
--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -15,6 +15,7 @@ struct zn_view_impl {
 
 enum zn_view_type {
   ZN_VIEW_XDG_TOPLEVEL,
+  ZN_VIEW_XWAYLAND,
 };
 
 struct zn_view {

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -1,0 +1,14 @@
+#ifndef ZEN_XWAYLAND_VIEW_H
+#define ZEN_XWAYLAND_VIEW_H
+
+#include <wlr/xwayland.h>
+
+#include "zen/server.h"
+
+/** this destroys itself when the given wlr_wayland_surface is destroyed */
+struct zn_xwayland_view;
+
+struct zn_xwayland_view *zn_xwayland_view_create(
+    struct wlr_xwayland_surface *xwayland_surface, struct zn_server *server);
+
+#endif  //  ZEN_XWAYLAND_VIEW_H

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -5,7 +5,7 @@
 
 #include "zen/server.h"
 
-/** this destroys itself when the given wlr_wayland_surface is destroyed */
+/** this destroys itself when the given wlr_xwayland_surface is destroyed */
 struct zn_xwayland_view;
 
 struct zn_xwayland_view *zn_xwayland_view_create(

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -7,6 +7,7 @@ _zen_desktop_srcs = [
   'seat.c',
   'server.c',
   'xdg-toplevel-view.c',
+  'xwayland-view.c',
 
   'scene/scene.c',
   'scene/screen.c',

--- a/zen/output.c
+++ b/zen/output.c
@@ -159,6 +159,7 @@ err_damage:
   wlr_output_damage_destroy(self->damage);
 
 err_free:
+  wlr_output_destroy_global(self->wlr_output);
   free(self);
 
 err:

--- a/zen/output.c
+++ b/zen/output.c
@@ -104,6 +104,8 @@ zn_output_create(struct wlr_output *wlr_output, struct zn_server *server)
   self->wlr_output = wlr_output;
   self->server = server;
 
+  wlr_output_create_global(wlr_output);
+
   self->damage = wlr_output_damage_create(self->wlr_output);
   if (self->damage == NULL) {
     zn_error("Failed to create wlr_output_damage");
@@ -169,5 +171,6 @@ zn_output_destroy(struct zn_output *self)
 {
   wl_event_source_remove(self->repaint_timer);
   zn_screen_destroy(self->screen);
+  wlr_output_destroy_global(self->wlr_output);
   free(self);
 }

--- a/zen/server.c
+++ b/zen/server.c
@@ -137,15 +137,17 @@ zn_server_get_scene(struct zn_server *self)
 int
 zn_server_run(struct zn_server *self)
 {
-  self->xwayland = wlr_xwayland_create(self->display, self->w_compositor, 0);
+  self->xwayland = wlr_xwayland_create(self->display, self->w_compositor, true);
   if (self->xwayland == NULL) {
     zn_error("Failed to start xwayland");
     return EXIT_FAILURE;
   }
+
   self->xwayland_new_surface_listener.notify =
       zn_server_xwayland_new_surface_handler;
   wl_signal_add(&self->xwayland->events.new_surface,
       &self->xwayland_new_surface_listener);
+
   setenv("DISPLAY", self->xwayland->display_name, true);
   zn_debug("DISPLAY=%s", self->xwayland->display_name);
 

--- a/zen/server.c
+++ b/zen/server.c
@@ -164,7 +164,6 @@ void
 zn_server_terminate(struct zn_server *self, int exit_code)
 {
   self->exit_code = exit_code;
-  wlr_xwayland_destroy(self->xwayland);
   wl_display_terminate(self->display);
 }
 
@@ -288,6 +287,7 @@ err:
 void
 zn_server_destroy(struct zn_server *self)
 {
+  if (self->xwayland) wlr_xwayland_destroy(self->xwayland);
   zn_input_manager_destroy(self->input_manager);
   free(self->socket);
   zn_scene_destroy(self->scene);

--- a/zen/server.c
+++ b/zen/server.c
@@ -28,6 +28,7 @@ struct zn_server {
   // these objects will be automatically destroyed when wl_display is destroyed
   struct wlr_compositor *w_compositor;
   struct wlr_xdg_shell *xdg_shell;
+
   struct wlr_xwayland *xwayland;
 
   struct zn_input_manager *input_manager;
@@ -139,7 +140,7 @@ zn_server_run(struct zn_server *self)
 {
   self->xwayland = wlr_xwayland_create(self->display, self->w_compositor, true);
   if (self->xwayland == NULL) {
-    zn_error("Failed to start xwayland");
+    zn_error("Failed to create xwayland");
     return EXIT_FAILURE;
   }
 

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -1,0 +1,122 @@
+#include "zen/xwayland-view.h"
+
+#include "zen-common.h"
+#include "zen/scene/view.h"
+
+struct zn_xwayland_view {
+  struct zn_view base;
+  struct wlr_xwayland_surface* wlr_xwayland_surface;  // nonnull
+
+  struct zn_server* server;
+
+  struct wl_listener map_listener;
+  struct wl_listener unmap_listener;
+  struct wl_listener wlr_xwayland_surface_destroy_listener;
+};
+
+static void zn_xwayland_view_destroy(struct zn_xwayland_view* self);
+
+static void
+zn_xwayland_view_map(struct wl_listener* listener, void* data)
+{
+  struct zn_xwayland_view* self = zn_container_of(listener, self, map_listener);
+  struct zn_scene* scene = zn_server_get_scene(self->server);
+  struct zn_screen* screen;
+  UNUSED(data);
+
+  if (!zn_assert(!zn_view_is_mapped(&self->base), "Tried to map a mapped view"))
+    return;
+
+  if (wl_list_empty(&scene->screens)) {
+    // TODO: handle this properly
+    zn_warn("View is mapped but no screen found");
+    return;
+  }
+
+  screen = zn_container_of(scene->screens.next, screen, link);
+
+  zn_view_map_to_screen(&self->base, screen);
+}
+
+static void
+zn_xwayland_view_unmap(struct wl_listener* listener, void* data)
+{
+  struct zn_xwayland_view* self =
+      zn_container_of(listener, self, unmap_listener);
+  UNUSED(data);
+
+  if (!zn_assert(
+          zn_view_is_mapped(&self->base), "Tried to unmap an unmapped view"))
+    return;
+
+  zn_view_unmap(&self->base);
+}
+
+static void
+zn_xwayland_view_wlr_xwayland_surface_destroy_handler(
+    struct wl_listener* listener, void* data)
+{
+  struct zn_xwayland_view* self =
+      zn_container_of(listener, self, wlr_xwayland_surface_destroy_listener);
+  UNUSED(data);
+
+  zn_xwayland_view_destroy(self);
+}
+
+static struct wlr_surface*
+zn_xwayland_view_impl_get_wlr_surface(struct zn_view* view)
+{
+  struct zn_xwayland_view* self = zn_container_of(view, self, base);
+  return self->wlr_xwayland_surface->surface;
+}
+
+static const struct zn_view_impl zn_xwayland_view_impl = {
+    .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
+};
+
+struct zn_xwayland_view*
+zn_xwayland_view_create(
+    struct wlr_xwayland_surface* xwayland_surface, struct zn_server* server)
+{
+  struct zn_xwayland_view* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory.");
+    wl_resource_post_no_memory(xwayland_surface->surface->resource);
+    goto err;
+  }
+
+  self->server = server;
+
+  zn_view_init(&self->base, ZN_VIEW_XWAYLAND, &zn_xwayland_view_impl);
+
+  self->wlr_xwayland_surface = xwayland_surface;
+
+  self->map_listener.notify = zn_xwayland_view_map;
+  wl_signal_add(&self->wlr_xwayland_surface->events.map, &self->map_listener);
+
+  self->unmap_listener.notify = zn_xwayland_view_unmap;
+  wl_signal_add(
+      &self->wlr_xwayland_surface->events.unmap, &self->unmap_listener);
+
+  self->wlr_xwayland_surface_destroy_listener.notify =
+      zn_xwayland_view_wlr_xwayland_surface_destroy_handler;
+  wl_signal_add(&self->wlr_xwayland_surface->events.destroy,
+      &self->wlr_xwayland_surface_destroy_listener);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+static void
+zn_xwayland_view_destroy(struct zn_xwayland_view* self)
+{
+  wl_list_remove(&self->wlr_xwayland_surface_destroy_listener.link);
+  wl_list_remove(&self->map_listener.link);
+  wl_list_remove(&self->unmap_listener.link);
+  zn_view_fini(&self->base);
+  free(self);
+}


### PR DESCRIPTION
Add Xwayland support for drawing only.
X clients such as steam and steamvr cannot be rendered yet, so I will create an additional PR for those support.
![IMG_3665](https://user-images.githubusercontent.com/32413673/180133351-1bc925aa-d9a1-4e80-b9d3-5e0149b32617.JPG)

