### PR TITLE
repaint loop with openvr

### DIFF
--- a/immersive-backend/include/zen-immersive-backend.h
+++ b/immersive-backend/include/zen-immersive-backend.h
@@ -1,20 +1,26 @@
 #ifndef ZEN_IMMERSIVE_BACKEND_H
 #define ZEN_IMMERSIVE_BACKEND_H
 
+#include <wayland-server-core.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
-struct zn_immersive_backend {};
-#pragma GCC diagnostic pop
+struct zn_immersive_backend {
+  struct {
+    struct wl_signal disconnected;
+  } events;
+};
+
+void zn_immersive_backend_start_repaint_loop(struct zn_immersive_backend* self);
 
 bool zn_immersive_backend_connect(struct zn_immersive_backend* self);
 
 void zn_immersive_backend_disconnect(struct zn_immersive_backend* self);
 
-struct zn_immersive_backend* zn_immersive_backend_create(void);
+struct zn_immersive_backend* zn_immersive_backend_create(
+    struct wl_event_loop* loop);
 
 void zn_immersive_backend_destroy(struct zn_immersive_backend* self);
 

--- a/immersive-backend/openvr/immersive-backend.cc
+++ b/immersive-backend/openvr/immersive-backend.cc
@@ -82,6 +82,7 @@ zn_immersive_backend_destroy(struct zn_immersive_backend* parent)
   struct zn_openvr_immersive_backend* self =
       zn_container_of(parent, self, base);
 
+  self->vr_system->Disconnect();
   self->vr_system.reset();
   free(self);
 }

--- a/immersive-backend/openvr/immersive-backend.cc
+++ b/immersive-backend/openvr/immersive-backend.cc
@@ -1,3 +1,5 @@
+#include <wayland-server-core.h>
+
 #include <memory>
 
 #include "vr-system.h"
@@ -8,6 +10,22 @@ struct zn_openvr_immersive_backend {
   struct zn_immersive_backend base;
   std::unique_ptr<zen::VrSystem> vr_system;  // nonnull
 };
+
+static void
+zn_openvr_immersive_backend_vr_system_disconnected_handler(
+    struct zn_openvr_immersive_backend* self)
+{
+  wl_signal_emit(&self->base.events.disconnected, NULL);
+}
+
+void
+zn_immersive_backend_start_repaint_loop(struct zn_immersive_backend* parent)
+{
+  struct zn_openvr_immersive_backend* self =
+      zn_container_of(parent, self, base);
+
+  self->vr_system->StartRepaintLoop();
+}
 
 bool
 zn_immersive_backend_connect(struct zn_immersive_backend* parent)
@@ -28,7 +46,7 @@ zn_immersive_backend_disconnect(struct zn_immersive_backend* parent)
 }
 
 struct zn_immersive_backend*
-zn_immersive_backend_create()
+zn_immersive_backend_create(struct wl_event_loop* loop)
 {
   struct zn_openvr_immersive_backend* self;
 
@@ -39,8 +57,20 @@ zn_immersive_backend_create()
   }
 
   self->vr_system = std::make_unique<zen::VrSystem>();
+  if (self->vr_system->Init(loop) == false) {
+    zn_error("Failed to init vr system");
+    goto err_free;
+  }
+
+  self->vr_system->callbacks.Disconnected = std::bind(
+      zn_openvr_immersive_backend_vr_system_disconnected_handler, self);
+
+  wl_signal_init(&self->base.events.disconnected);
 
   return &self->base;
+
+err_free:
+  free(self);
 
 err:
   return NULL;

