### PR TITLE
Remove relative path prefix from __FILE__

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ build_root = meson.global_build_root().split('/')
 slen = source_root.length()
 blen = build_root.length()
 
-shorter_path_len = source_root.length() >= build_root.length() ? build_root.length() : source_root.length()
+shorter_path_len = slen >= blen ? blen : slen
 
 relative_source_parts = []
 common_prefix_len = 0

--- a/meson.build
+++ b/meson.build
@@ -35,26 +35,22 @@ shorter_path_len = slen >= blen ? blen : slen
 relative_source_parts = []
 common_prefix_len = 0
 
-foreach _ : build_root
-  if shorter_path_len > common_prefix_len and source_root[common_prefix_len] == build_root[common_prefix_len]
-    common_prefix_len += 1
-  else
-    break
-  endif
-endforeach
-
 i = 0
-foreach _ : build_root
-  if i >= common_prefix_len
-    relative_source_parts += '..'
+in_prefix = true
+foreach p : build_root
+  if not in_prefix or p != source_root[i]
+    in_prefix = false
+    relative_dir_parts += '..'
   endif
   i += 1
 endforeach
 
 i = 0
-foreach dir : source_root
-  if i >= common_prefix_len
-    relative_source_parts += dir
+in_prefix = true
+foreach p : source_root
+  if not in_prefix or build_root[i] != p
+    in_prefix = false
+    relative_dir_parts += p
   endif
   i += 1
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -22,30 +22,6 @@ foreach arg : global_args_maybe
 endforeach
 add_project_arguments(global_args, language: 'c')
 
-datadir = get_option('datadir')
-
-# generic version requirements
-
-wayland_server_req = '>= 1.18.0'
-wayland_protocols_req = '>= 1.24'
-wlroots_req = ['>= 0.15', '< 0.16']
-
-# dependencies
-
-wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
-wayland_scanner_dep = dependency('wayland-scanner')
-wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protocols_req)
-wlroots_dep = dependency('wlroots', version: wlroots_req)
-pixman_dep = dependency('pixman-1')
-
-zen_inc = include_directories('include')
-
-subdir('protocols')
-subdir('common')
-subdir('zen')
-
-find_program('weston-terminal', required: true) # used in zen.desktop
-
 # Compute the relative path from build_root to source_root
 
 source_root = meson.current_source_dir().split('/')
@@ -94,6 +70,29 @@ if cc.has_argument('-fmacro-prefix-map=/prefix/to/hide=')
 	)
 endif
 
+datadir = get_option('datadir')
+
+# generic version requirements
+
+wayland_server_req = '>= 1.18.0'
+wayland_protocols_req = '>= 1.24'
+wlroots_req = ['>= 0.15', '< 0.16']
+
+# dependencies
+
+wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
+wayland_scanner_dep = dependency('wayland-scanner')
+wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protocols_req)
+wlroots_dep = dependency('wlroots', version: wlroots_req)
+pixman_dep = dependency('pixman-1')
+
+zen_inc = include_directories('include')
+
+subdir('protocols')
+subdir('common')
+subdir('zen')
+
+find_program('weston-terminal', required: true) # used in zen.desktop
 
 install_data(
   'zen.desktop',

--- a/meson.build
+++ b/meson.build
@@ -30,17 +30,14 @@ build_root = meson.global_build_root().split('/')
 slen = source_root.length()
 blen = build_root.length()
 
-shorter_path_len = slen >= blen ? blen : slen
-
 relative_source_parts = []
-common_prefix_len = 0
 
 i = 0
 in_prefix = true
 foreach p : build_root
-  if not in_prefix or p != source_root[i]
+  if not in_prefix or i >= slen or p != source_root[i]
     in_prefix = false
-    relative_dir_parts += '..'
+    relative_source_parts += '..'
   endif
   i += 1
 endforeach
@@ -48,9 +45,9 @@ endforeach
 i = 0
 in_prefix = true
 foreach p : source_root
-  if not in_prefix or build_root[i] != p
+  if not in_prefix or i >= blen or build_root[i] != p
     in_prefix = false
-    relative_dir_parts += p
+    relative_source_parts += p
   endif
   i += 1
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,55 @@ subdir('zen')
 
 find_program('weston-terminal', required: true) # used in zen.desktop
 
+# Compute the relative path from build_root to source_root
+
+source_root = meson.current_source_dir().split('/')
+build_root = meson.global_build_root().split('/')
+
+slen = source_root.length()
+blen = build_root.length()
+
+shorter_path_len = source_root.length() >= build_root.length() ? build_root.length() : source_root.length()
+
+relative_source_parts = []
+common_prefix_len = 0
+
+foreach _ : build_root
+  if shorter_path_len > common_prefix_len and source_root[common_prefix_len] == build_root[common_prefix_len]
+    common_prefix_len += 1
+  else
+    break
+  endif
+endforeach
+
+i = 0
+foreach _ : build_root
+  if i >= common_prefix_len
+    relative_source_parts += '..'
+  endif
+  i += 1
+endforeach
+
+i = 0
+foreach dir : source_root
+  if i >= common_prefix_len
+    relative_source_parts += dir
+  endif
+  i += 1
+endforeach
+
+relative_source_dir = join_paths(relative_source_parts) + '/'
+
+# If relative_source_dir is used as the prefix of preprocessor macros such as __FILE__,
+# Replace that with an empty string.
+if cc.has_argument('-fmacro-prefix-map=/prefix/to/hide=')
+	add_project_arguments(
+		'-fmacro-prefix-map=@0@='.format(relative_source_dir),
+		language: 'c',
+	)
+endif
+
+
 install_data(
   'zen.desktop',
   install_dir: join_paths(datadir, 'wayland-sessions')


### PR DESCRIPTION
# Issue
#74 

# Summary
Remove prefix from `__FILE__` macro with a compiler option.
 See `-fmacro-prefix-map` in the [gcc doumentation](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html). In [the sway change I referred to](https://github.com/swaywm/sway/commit/2dc4978d8af326c310057ca8fd22a4c7f5d09335), it also handles the cases when the option is not available. However, the change adds another macro and complicates the program, and the option has been available for a long time (from gcc8 and clang10), so I decided to just ignore such a case.

# Test
I bulit `zen-desktop`, ran it, and saw the following output as the log.
```
00:00:00.026 [zen/server.c:255] WAYLAND_DISPLAY=wayland-1
00:00:00.026 [zen/server.c:256] XDG_RUNTIME_DIR=/run/user/1000
00:00:00.026 [zen/server.c:153] DISPLAY=:2
```