### PR TITLE
Immersive backend

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,8 @@ jobs:
         run: |
           sudo apt-get update &&
           sudo apt-get install \
-            libwayland-dev libwlroots-dev libpixman-1-dev libxml2-dev weston
+            libwayland-dev libwlroots-dev libpixman-1-dev libxml2-dev \
+            libopenvr-dev weston
 
       - uses: actions/setup-python@v1
         with:

--- a/common/include/zen-common/util.h
+++ b/common/include/zen-common/util.h
@@ -1,6 +1,10 @@
 #ifndef ZEN_UTIL_H
 #define ZEN_UTIL_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stddef.h>
 #include <stdlib.h>
 
@@ -31,5 +35,9 @@ zalloc(size_t size)
 /** Retrieve a pointer to a containing struct */
 #define zn_container_of(ptr, sample, member) \
   (__typeof__(sample))((char *)(ptr)-offsetof(__typeof__(*sample), member))
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  //  ZEN_UTIL_H

--- a/common/include/zen-common/util.h
+++ b/common/include/zen-common/util.h
@@ -37,6 +37,16 @@ zalloc(size_t size)
   (__typeof__(sample))((char *)(ptr)-offsetof(__typeof__(*sample), member))
 
 #ifdef __cplusplus
+
+#define DISABLE_MOVE_AND_COPY(Class)        \
+  Class(const Class &) = delete;            \
+  Class(Class &&) = delete;                 \
+  Class &operator=(const Class &) = delete; \
+  Class &operator=(Class &&) = delete;
+
+#endif
+
+#ifdef __cplusplus
 }
 #endif
 

--- a/cui-client/main.c
+++ b/cui-client/main.c
@@ -138,8 +138,21 @@ display_system_applied(
       type == ZEN_DISPLAY_SYSTEM_TYPE_SCREEN ? "screen" : "immersive");
 }
 
+static void
+display_system_warning(void *data,
+    struct zen_display_system *zen_display_system, uint32_t code,
+    const char *message)
+{
+  struct client *cui = data;
+  UNUSED(zen_display_system);
+  UNUSED(code);
+
+  command_printf(&cui->cmd, "<<< WARN: %s\n", message);
+}
+
 static const struct zen_display_system_listener display_system_listener = {
     .applied = display_system_applied,
+    .warning = display_system_warning,
 };
 
 static void
@@ -181,7 +194,6 @@ connect(struct client *cui, char *socket_name)
   cui->registry = wl_display_get_registry(cui->display);
   wl_registry_add_listener(cui->registry, &registry_listener, cui);
 
