### PR TITLE
Exit normally

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,22 +14,29 @@ $ ninja -C build install
 
 == Start ZEN Desktop
 
-[red]#***__caution__**# +
-If you cannot connect to your machine via ssh from another PC, do not use
-zen-desktop yet. You will have no way to return to the original GUI other than
-a forced reboot.
+=== Option 1
 
 Select `ZEN` from your display manager.
 
+=== Option 2
+
+[red]#***__caution__**# +
+Switching between virtual terminals may be confusing if you are not familiar
+with it. You may not be able to return to your GUI desktop except by forced
+reboot.
+
+- Switch virtual terminal
+
+```
+$ sudo chvt <number>
+```
+
+- In a virtual terminal (CUI),
+
+```
+$ zen-desktop
+```
+
 == Stop ZEN Desktop
 
-Since we have not yet implemented the input functionalities, the possible way to
-stop ZEN Desktop is to send a kill signal to the process from another terminal.
-
-
-From another terminal (another virtual terminal or ssh)
-
-[source, shell]
-----
-$ pkill zen-desktop
-----
+Press `q` to quit.

--- a/include/zen/input-device.h
+++ b/include/zen/input-device.h
@@ -14,7 +14,8 @@ struct zn_input_device {
     struct zn_keyboard* keyboard;
   };
 
