### PR TITLE
cursor move between screens

### DIFF
--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -15,9 +15,8 @@ struct zn_screen_layout {
   } events;
 };
 
-// Searches for the screen from **global** coordinates,
-// and return the screen corresponding to the position.
-// If there is no screen, return NULL.
+// Returns the screen at the given x, y of the coordinates of screen layout.
+// If there is no screen, returns NULL.
 struct zn_screen* zn_screen_layout_get_screen_at(
     struct zn_screen_layout* self, int x, int y);
 

--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -15,6 +15,12 @@ struct zn_screen_layout {
   } events;
 };
 
+// Searches for the screen from **global** coordinates,
+// and return the screen corresponding to the position.
+// If there is no screen, return NULL.
+struct zn_screen* zn_screen_layout_get_screen_at(
+    struct zn_screen_layout* self, int x, int y);
+
 void zn_screen_layout_add(
     struct zn_screen_layout* self, struct zn_screen* screen);
 

--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -16,7 +16,7 @@ struct zn_screen_layout {
 };
 
 // Returns the screen at the given x, y of the coordinates of screen layout.
-// And sets the the screen-local coordinates to dst_{x,y}
+// And sets the screen-local coordinates to dst_{x,y}
 struct zn_screen* zn_screen_layout_get_closest_screen(
     struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y);
 

--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -16,9 +16,9 @@ struct zn_screen_layout {
 };
 
 // Returns the screen at the given x, y of the coordinates of screen layout.
-// If there is no screen, returns NULL.
-struct zn_screen* zn_screen_layout_get_screen_at(
-    struct zn_screen_layout* self, int x, int y);
+// And set the coordinates of the screen to dst_{x,y}
+struct zn_screen* zn_screen_layout_get_closest_screen(
+    struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y);
 
 void zn_screen_layout_add(
     struct zn_screen_layout* self, struct zn_screen* screen);

--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -16,7 +16,7 @@ struct zn_screen_layout {
 };
 
 // Returns the screen at the given x, y of the coordinates of screen layout.
-// And set the coordinates of the screen to dst_{x,y}
+// And sets the the screen-local coordinates to dst_{x,y}
 struct zn_screen* zn_screen_layout_get_closest_screen(
     struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y);
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -20,6 +20,9 @@ struct zn_screen {
   } events;
 };
 
+void zn_screen_get_screen_layout_coords(
+    struct zn_screen *self, int x, int y, int *dst_x, int *dst_y);
+
 void zn_screen_get_box(struct zn_screen *self, struct wlr_box *box);
 
 struct zn_screen *zn_screen_create(

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -7,7 +7,7 @@
 #include "zen/scene/screen-layout.h"
 
 struct zn_screen {
-  int x, y;
+  struct wlr_box box;
   struct zn_output *output;  // zn_output owns zn_screen, nonnull
   struct zn_screen_layout *screen_layout;
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -7,7 +7,7 @@
 #include "zen/scene/screen-layout.h"
 
 struct zn_screen {
-  struct wlr_box box;
+  int x, y;
   struct zn_output *output;  // zn_output owns zn_screen, nonnull
   struct zn_screen_layout *screen_layout;
 
@@ -19,6 +19,8 @@ struct zn_screen {
     struct wl_signal destroy;  // (NULL)
   } events;
 };
+
+void zn_screen_get_box(struct zn_screen *self, struct wlr_box *box);
 
 struct zn_screen *zn_screen_create(
     struct zn_screen_layout *screen_layout, struct zn_output *output);

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ wlroots_req = ['>= 0.15', '< 0.16']
 
 # dependencies
 
+m_dep = cc.find_library('m')
 openvr_dep = dependency('openvr', version: openvr_req)
 pixman_dep = dependency('pixman-1')
 wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protocols_req)

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -47,26 +47,16 @@ zn_cursor_move(struct zn_cursor* self, int x, int y)
 }
 
 static void