-  wl_display_dispatch(cui->display);
   wl_display_roundtrip(cui->display);
 
   if (cui->display_system == NULL) {

--- a/immersive-backend/include/zen-immersive-backend.h
+++ b/immersive-backend/include/zen-immersive-backend.h
@@ -1,0 +1,25 @@
+#ifndef ZEN_IMMERSIVE_BACKEND_H
+#define ZEN_IMMERSIVE_BACKEND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zn_immersive_backend {};
+#pragma GCC diagnostic pop
+
+bool zn_immersive_backend_connect(struct zn_immersive_backend* self);
+
+void zn_immersive_backend_disconnect(struct zn_immersive_backend* self);
+
+struct zn_immersive_backend* zn_immersive_backend_create();
+
+void zn_immersive_backend_destroy(struct zn_immersive_backend* self);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  //  ZEN_IMMERSIVE_BACKEND_H

--- a/immersive-backend/meson.build
+++ b/immersive-backend/meson.build
@@ -1,0 +1,3 @@
+_zen_immersive_backend_inc = include_directories('include')
+
+subdir('openvr')

--- a/immersive-backend/openvr/immersive-backend.cc
+++ b/immersive-backend/openvr/immersive-backend.cc
@@ -1,40 +1,57 @@
+#include <memory>
+
+#include "vr-system.h"
 #include "zen-common.h"
 #include "zen-immersive-backend.h"
 
+struct zn_openvr_immersive_backend {
+  struct zn_immersive_backend base;
+  std::unique_ptr<zen::VrSystem> vr_system;  // nonnull
+};
+
 bool
-zn_immersive_backend_connect(struct zn_immersive_backend* self)
+zn_immersive_backend_connect(struct zn_immersive_backend* parent)
 {
-  UNUSED(self);
-  // TODO:
-  return false;
+  struct zn_openvr_immersive_backend* self =
+      zn_container_of(parent, self, base);
+
+  return self->vr_system->Connect();
 }
 
 void
-zn_immersive_backend_disconnect(struct zn_immersive_backend* self)
+zn_immersive_backend_disconnect(struct zn_immersive_backend* parent)
 {
-  UNUSED(self);
-  // TODO:
+  struct zn_openvr_immersive_backend* self =
+      zn_container_of(parent, self, base);
+
+  self->vr_system->Disconnect();
 }
 
 struct zn_immersive_backend*
 zn_immersive_backend_create()
 {
-  struct zn_immersive_backend* self;
+  struct zn_openvr_immersive_backend* self;
 
-  self = static_cast<struct zn_immersive_backend*>(zalloc(sizeof *self));
+  self = static_cast<struct zn_openvr_immersive_backend*>(zalloc(sizeof *self));
   if (self == NULL) {
     zn_error("Failed to allocate memory");
     goto err;
   }
 
-  return self;
+  self->vr_system = std::make_unique<zen::VrSystem>();
+
+  return &self->base;
 
 err:
   return NULL;
 }
 
 void
-zn_immersive_backend_destroy(struct zn_immersive_backend* self)
+zn_immersive_backend_destroy(struct zn_immersive_backend* parent)
 {
+  struct zn_openvr_immersive_backend* self =
+      zn_container_of(parent, self, base);
+
+  self->vr_system.reset();
   free(self);
 }

--- a/immersive-backend/openvr/immersive-backend.cc
+++ b/immersive-backend/openvr/immersive-backend.cc
@@ -1,0 +1,40 @@
+#include "zen-common.h"
+#include "zen-immersive-backend.h"
+
+bool
+zn_immersive_backend_connect(struct zn_immersive_backend* self)
+{
+  UNUSED(self);
+  // TODO:
+  return false;
+}
+
+void
+zn_immersive_backend_disconnect(struct zn_immersive_backend* self)
+{
+  UNUSED(self);
+  // TODO:
+}
+
+struct zn_immersive_backend*
+zn_immersive_backend_create()
+{
+  struct zn_immersive_backend* self;
+
+  self = static_cast<struct zn_immersive_backend*>(zalloc(sizeof *self));
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_immersive_backend_destroy(struct zn_immersive_backend* self)
+{
+  free(self);
+}

--- a/immersive-backend/openvr/meson.build
+++ b/immersive-backend/openvr/meson.build
@@ -1,0 +1,20 @@
+_zen_openvr_immersive_backend_srcs =[
+  'immersive-backend.cc',
+]
+
+_zen_openvr_immersive_backend_deps =[
+  zen_common_dep,
+]
+
+_zen_openvr_immersive_backend_lib = static_library(
+  'zen-openvr-immersive-backend',
+  _zen_openvr_immersive_backend_srcs,
+  dependencies: _zen_openvr_immersive_backend_deps,
+  include_directories: _zen_immersive_backend_inc,
+  install: false,
+)
+
+zen_openvr_immersive_backend_dep = declare_dependency(
+  link_with: _zen_openvr_immersive_backend_lib,
+  include_directories: _zen_immersive_backend_inc,
+)

--- a/immersive-backend/openvr/meson.build
+++ b/immersive-backend/openvr/meson.build
@@ -1,8 +1,10 @@
 _zen_openvr_immersive_backend_srcs =[
   'immersive-backend.cc',
+  'vr-system.cc',
 ]
 
 _zen_openvr_immersive_backend_deps =[
+  openvr_dep,
   zen_common_dep,
 ]
 

--- a/immersive-backend/openvr/vr-system.cc
+++ b/immersive-backend/openvr/vr-system.cc
@@ -1,0 +1,31 @@
+#include "vr-system.h"
+
+#include <openvr/openvr.h>
+
+namespace zen {
+
+bool
+VrSystem::Connect()
+{
+  auto init_error = vr::VRInitError_None;
+
+  (void)vr::VR_Init(&init_error, vr::VRApplication_Scene);
+  if (init_error != vr::VRInitError_None) {
+    zn_warn("Failed to init OpenVR: %s",
+        vr::VR_GetVRInitErrorAsEnglishDescription(init_error));
+    goto err;
+  }
+
+  return true;
+
+err:
+  return false;
+}
+
+void
+VrSystem::Disconnect()
+{
+  vr::VR_Shutdown();
+}
+
+}  // namespace zen

--- a/immersive-backend/openvr/vr-system.h
+++ b/immersive-backend/openvr/vr-system.h
@@ -1,0 +1,23 @@
+#ifndef ZEN_OPENVR_BACKEND_VR_SYSTEM_H
+#define ZEN_OPENVR_BACKEND_VR_SYSTEM_H
+
+#include <openvr/openvr.h>
+
+#include "zen-common.h"
+
+namespace zen {
+
+class VrSystem
+{
+ public:
+  VrSystem() = default;
+  ~VrSystem() = default;
+  DISABLE_MOVE_AND_COPY(VrSystem)
+
+  bool Connect();
+  void Disconnect();
+};
+
+}  // namespace zen
+
+#endif  //  ZEN_OPENVR_BACKEND_VR_SYSTEM_H

--- a/include/zen/display-system.h
+++ b/include/zen/display-system.h
@@ -5,18 +5,21 @@
 #include <zen-desktop-protocol.h>
 
 struct zn_display_system_switch_event {
+  struct wl_resource* issuer;
   enum zen_display_system_type type;
 };
 
 struct zn_display_system {
   struct wl_global* global;
 
+  enum zen_display_system_type type;
+
   struct wl_list resources;
 
   struct wl_signal switch_signal;  // (struct zn_display_system_switch_event *)
 };
 
-void zn_display_system_send_applied(
+void zn_display_system_applied(
     struct zn_display_system* self, enum zen_display_system_type type);
 
 struct zn_display_system* zn_display_system_create(struct wl_display* display);

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -10,6 +10,7 @@
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/xwayland.h>
 
+#include "zen-immersive-backend.h"
 #include "zen/display-system.h"
 #include "zen/input-manager.h"
 #include "zen/scene/scene.h"
@@ -28,6 +29,7 @@ struct zn_server {
 
   struct zn_display_system *display_system;
   struct zn_input_manager *input_manager;
+  struct zn_immersive_backend *immersive_backend;
 
   struct zn_scene *scene;
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project(
-  'zen', 'c',
+  'zen', 'c', 'cpp',
   version: '0.0.1-dev',
   license: 'MIT',
   meson_version: '>= 0.58.0',
@@ -86,6 +86,7 @@ zen_inc = include_directories('include')
 
 subdir('protocols')
 subdir('common')
+subdir('immersive-backend')
 subdir('zen')
 if get_option('cui-client')
   subdir('cui-client')

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   version: '0.0.1-dev',
   license: 'MIT',
   meson_version: '>= 0.58.0',
-  default_options: [ 'warning_level=3', 'werror=true', 'optimization=2', 'c_std=gnu11' ],
+  default_options: [ 'warning_level=3', 'werror=true', 'optimization=2', 'c_std=gnu11', 'cpp_std=gnu++14' ],
 )
 
 cc = meson.get_compiler('c')
@@ -67,17 +67,19 @@ datadir = get_option('datadir')
 
 # generic version requirements
 
-wayland_server_req = '>= 1.18.0'
+openvr_req = '>= 1.12.5'
 wayland_protocols_req = '>= 1.24'
+wayland_server_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 
 # dependencies
 
-wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
-wayland_scanner_dep = dependency('wayland-scanner')
-wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protocols_req)
-wlroots_dep = dependency('wlroots', version: wlroots_req)
+openvr_dep = dependency('openvr', version: openvr_req)
 pixman_dep = dependency('pixman-1')
+wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protocols_req)
+wayland_scanner_dep = dependency('wayland-scanner')
+wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
+wlroots_dep = dependency('wlroots', version: wlroots_req)
 if get_option('cui-client')
   wayland_client_dep = dependency('wayland-client')
 endif

--- a/protocols/zen-desktop.xml
+++ b/protocols/zen-desktop.xml
@@ -32,8 +32,8 @@
       user. For example, it can be presented in VR.
     </description>
 
-    <enum name="error">
-      <description summary="zen_display_system error values"/>
+    <enum name="warning">
+      <description summary="warning values"/>
       <entry name="no_immersive_device" value="0" summary="No device found for immersive display"/>
     </enum>
 
@@ -52,9 +52,20 @@
 
     <event name="applied">
       <description summary="new display system type applied">
-        Notification that a new display system type has been applied.
+        Notification that a new display system type has been applied. When a
+        client binds to zen_displa_system, creating clien-side handle, the
+        server must send this event immediately to the handle.
       </description>
       <arg name="type" type="uint" enum="type" summary="new display system type"/>
+    </event>
+
+    <event name="warning">
+      <description summary="warning event">
+       The warning event is sent out when a non-fatal error has occurred. The
+       message is a brief description of the error, for (debugging) convenience.
+      </description>
+      <arg name="code" type="uint" enum="warning" summary="warning code"/>
+      <arg name="message" type="string" summary="warning description"/>
     </event>
 
     <request name="release" type="destructor">

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -25,6 +25,7 @@ _zen_desktop_deps = [
   wayland_server_dep,
   wlroots_dep,
   zen_common_dep,
+  zen_openvr_immersive_backend_dep,
 ]
 
 executable(


### PR DESCRIPTION
## Context

See #78

> create openvr backend as the first option of "immersive backend", and check if immersive display system is now available or not when a client request server to switch display system to "immersive".

## Summary

- add concept of immersive backend, which handles immersive devices like HMD.
- create openvr immersive backend as the first option of "immersive backend", and check if immersive display system is now available or not when a client request server to switch display system to "immersive".

## How to check behavior

1. build
2. start zen-desktop without startup command. In its log, DISPLAY environment variable to use is printed.
3. start alvr
```
$ DISPLAY=:0 alvr_launcher
```
4. start cui-client (see #76 for detail)
5. enter "immersive" command in the cui client.
6. you will soon receive applied event if steamvr is ready.
7. if you enter "immerisive" command without starting alvr, you will soon get warning which says no immersive device found.