--- a/immersive-backend/openvr/meson.build
+++ b/immersive-backend/openvr/meson.build
@@ -5,6 +5,7 @@ _zen_openvr_immersive_backend_srcs =[
 
 _zen_openvr_immersive_backend_deps =[
   openvr_dep,
+  wayland_server_dep,
   zen_common_dep,
 ]
 

--- a/immersive-backend/openvr/vr-system.cc
+++ b/immersive-backend/openvr/vr-system.cc
@@ -1,14 +1,34 @@
 #include "vr-system.h"
 
+#include <fcntl.h>
 #include <openvr/openvr.h>
+#include <unistd.h>
 
 namespace zen {
+
+bool
+VrSystem::Init(struct wl_event_loop *loop)
+{
+  if (pipe2(pipe_, O_CLOEXEC) == -1) return false;
+
+  wl_event_loop_add_fd(
+      loop, pipe_[0], WL_EVENT_READABLE,
+      []([[maybe_unused]] int fd, [[maybe_unused]] uint32_t mask,
+          void *data) -> int {
+        auto that = static_cast<VrSystem *>(data);
+        return that->HandlePollInThreadResult();
+      },
+      this);
+
+  return true;
+}
 
 bool
 VrSystem::Connect()
 {
   auto init_error = vr::VRInitError_None;
 
+  if (poll_thread_.joinable()) poll_thread_.join();
   (void)vr::VR_Init(&init_error, vr::VRApplication_Scene);
   if (init_error != vr::VRInitError_None) {
     zn_warn("Failed to init OpenVR: %s",
@@ -25,7 +45,87 @@ err:
 void
 VrSystem::Disconnect()
 {
+  this->StopRepaintLoop();
+  if (poll_thread_.joinable()) poll_thread_.join();
   vr::VR_Shutdown();
+  if (callbacks.Disconnected) callbacks.Disconnected();
+}
+
+int
+VrSystem::HandlePollInThreadResult()
+{
+  VrSystem::PollInThreadResult res;
+
+  if (read(pipe_[0], &res, sizeof(res)) != sizeof(res)) {
+    zn_abort("Failed to get result of openvr polling thread");
+    return 0;
+  }
+
+  switch (res) {
+    case VrSystem::PollInThreadResult::kShouldStopOpenVr:
+      this->Disconnect();
+      break;
+
+    case VrSystem::PollInThreadResult::kReadyForNextRepaint:
+      // TODO: render and IVRCompositor::Submit here
+      if (is_repaint_loop_running_) this->PollInThread();
+      break;
+    default:
+      break;
+  }
+
+  return 0;
+}
+
+void
+VrSystem::PollInThread()
+{
+  if (poll_thread_.joinable()) poll_thread_.join();
+  poll_thread_ = std::thread([this]() {
+    vr::TrackedDevicePose_t
+        tracked_device_post_list[vr::k_unMaxTrackedDeviceCount];
+    vr::VREvent_t event;
+    vr::IVRCompositor *compositor = vr::VRCompositor();
+    vr::IVRSystem *system = vr::VRSystem();
+    VrSystem::PollInThreadResult res;
+    ssize_t unused __attribute__((unused));
+
+    compositor->WaitGetPoses(
+        tracked_device_post_list, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+
+    system->PollNextEvent(&event, sizeof(event));
+
+    switch (event.eventType) {
+      case vr::VREvent_Quit:         // fall through
+      case vr::VREvent_ProcessQuit:  // fall through
+      case vr::VREvent_DriverRequestedQuit:
+        res = VrSystem::PollInThreadResult::kShouldStopOpenVr;
+
+        // just return even if write fails
+        unused = write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
+        return;
+
+      default:
+        break;
+    }
+
+    res = VrSystem::PollInThreadResult::kReadyForNextRepaint;
+    unused = write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
+  });
+}
+
+void
+VrSystem::StartRepaintLoop()
+{
+  if (is_repaint_loop_running_) return;
+  is_repaint_loop_running_ = true;
+  this->PollInThread();
+}
+
+void
+VrSystem::StopRepaintLoop()
+{
+  is_repaint_loop_running_ = false;
 }
 
 }  // namespace zen

--- a/immersive-backend/openvr/vr-system.cc
+++ b/immersive-backend/openvr/vr-system.cc
@@ -29,7 +29,7 @@ VrSystem::Connect()
   auto init_error = vr::VRInitError_None;
 
   if (poll_thread_.joinable()) poll_thread_.join();
-  (void)vr::VR_Init(&init_error, vr::VRApplication_Scene);
+  std::ignore = vr::VR_Init(&init_error, vr::VRApplication_Scene);
   if (init_error != vr::VRInitError_None) {
     zn_warn("Failed to init OpenVR: %s",
         vr::VR_GetVRInitErrorAsEnglishDescription(init_error));
@@ -88,7 +88,6 @@ VrSystem::PollInThread()
     vr::IVRCompositor *compositor = vr::VRCompositor();
     vr::IVRSystem *system = vr::VRSystem();
     VrSystem::PollInThreadResult res;
-    ssize_t unused __attribute__((unused));
 
     compositor->WaitGetPoses(
         tracked_device_post_list, vr::k_unMaxTrackedDeviceCount, NULL, 0);
@@ -102,7 +101,8 @@ VrSystem::PollInThread()
         res = VrSystem::PollInThreadResult::kShouldStopOpenVr;
 
         // just return even if write fails
-        unused = write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
+        std::ignore =
+            write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
         return;
 
       default:
@@ -110,7 +110,7 @@ VrSystem::PollInThread()
     }
 
     res = VrSystem::PollInThreadResult::kReadyForNextRepaint;
-    unused = write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
+    std::ignore = write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
   });
 }
 

--- a/immersive-backend/openvr/vr-system.h
+++ b/immersive-backend/openvr/vr-system.h
@@ -2,6 +2,10 @@
 #define ZEN_OPENVR_BACKEND_VR_SYSTEM_H
 
 #include <openvr/openvr.h>
+#include <wayland-server-core.h>
+
+#include <functional>
+#include <thread>
 
 #include "zen-common.h"
 
@@ -14,8 +18,28 @@ class VrSystem
   ~VrSystem() = default;
   DISABLE_MOVE_AND_COPY(VrSystem)
 
+  bool Init(struct wl_event_loop *loop);
   bool Connect();
   void Disconnect();
+  void StartRepaintLoop();
+
+  struct {
+    std::function<void()> Disconnected;
+  } callbacks;
+
+ private:
+  enum class PollInThreadResult : uint8_t {
+    kReadyForNextRepaint = 0,
+    kShouldStopOpenVr = 1,
+  };
+
+  int HandlePollInThreadResult();
+  void PollInThread();
+  void StopRepaintLoop();
+
+  bool is_repaint_loop_running_ = false;
+  int pipe_[2];  // use pipe_[0] in main thread, pipe_[1] in polling thread
+  std::thread poll_thread_;
 };
 
 }  // namespace zen

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -39,6 +39,7 @@ struct zn_server {
   struct wl_listener new_output_listener;
   struct wl_listener xdg_shell_new_surface_listener;
   struct wl_listener display_system_switch_listener;
+  struct wl_listener immersive_backend_disconnected_listener;
   struct wl_listener xwayland_new_surface_listener;
 
   int exit_code;

--- a/zen/server.c
+++ b/zen/server.c
@@ -333,9 +333,9 @@ zn_server_destroy(struct zn_server *self)
   zn_display_system_destroy(self->display_system);
   zn_immersive_backend_destroy(self->immersive_backend);
   free(self->socket);
+  wlr_backend_destroy(self->backend);
   wlr_allocator_destroy(self->allocator);
   wlr_renderer_destroy(self->renderer);
-  wlr_backend_destroy(self->backend);
   zn_scene_destroy(self->scene);
   server_singleton = NULL;
   free(self);


### PR DESCRIPTION
## Context

See #78 

## Summary

Integrate OpenVR's rendering and event loop with wayland's loop.
The wayland loop is event driven, epoll base loop.
OpenVR's loop with `vr::IVRCompositor::WaitGetPose` is blocking, synchronous loop like this.
```c
while(true){
  HmdPose pose = compositor->WaitGetPose(); // block until next frame timing
  event = compositor->PollNextEvent();
  process_event(event);
  texture_left_eye, texture_right_eye = render_with_pose(pose);
  compositor->Submit(texture_left_eye, texture_right_eye);
}
```

This is the design diagram I implemented here. Actual rendering and submitting the rendered texture to OpenVR are out of this PR's scope.

![Untitled Diagram drawio](https://user-images.githubusercontent.com/44729662/181933947-00b16b97-244d-4e02-b94c-d631683e2d21.png)

## How to check behavior
1. Build
2. Start zen-desktop without startup command.
3. Start alvr and confirm that the alvr works with your HMD.
4. Start cui-client

Enter "immersive" command in the cui-client, then the running OpenVR apps will be closed and `Zen-Desktop` tries to start, but as it doesn't actually submit textures to OpenVR, it won't start. That what I'm expected with this PR.
Then, enter "screen" command, and the "Zen-Desktop" should stop.

Again, enter "immersive" command, and kill the process of steam by something like `pkill steam`. Then, your cui-client will be notified that the display system is automatically changed to "screen" type.