-zn_cursor_move_center(struct zn_cursor* self)
-{
-  struct wlr_box box;
-
-  if (self->screen == NULL) {
-    return;
-  }
-  zn_screen_get_box(self->screen, &box);
-  zn_cursor_move(self, box.width / 2, box.height / 2);
-}
-
-static void
 zn_cursor_handle_new_screen(struct wl_listener* listener, void* data)
 {
   struct zn_cursor* self = zn_container_of(listener, self, new_screen_listener);
   struct zn_screen* screen = data;
+  struct wlr_box box;
 
   if (self->screen == NULL) {
     zn_cursor_set_screen(self, screen);
-    zn_cursor_move_center(self);
+    zn_screen_get_box(self->screen, &box);
+    zn_cursor_move(self, box.width / 2, box.height / 2);
   }
 }
 
@@ -79,6 +69,7 @@ zn_cursor_handle_destroy_screen(struct wl_listener* listener, void* data)
   struct zn_server* server = zn_server_get_singleton();
   struct zn_screen_layout* screen_layout = server->scene->screen_layout;
   struct zn_screen* screen;
+  struct wlr_box box;
   bool found = false;
 
   wl_list_for_each(screen, &screen_layout->screens, link)
@@ -91,7 +82,8 @@ zn_cursor_handle_destroy_screen(struct wl_listener* listener, void* data)
 
   zn_cursor_set_screen(self, found ? screen : NULL);
   if (found) {
-    zn_cursor_move_center(self);
+    zn_screen_get_box(self->screen, &box);
+    zn_cursor_move(self, box.width / 2, box.height / 2);
   }
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -10,9 +10,14 @@
 #include "zen/scene/screen-layout.h"
 #include "zen/server.h"
 
+// screen_x and screen_y must be less than screen->width/height
 static void
-zn_cursor_set_screen(struct zn_cursor* self, struct zn_screen* screen)
+zn_cursor_update_position(struct zn_cursor* self, struct zn_screen* screen,
+    int screen_x, int screen_y)
 {
+  self->x = screen_x;
+  self->y = screen_y;
+
   if (self->screen == screen) {
     return;
   }
@@ -26,16 +31,6 @@ zn_cursor_set_screen(struct zn_cursor* self, struct zn_screen* screen)
   }
 
   self->screen = screen;
-}
-
-// screen_x and screen_y must be less than screen->width/height
-static void
-zn_cursor_update_position(struct zn_cursor* self, struct zn_screen* screen,
-    int screen_x, int screen_y)
-{
-  zn_cursor_set_screen(self, screen);
-  self->x = screen_x;
-  self->y = screen_y;
 }
 
 static void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -69,7 +69,8 @@ zn_cursor_handle_destroy_screen(struct wl_listener* listener, void* data)
   if (found) {
     zn_screen_get_box(self->screen, &box);
   }
-  zn_cursor_update_position(self, screen, box.width / 2, box.height / 2);
+  zn_cursor_update_position(
+      self, found ? screen : NULL, box.width / 2, box.height / 2);
 }
 
 void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -82,19 +82,6 @@ zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy)
     return;
   }
 
-  if (new_screen) {
-    zn_debug(
-        "\n"
-        "    scr: (%4d, %4d, %4d, %4d, %p)\n"
-        "new_scr: (%4d, %4d, %4d, %4d, %p)\n"
-        "    pos: (%4d, %4d)",
-        self->screen->box.x, self->screen->box.y, self->screen->box.width,
-        self->screen->box.height, (void*)self->screen, new_screen->box.x,
-        new_screen->box.y, new_screen->box.width, new_screen->box.height,
-        (void*)new_screen, self->x, self->y);
-  } else
-    zn_debug("new_scr is NULL");
-
   left = self->x < 0;
   right = self->x >= self->screen->box.width;
   top = self->y < 0;
@@ -131,10 +118,7 @@ zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy)
   if (bottom) {
     self->y = 0;
   }
-  // self->x += (new_screen->box.x - self->screen->box.x);
-  // self->y += (new_screen->box.y - self->screen->box.y);
-  zn_debug(
-      "\nnew_pos: (%4d, %4d)\n=============================", self->x, self->y);
+
   zn_cursor_set_screen(self, new_screen);
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -36,6 +36,9 @@ zn_cursor_move(struct zn_cursor* self, int x, int y)
   struct zn_screen* new_screen;
   int layout_x, layout_y;
 
