### PR TITLE
add -Wstrict-prototypes

### DIFF
--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -44,7 +44,7 @@ struct zn_server {
   int exit_code;
 };
 
-struct zn_server *zn_server_get_singleton();
+struct zn_server *zn_server_get_singleton(void);
 
 /** returns exit code */
 int zn_server_run(struct zn_server *self);

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ global_args_maybe = [
   '-D_GNU_SOURCE',
   '-DWLR_USE_UNSTABLE',
   '-fvisibility=hidden',
+  '-Wstrict-prototypes',
 ]
 
 foreach arg : global_args_maybe

--- a/zen/server.c
+++ b/zen/server.c
@@ -112,7 +112,7 @@ zn_server_xwayland_new_surface_handler(struct wl_listener *listener, void *data)
 }
 
 struct zn_server *
-zn_server_get_singleton()
+zn_server_get_singleton(void)
 {
   zn_assert(server_singleton != NULL,
       "zn_server_get_singleton was called before creating zn_server");


### PR DESCRIPTION
## Context

See https://github.com/zigen-project/zen/pull/94#pullrequestreview-1057041890

## Summary

Add compiler parameter that forbidden function declaration/definition with empty parentheses.

**bad (compile error)**
```
void func();
```
**good**
```
void func(void);
```

## How to check behavior

Compile with some empty parentheses function, and you will get compile error.
