### PR TITLE
use func(void)

### DIFF
--- a/cui-client/main.c
+++ b/cui-client/main.c
@@ -37,7 +37,7 @@ char_is_alphanumeric(char c)
 }
 
 static void
-cursor_erase_line()
+cursor_erase_line(void)
 {
   printf("\x1b[2K");  // clear line
   printf("\x1b[0G");  // move cursor to the head of the line
@@ -55,7 +55,7 @@ cursor_move_right(int n)
 
 /** remove chars after the cursor */
 static void
-cursor_erase_after()
+cursor_erase_after(void)
 {
   printf("\x1b[0J");
 }
@@ -282,7 +282,7 @@ handle_stdin(struct client *cui)
 }
 
 static void
-set_stdin_non_canonical_and_no_echo()
+set_stdin_non_canonical_and_no_echo(void)
 {
   struct termios opt;
   tcgetattr(STDIN_FILENO, &opt);
@@ -292,7 +292,7 @@ set_stdin_non_canonical_and_no_echo()
 }
 
 int
-main()
+main(void)
 {
   struct client cui;
   char *socket;

--- a/immersive-backend/include/zen-immersive-backend.h
+++ b/immersive-backend/include/zen-immersive-backend.h
@@ -14,7 +14,7 @@ bool zn_immersive_backend_connect(struct zn_immersive_backend* self);
 
 void zn_immersive_backend_disconnect(struct zn_immersive_backend* self);
 
-struct zn_immersive_backend* zn_immersive_backend_create();
+struct zn_immersive_backend* zn_immersive_backend_create(void);
 
 void zn_immersive_backend_destroy(struct zn_immersive_backend* self);
 

--- a/include/zen/scene/scene.h
+++ b/include/zen/scene/scene.h
@@ -9,7 +9,7 @@ struct zn_scene {
   struct zn_screen_layout* screen_layout;
 };
 
-struct zn_scene* zn_scene_create();
+struct zn_scene* zn_scene_create(void);
 
 void zn_scene_destroy(struct zn_scene* self);
 

--- a/tests/test-runner.c
+++ b/tests/test-runner.c
@@ -37,7 +37,7 @@ run_test(const struct test *t)
 }
 
 int
-main()
+main(void)
 {
   const struct test *t;
   pid_t pid;

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -3,7 +3,7 @@
 #include "zen-common.h"
 
 struct zn_scene*
-zn_scene_create()
+zn_scene_create(void)
 {
   struct zn_scene* self;
 


### PR DESCRIPTION
## Context

#85 

## Summary

For definitions and declarations of functions without argument in C, I proposed to use
```c
void func(void);
```
instead of
```c
void func();
```

This should be applied to C file and header files which can be included by C files.
Not applied to C++ code and header files only for C++

## Reason

Each types of declaration/definition means different things.
Proposed one is more restriced.

This might be useful to understand the difference.
https://softwareengineering.stackexchange.com/questions/286490/what-is-the-difference-between-function-and-functionvoid

## How to check behavior

None.