+  if (self->screen == NULL) {
+    return;
+  }
   zn_screen_get_screen_layout_coords(self->screen, x, y, &layout_x, &layout_y);
 
   new_screen = zn_screen_layout_get_closest_screen(
@@ -47,6 +50,10 @@ static void
 zn_cursor_move_center(struct zn_cursor* self)
 {
   struct wlr_box box;
+
+  if (self->screen == NULL) {
+    return;
+  }
   zn_screen_get_box(self->screen, &box);
   zn_cursor_move(self, box.width / 2, box.height / 2);
 }

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -39,6 +39,7 @@ zn_cursor_move(struct zn_cursor* self, int x, int y)
   if (self->screen == NULL) {
     return;
   }
+
   zn_screen_get_screen_layout_coords(self->screen, x, y, &layout_x, &layout_y);
 
   new_screen = zn_screen_layout_get_closest_screen(

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -29,7 +29,7 @@ zn_cursor_set_screen(struct zn_cursor* self, struct zn_screen* screen)
 }
 
 static void
-zn_cursor_move(struct zn_cursor* self, int x, int y)
+zn_cursor_process_move(struct zn_cursor* self, int x, int y)
 {
   struct zn_server* server = zn_server_get_singleton();
   struct zn_screen_layout* layout = server->scene->screen_layout;
@@ -57,7 +57,7 @@ zn_cursor_handle_new_screen(struct wl_listener* listener, void* data)
   if (self->screen == NULL) {
     zn_cursor_set_screen(self, screen);
     zn_screen_get_box(self->screen, &box);
-    zn_cursor_move(self, box.width / 2, box.height / 2);
+    zn_cursor_process_move(self, box.width / 2, box.height / 2);
   }
 }
 
@@ -84,14 +84,14 @@ zn_cursor_handle_destroy_screen(struct wl_listener* listener, void* data)
   zn_cursor_set_screen(self, found ? screen : NULL);
   if (found) {
     zn_screen_get_box(self->screen, &box);
-    zn_cursor_move(self, box.width / 2, box.height / 2);
+    zn_cursor_process_move(self, box.width / 2, box.height / 2);
   }
 }
 
 void
 zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy)
 {
-  zn_cursor_move(self, self->x + dx, self->y + dy);
+  zn_cursor_process_move(self, self->x + dx, self->y + dy);
 }
 
 struct zn_cursor*

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -22,8 +22,8 @@ zn_cursor_set_screen(struct zn_cursor* self, struct zn_screen* screen)
     wl_list_init(&self->destroy_screen_listener.link);
   }
   if (screen != NULL) {
-    self->x = screen->output->wlr_output->width / 2;
-    self->y = screen->output->wlr_output->height / 2;
+    self->x = screen->box.width / 2;
+    self->y = screen->box.height / 2;
     wl_signal_add(&screen->events.destroy, &self->destroy_screen_listener);
   }
 

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -25,6 +25,7 @@ _zen_desktop_srcs = [
 ]
 
 _zen_desktop_deps = [
+  m_dep,
   pixman_dep,
   wayland_server_dep,
   wlroots_dep,

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -15,7 +15,8 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   struct zn_server* server = zn_server_get_singleton();
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
 
-  zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
+  // zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
+  zn_cursor_move_relative(cursor, event->unaccel_dx, event->unaccel_dy);
 }
 
 struct zn_pointer*

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -15,8 +15,7 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   struct zn_server* server = zn_server_get_singleton();
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
 
-  // zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
-  zn_cursor_move_relative(cursor, event->unaccel_dx, event->unaccel_dy);
+  zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
 }
 
 struct zn_pointer*

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -1,5 +1,7 @@
 #include "zen/scene/screen-layout.h"
 
+#include <math.h>
+
 #include "zen-common.h"
 #include "zen/scene/screen.h"
 

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -4,18 +4,32 @@
 #include "zen/scene/screen.h"
 
 struct zn_screen*