-  struct wl_listener device_destroy_listener;
+  struct wl_listener wlr_input_destroy_listener;
+  struct wl_listener seat_destroy_listener;
 };
 
 struct zn_input_device* zn_input_device_create(

--- a/include/zen/seat.h
+++ b/include/zen/seat.h
@@ -9,7 +9,11 @@
 
 struct zn_seat {
   struct wlr_seat* wlr_seat;
-  struct wl_list devices;    // zn_input_device::link
+  struct wl_list devices;  // zn_input_device::link
+
+  struct {
+    struct wl_signal destroy;
+  } events;
 };
 
 void zn_seat_add_device(

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -44,6 +44,8 @@ struct zn_server {
   int exit_code;
 };
 
+struct zn_server *zn_server_get_singleton();
+
 /** returns exit code */
 int zn_server_run(struct zn_server *self);
 

--- a/zen/keyboard.c
+++ b/zen/keyboard.c
@@ -3,14 +3,16 @@
 #include <wlr/types/wlr_seat.h>
 
 #include "zen-common.h"
+#include "zen/server.h"
 
 static void
-handle_key(struct wl_listener* listener, void* data)
+zn_keyboard_handle_key(struct wl_listener* listener, void* data)
 {
+  struct zn_server* server = zn_server_get_singleton();
   UNUSED(listener);
   UNUSED(data);
   // Terminate the program with a keyboard event for development convenience.
-  exit(0);
+  zn_server_terminate(server, EXIT_SUCCESS);
 }
 
 struct zn_keyboard*
@@ -29,7 +31,7 @@ zn_keyboard_create(struct wlr_input_device* wlr_input_device)
     goto err;
   }
 
-  self->key_listener.notify = handle_key;
+  self->key_listener.notify = zn_keyboard_handle_key;
   wl_signal_add(&wlr_input_device->keyboard->events.key, &self->key_listener);
 
   return self;

--- a/zen/keyboard.c
+++ b/zen/keyboard.c
@@ -1,5 +1,6 @@
 #include "zen/keyboard.h"
 
+#include <linux/input.h>
 #include <wlr/types/wlr_seat.h>
 
 #include "zen-common.h"
@@ -9,10 +10,12 @@ static void
 zn_keyboard_handle_key(struct wl_listener* listener, void* data)
 {
   struct zn_server* server = zn_server_get_singleton();
+  struct wlr_event_keyboard_key* event = data;
   UNUSED(listener);
-  UNUSED(data);
+
   // Terminate the program with a keyboard event for development convenience.
-  zn_server_terminate(server, EXIT_SUCCESS);
+  if (event->keycode == KEY_Q && event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
+    zn_server_terminate(server, EXIT_SUCCESS);
 }
 
 struct zn_keyboard*

--- a/zen/main.c
+++ b/zen/main.c
@@ -8,7 +8,6 @@
 #include "zen-common.h"
 #include "zen/server.h"
 
-static struct zn_server *server;
 static pid_t startup_command_pid = -1;
 
 static zn_log_importance_t
@@ -36,12 +35,14 @@ handle_wlr_log(
 static void
 zn_terminate(int exit_code)
 {
+  struct zn_server *server = zn_server_get_singleton();
   zn_server_terminate(server, exit_code);
 }
 
 static int
 on_term_signal(int signal_number, void *data)
 {
+  struct zn_server *server = zn_server_get_singleton();
   UNUSED(data);
 
   zn_info("Caught signal %d", signal_number);
@@ -53,6 +54,7 @@ on_term_signal(int signal_number, void *data)
 static int
 on_signal_child(int signal_number, void *data)
 {
+  struct zn_server *server = zn_server_get_singleton();
   pid_t pid;
   int status;
   UNUSED(data);
@@ -98,6 +100,7 @@ main(int argc, char *argv[])
   struct wl_event_source *signal_sources[4];
   int i, exit_status = EXIT_FAILURE;
   char *startup_command = NULL;
+  struct zn_server *server;
 
   static const struct option long_options[] = {
       {"help", no_argument, NULL, 'h'},

--- a/zen/seat.c
+++ b/zen/seat.c
@@ -65,6 +65,7 @@ zn_seat_create(struct wl_display* display, const char* seat_name)
   }
 
   wl_list_init(&self->devices);
+  wl_signal_init(&self->events.destroy);
 
   return self;
 
@@ -78,6 +79,8 @@ err:
 void
 zn_seat_destroy(struct zn_seat* self)
 {
+  wl_signal_emit(&self->events.destroy, NULL);
+
   wl_list_remove(&self->devices);
   wlr_seat_destroy(self->wlr_seat);
   free(self);

--- a/zen/server.c
+++ b/zen/server.c
@@ -159,8 +159,10 @@ zn_server_create(struct wl_display *display)
   char socket_name_candidate[16];
   char *xdg;
 
-  zn_assert(
-      server_singleton == NULL, "Tried to create zn_server multiple times");
+  if (!zn_assert(server_singleton == NULL,
+          "Tried to create zn_server multiple times")) {
+    goto err;
+  }
 
   self = zalloc(sizeof *self);
   if (self == NULL) {

--- a/zen/server.c
+++ b/zen/server.c
@@ -170,6 +170,7 @@ zn_server_create(struct wl_display *display)
     goto err;
   }
 
+  server_singleton = self;
   self->display = display;
   self->exit_code = EXIT_FAILURE;
   self->loop = wl_display_get_event_loop(display);
@@ -267,7 +268,6 @@ zn_server_create(struct wl_display *display)
   wl_signal_add(&self->display_system->switch_signal,
       &self->display_system_switch_listener);
 
-  server_singleton = self;
   return self;
 
 err_socket:
@@ -301,7 +301,6 @@ err:
 void
 zn_server_destroy(struct zn_server *self)
 {
-  server_singleton = NULL;
   if (self->xwayland) wlr_xwayland_destroy(self->xwayland);
   zn_input_manager_destroy(self->input_manager);
   zn_display_system_destroy(self->display_system);
@@ -310,5 +309,6 @@ zn_server_destroy(struct zn_server *self)
   wlr_allocator_destroy(self->allocator);
   wlr_renderer_destroy(self->renderer);
   wlr_backend_destroy(self->backend);
+  server_singleton = NULL;
   free(self);
 }


### PR DESCRIPTION
## Context

See #83 

## Summary

### 6e4d470d0f712e7067bda12c27818efe077662e5

Destroy zn_input_device before zn_seat

### 37a75d26dce176bb68753e96dee5295540f107c2

Exit more gracefully when key input is detected. If just  terminate with `exit(0)`, developers cannot know the termination process works well or not.

### 882d26b5563c1a91a989d289f5868ab11dd51f79

Exit with only Q key pressed. I want to use some key to switch keyboard between multiple computers.

## How to check behavior

1. build
2. start `zen-desktop`
3. press 'q'

You'll see `[zen/main.c:195] Exited gracefully` at the end of the log.