-zn_screen_layout_get_screen_at(struct zn_screen_layout* self, int x, int y)
+zn_screen_layout_get_closest_screen(
+    struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y)
 {
+  double current_closest_x, current_closest_y, current_closest_distance;
+  double closest_x, closest_y, closest_distance;
+  struct wlr_box box;
+  struct zn_screen* closest_screen = NULL;
   struct zn_screen* screen;
 
   wl_list_for_each(screen, &self->screens, link)
   {
-    if (wlr_box_contains_point(&screen->box, x, y)) {
-      return screen;
+    zn_screen_get_box(screen, &box);
+    wlr_box_closest_point(&box, x, y, &current_closest_x, &current_closest_y);
+    current_closest_distance =
+        pow(x - current_closest_x, 2) + pow(y - current_closest_y, 2);
+    if (closest_screen == NULL || current_closest_distance < closest_distance) {
+      closest_x = current_closest_x;
+      closest_y = current_closest_y;
+      closest_distance = current_closest_distance;
+      closest_screen = screen;
     }
   }
 
-  return NULL;
+  *dst_x = closest_x - closest_screen->x;
+  *dst_y = closest_y - closest_screen->y;
+  return closest_screen;
 }
 
 void

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -1,5 +1,6 @@
 #include "zen/scene/screen-layout.h"
 
+#include <float.h>
 #include <math.h>
 
 #include "zen-common.h"
@@ -9,14 +10,15 @@ struct zn_screen*
 zn_screen_layout_get_closest_screen(
     struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y)
 {
-  double current_closest_x, current_closest_y, current_closest_distance;
   double closest_x, closest_y, closest_distance;
-  struct wlr_box box;
   struct zn_screen* closest_screen = NULL;
   struct zn_screen* screen;
 
   wl_list_for_each(screen, &self->screens, link)
   {
+    double current_closest_x, current_closest_y,
+        current_closest_distance = DBL_MAX;
+    struct wlr_box box;
     zn_screen_get_box(screen, &box);
     wlr_box_closest_point(&box, x, y, &current_closest_x, &current_closest_y);
     current_closest_distance =

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -13,8 +13,6 @@ zn_screen_layout_add(
   wl_list_insert(&self->screens, &new_screen->link);
   wl_list_for_each(screen, &self->screens, link)
   {
-    wlr_output_effective_resolution(
-        screen->output->wlr_output, &screen->box.width, &screen->box.height);
     screen->box.x = x;
     screen->box.y = 0;
     x += screen->box.width;

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -3,6 +3,21 @@
 #include "zen-common.h"
 #include "zen/scene/screen.h"
 
+struct zn_screen*
+zn_screen_layout_get_screen_at(struct zn_screen_layout* self, int x, int y)
+{
+  struct zn_screen* screen;
+
+  wl_list_for_each(screen, &self->screens, link)
+  {
+    if (wlr_box_contains_point(&screen->box, x, y)) {
+      return screen;
+    }
+  }
+
+  return NULL;
+}
+
 void
 zn_screen_layout_add(
     struct zn_screen_layout* self, struct zn_screen* new_screen)

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -24,13 +24,15 @@ zn_screen_layout_add(
 {
   int x = 0;
   struct zn_screen* screen;
+  struct wlr_box box;
 
   wl_list_insert(&self->screens, &new_screen->link);
   wl_list_for_each(screen, &self->screens, link)
   {
-    screen->box.x = x;
-    screen->box.y = 0;
-    x += screen->box.width;
+    zn_screen_get_box(screen, &box);
+    screen->x = x;
+    screen->y = 0;
+    x += box.width;
   }
 
   wl_signal_emit(&self->events.new_screen, new_screen);

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -22,7 +22,7 @@ zn_screen_layout_get_closest_screen(
     wlr_box_closest_point(&box, x, y, &current_closest_x, &current_closest_y);
     current_closest_distance =
         pow(x - current_closest_x, 2) + pow(y - current_closest_y, 2);
-    if (closest_screen == NULL || current_closest_distance < closest_distance) {
+    if (current_closest_distance < closest_distance) {
       closest_x = current_closest_x;
       closest_y = current_closest_y;
       closest_distance = current_closest_distance;

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -10,7 +10,7 @@ struct zn_screen*
 zn_screen_layout_get_closest_screen(
     struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y)
 {
-  double closest_x, closest_y, closest_distance = DBL_MAX;
+  double closest_x = 0, closest_y = 0, closest_distance = DBL_MAX;
   struct zn_screen* closest_screen = NULL;
   struct zn_screen* screen;
 

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -10,14 +10,13 @@ struct zn_screen*
 zn_screen_layout_get_closest_screen(
     struct zn_screen_layout* self, int x, int y, int* dst_x, int* dst_y)
 {
-  double closest_x, closest_y, closest_distance;
+  double closest_x, closest_y, closest_distance = DBL_MAX;
   struct zn_screen* closest_screen = NULL;
   struct zn_screen* screen;
 
   wl_list_for_each(screen, &self->screens, link)
   {
-    double current_closest_x, current_closest_y,
-        current_closest_distance = DBL_MAX;
+    double current_closest_x, current_closest_y, current_closest_distance;
     struct wlr_box box;
     zn_screen_get_box(screen, &box);
     wlr_box_closest_point(&box, x, y, &current_closest_x, &current_closest_y);

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -9,16 +9,15 @@ zn_screen_layout_add(
 {
   int x = 0;
   struct zn_screen* screen;
-  struct wlr_box box;
 
   wl_list_insert(&self->screens, &new_screen->link);
   wl_list_for_each(screen, &self->screens, link)
   {
     wlr_output_effective_resolution(
-        screen->output->wlr_output, &box.width, &box.height);
-    screen->x = x;
-    screen->y = 0;
-    x += box.width;
+        screen->output->wlr_output, &screen->box.width, &screen->box.height);
+    screen->box.x = x;
+    screen->box.y = 0;
+    x += screen->box.width;
   }
 
   wl_signal_emit(&self->events.new_screen, new_screen);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -15,6 +15,8 @@ zn_screen_create(
     goto err;
   }
 
+  self->box.x = output->wlr_output->width;
+  self->box.y = output->wlr_output->height;
   self->output = output;
   self->screen_layout = screen_layout;
   wl_list_init(&self->views);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -15,8 +15,8 @@ zn_screen_create(
     goto err;
   }
 
-  self->box.x = output->wlr_output->width;
-  self->box.y = output->wlr_output->height;
+  self->box.width = output->wlr_output->width;
+  self->box.height = output->wlr_output->height;
   self->output = output;
   self->screen_layout = screen_layout;
   wl_list_init(&self->views);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -3,6 +3,15 @@
 #include "zen-common.h"
 #include "zen/scene/screen-layout.h"
 
+void
+zn_screen_get_box(struct zn_screen *self, struct wlr_box *box)
+{
+  wlr_output_effective_resolution(
+      self->output->wlr_output, &box->width, &box->height);
+  box->x = self->x;
+  box->y = self->y;
+}
+
 struct zn_screen *
 zn_screen_create(
     struct zn_screen_layout *screen_layout, struct zn_output *output)
@@ -15,8 +24,6 @@ zn_screen_create(
     goto err;
   }
 
-  self->box.width = output->wlr_output->width;
-  self->box.height = output->wlr_output->height;
   self->output = output;
   self->screen_layout = screen_layout;
   wl_list_init(&self->views);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -4,6 +4,14 @@
 #include "zen/scene/screen-layout.h"
 
 void
+zn_screen_get_screen_layout_coords(
+    struct zn_screen *self, int x, int y, int *dst_x, int *dst_y)
+{
+  *dst_x = self->x + x;
+  *dst_y = self->y + y;
+}
+
+void
 zn_screen_get_box(struct zn_screen *self, struct wlr_box *box)
 {
   wlr_output_effective_resolution(


### PR DESCRIPTION
## Context

implement a part of #89 

## Summary

The cursor is moved within the screen, and jump to other screens.

## How to check behavior

1. start zen
2. try to move out of screen - it cannot
3. try to move adjacent screen - the cursor is moved to that screen