### PR TITLE
Send pointer event

### DIFF
--- a/include/zen/pointer.h
+++ b/include/zen/pointer.h
@@ -5,9 +5,6 @@
 #include <wlr/interfaces/wlr_pointer.h>
 
 struct zn_pointer {
-  int prev_x, prev_y;
-  struct zn_view* grabbing_view;  // nullable
-
   struct wl_listener button_listener;
   struct wl_listener motion_listener;
   struct wl_listener axis_listener;

--- a/include/zen/pointer.h
+++ b/include/zen/pointer.h
@@ -5,6 +5,7 @@
 #include <wlr/interfaces/wlr_pointer.h>
 
 struct zn_pointer {
+  struct wl_listener button_listener;
   struct wl_listener motion_listener;
 };
 

--- a/include/zen/pointer.h
+++ b/include/zen/pointer.h
@@ -5,6 +5,9 @@
 #include <wlr/interfaces/wlr_pointer.h>
 
 struct zn_pointer {
+  int prev_x, prev_y;
+  struct zn_view* grabbing_view;  // nullable
+
   struct wl_listener button_listener;
   struct wl_listener motion_listener;
 };

--- a/include/zen/pointer.h
+++ b/include/zen/pointer.h
@@ -8,6 +8,7 @@ struct zn_pointer {
   struct wl_listener button_listener;
   struct wl_listener motion_listener;
   struct wl_listener axis_listener;
+  struct wl_listener frame_listener;
 };
 
 struct zn_pointer* zn_pointer_create(struct wlr_input_device* input_device);

--- a/include/zen/pointer.h
+++ b/include/zen/pointer.h
@@ -10,6 +10,7 @@ struct zn_pointer {
 
   struct wl_listener button_listener;
   struct wl_listener motion_listener;
+  struct wl_listener axis_listener;
 };
 
 struct zn_pointer* zn_pointer_create(struct wlr_input_device* input_device);

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -20,6 +20,8 @@ struct zn_screen {
   } events;
 };
 
+struct zn_view *zn_screen_get_view_at(struct zn_screen *self, int x, int y);
+
 void zn_screen_get_screen_layout_coords(
     struct zn_screen *self, int x, int y, int *dst_x, int *dst_y);
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -20,7 +20,8 @@ struct zn_screen {
   } events;
 };
 
-struct zn_view *zn_screen_get_view_at(struct zn_screen *self, int x, int y);
+struct zn_view *zn_screen_get_view_at(
+    struct zn_screen *self, double x, double y);
 
 void zn_screen_get_screen_layout_coords(
     struct zn_screen *self, int x, int y, int *dst_x, int *dst_y);

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -21,7 +21,7 @@ struct zn_screen {
 };
 
 struct zn_view *zn_screen_get_view_at(
-    struct zn_screen *self, double x, double y);
+    struct zn_screen *self, double x, double y, double *view_x, double *view_y);
 
 void zn_screen_get_screen_layout_coords(
     struct zn_screen *self, int x, int y, int *dst_x, int *dst_y);

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -11,6 +11,7 @@ struct zn_screen {
   struct zn_output *output;  // zn_output owns zn_screen, nonnull
   struct zn_screen_layout *screen_layout;
 
+  // List of mapped zn_view in z-order, from bottom to top
   struct wl_list views;  // zn_view::link;
 
   struct wl_list link;  // zn_screen_layout::screens;

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -28,7 +28,7 @@ struct zn_view {
   struct wl_list link;  // zn_screen::views;
 };
 
-void zn_view_get_box(struct zn_view *self, struct wlr_box *box);
+void zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 bool zn_view_is_mapped(struct zn_view *self);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -32,6 +32,8 @@ void zn_view_get_box(struct zn_view *self, struct wlr_box *box);
 
 bool zn_view_is_mapped(struct zn_view *self);
 
+void zn_view_focus(struct zn_view *self);
+
 void zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen);
 
 void zn_view_unmap(struct zn_view *self);

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -19,12 +19,16 @@ enum zn_view_type {
 };
 
 struct zn_view {
+  int x, y;
+
   enum zn_view_type type;
 
   const struct zn_view_impl *impl;
 
   struct wl_list link;  // zn_screen::views;
 };
+
+void zn_view_get_box(struct zn_view *self, struct wlr_box *box);
 
 bool zn_view_is_mapped(struct zn_view *self);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -20,7 +20,6 @@ enum zn_view_type {
 
 struct zn_view {
   int x, y;
-  bool is_moving;
 
   enum zn_view_type type;
 
@@ -32,8 +31,6 @@ struct zn_view {
 void zn_view_get_box(struct zn_view *self, struct wlr_box *box);
 
 bool zn_view_is_mapped(struct zn_view *self);
-
-void zn_view_move(struct zn_view *self, int dx, int dy);
 
 void zn_view_focus(struct zn_view *self);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -19,7 +19,7 @@ enum zn_view_type {
 };
 
 struct zn_view {
-  int x, y;
+  double x, y;
 
   enum zn_view_type type;
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -20,6 +20,7 @@ enum zn_view_type {
 
 struct zn_view {
   int x, y;
+  bool is_moving;
 
   enum zn_view_type type;
 
@@ -31,6 +32,8 @@ struct zn_view {
 void zn_view_get_box(struct zn_view *self, struct wlr_box *box);
 
 bool zn_view_is_mapped(struct zn_view *self);
+
+void zn_view_move(struct zn_view *self, int dx, int dy);
 
 void zn_view_focus(struct zn_view *self);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -34,6 +34,8 @@ bool zn_view_is_mapped(struct zn_view *self);
 
 void zn_view_focus(struct zn_view *self);
 
+void zn_view_unfocus(struct zn_view *self);
+
 void zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen);
 
 void zn_view_unmap(struct zn_view *self);

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -32,8 +32,6 @@ void zn_view_get_box(struct zn_view *self, struct wlr_box *box);
 
 bool zn_view_is_mapped(struct zn_view *self);
 
-void zn_view_focus(struct zn_view *self);
-
 void zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen);
 
 void zn_view_unmap(struct zn_view *self);

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -34,8 +34,6 @@ bool zn_view_is_mapped(struct zn_view *self);
 
 void zn_view_focus(struct zn_view *self);
 
-void zn_view_unfocus(struct zn_view *self);
-
 void zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen);
 
 void zn_view_unmap(struct zn_view *self);

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -13,6 +13,7 @@ struct zn_xdg_toplevel_view {
 
   struct zn_server *server;
 
+  struct wl_listener request_move_listener;
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -20,6 +20,8 @@ struct zn_xdg_toplevel_view {
 
 void zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view *self);
 
+void zn_xdg_toplevel_view_unfocus(struct zn_xdg_toplevel_view *self);
+
 struct zn_xdg_toplevel_view *zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel *xdg_toplevel, struct zn_server *server);
 

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -20,8 +20,6 @@ struct zn_xdg_toplevel_view {
 
 void zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view *self);
 
-void zn_xdg_toplevel_view_unfocus(struct zn_xdg_toplevel_view *self);
-
 struct zn_xdg_toplevel_view *zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel *xdg_toplevel, struct zn_server *server);
 

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -18,8 +18,6 @@ struct zn_xdg_toplevel_view {
   struct wl_listener wlr_xdg_surface_destroy_listener;
 };
 
-void zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view *self);
-
 struct zn_xdg_toplevel_view *zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel *xdg_toplevel, struct zn_server *server);
 

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -13,7 +13,6 @@ struct zn_xdg_toplevel_view {
 
   struct zn_server *server;
 
-  struct wl_listener request_move_listener;
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -3,10 +3,22 @@
 
 #include <wlr/types/wlr_xdg_shell.h>
 
+#include "zen/scene/view.h"
 #include "zen/server.h"
 
 /** this destroys itself when the given wlr_xdg_surface is destroyed */
-struct zn_xdg_toplevel_view;
+struct zn_xdg_toplevel_view {
+  struct zn_view base;
+  struct wlr_xdg_toplevel *wlr_xdg_toplevel;  // nonnull
+
+  struct zn_server *server;
+
+  struct wl_listener map_listener;
+  struct wl_listener unmap_listener;
+  struct wl_listener wlr_xdg_surface_destroy_listener;
+};
+
+void zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view *self);
 
 struct zn_xdg_toplevel_view *zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel *xdg_toplevel, struct zn_server *server);

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -3,10 +3,22 @@
 
 #include <wlr/xwayland.h>
 
+#include "zen/scene/view.h"
 #include "zen/server.h"
 
 /** this destroys itself when the given wlr_xwayland_surface is destroyed */
-struct zn_xwayland_view;
+struct zn_xwayland_view {
+  struct zn_view base;
+  struct wlr_xwayland_surface *wlr_xwayland_surface;  // nonnull
+
+  struct zn_server *server;
+
+  struct wl_listener map_listener;
+  struct wl_listener unmap_listener;
+  struct wl_listener wlr_xwayland_surface_destroy_listener;
+};
+
+void zn_xwayland_view_focus(struct zn_xwayland_view *self);
 
 struct zn_xwayland_view *zn_xwayland_view_create(
     struct wlr_xwayland_surface *xwayland_surface, struct zn_server *server);

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -20,8 +20,6 @@ struct zn_xwayland_view {
 
 void zn_xwayland_view_focus(struct zn_xwayland_view *self);
 
-void zn_xwayland_view_unfocus(struct zn_xwayland_view *self);
-
 struct zn_xwayland_view *zn_xwayland_view_create(
     struct wlr_xwayland_surface *xwayland_surface, struct zn_server *server);
 

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -20,6 +20,8 @@ struct zn_xwayland_view {
 
 void zn_xwayland_view_focus(struct zn_xwayland_view *self);
 
+void zn_xwayland_view_unfocus(struct zn_xwayland_view *self);
+
 struct zn_xwayland_view *zn_xwayland_view_create(
     struct wlr_xwayland_surface *xwayland_surface, struct zn_server *server);
 

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -18,8 +18,6 @@ struct zn_xwayland_view {
   struct wl_listener wlr_xwayland_surface_destroy_listener;
 };
 
-void zn_xwayland_view_focus(struct zn_xwayland_view *self);
-
 struct zn_xwayland_view *zn_xwayland_view_create(
     struct wlr_xwayland_surface *xwayland_surface, struct zn_server *server);
 

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -93,12 +93,12 @@ zn_pointer_create(struct wlr_input_device* wlr_input_device)
   wl_signal_add(
       &wlr_input_device->pointer->events.motion, &self->motion_listener);
 
-  self->axis_listener.notify = zn_pointer_handle_axis;
-  wl_signal_add(&wlr_input_device->pointer->events.axis, &self->axis_listener);
-
   self->button_listener.notify = zn_pointer_handle_button;
   wl_signal_add(
       &wlr_input_device->pointer->events.button, &self->button_listener);
+
+  self->axis_listener.notify = zn_pointer_handle_axis;
+  wl_signal_add(&wlr_input_device->pointer->events.axis, &self->axis_listener);
 
   self->frame_listener.notify = zn_pointer_handle_frame;
   wl_signal_add(

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -46,19 +46,10 @@ zn_pointer_handle_button(struct wl_listener* listener, void* data)
   UNUSED(listener);
   struct wlr_event_pointer_button* event = data;
   struct zn_server* server = zn_server_get_singleton();
-  struct zn_cursor* cursor = server->input_manager->seat->cursor;
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
-  struct zn_view* view;
 
   wlr_seat_pointer_notify_button(
       seat, event->time_msec, event->button, event->state);
-
-  view = zn_screen_get_view_at(cursor->screen, cursor->x, cursor->y);
-  if (event->state == WLR_BUTTON_RELEASED) {
-    if (view != NULL) {
-      zn_view_focus(view);
-    }
-  }
 }
 
 static void

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -62,6 +62,16 @@ zn_pointer_handle_axis(struct wl_listener* listener, void* data)
       event->delta, event->delta_discrete, event->source);
 }
 
+static void
+zn_pointer_handle_frame(struct wl_listener* listener, void* data)
+{
+  UNUSED(listener);
+  UNUSED(data);
+  struct zn_server* server = zn_server_get_singleton();
+  struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
+  wlr_seat_pointer_notify_frame(seat);
+}
+
 struct zn_pointer*
 zn_pointer_create(struct wlr_input_device* wlr_input_device)
 {
@@ -89,6 +99,10 @@ zn_pointer_create(struct wlr_input_device* wlr_input_device)
   self->button_listener.notify = zn_pointer_handle_button;
   wl_signal_add(
       &wlr_input_device->pointer->events.button, &self->button_listener);
+
+  self->frame_listener.notify = zn_pointer_handle_frame;
+  wl_signal_add(
+      &wlr_input_device->pointer->events.frame, &self->frame_listener);
 
   return self;
 

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -116,5 +116,6 @@ zn_pointer_destroy(struct zn_pointer* self)
   wl_list_remove(&self->motion_listener.link);
   wl_list_remove(&self->button_listener.link);
   wl_list_remove(&self->axis_listener.link);
+  wl_list_remove(&self->frame_listener.link);
   free(self);
 }

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -53,13 +53,11 @@ zn_pointer_handle_button(struct wl_listener* listener, void* data)
   wlr_seat_pointer_notify_button(
       seat, event->time_msec, event->button, event->state);
 
-  if (event->state == WLR_BUTTON_RELEASED) {
-    return;
-  }
-
   view = zn_screen_get_view_at(cursor->screen, cursor->x, cursor->y);
-  if (view) {
-    zn_view_focus(view);
+  if (event->state == WLR_BUTTON_RELEASED) {
+    if (view != NULL) {
+      zn_view_focus(view);
+    }
   }
 }
 

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -113,5 +113,6 @@ zn_pointer_destroy(struct zn_pointer* self)
 {
   wl_list_remove(&self->motion_listener.link);
   wl_list_remove(&self->button_listener.link);
+  wl_list_remove(&self->axis_listener.link);
   free(self);
 }

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -57,6 +57,8 @@ zn_pointer_handle_button(struct wl_listener* listener, void* data)
   if (event->state == WLR_BUTTON_RELEASED) {
     if (view != NULL) {
       zn_view_focus(view);
+    }else {
+      zn_view_unfocus(view);
     }
   }
 }

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -76,6 +76,17 @@ zn_pointer_handle_button(struct wl_listener* listener, void* data)
   }
 }
 
+static void
+zn_pointer_handle_axis(struct wl_listener* listener, void* data)
+{
+  struct zn_pointer* self = zn_container_of(listener, self, axis_listener);
+  struct wlr_event_pointer_axis* event = data;
+  struct zn_server* server = zn_server_get_singleton();
+  struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
+  wlr_seat_pointer_notify_axis(seat, event->time_msec, event->orientation,
+      event->delta, event->delta_discrete, event->source);
+}
+
 struct zn_pointer*
 zn_pointer_create(struct wlr_input_device* wlr_input_device)
 {
@@ -96,6 +107,9 @@ zn_pointer_create(struct wlr_input_device* wlr_input_device)
   self->motion_listener.notify = zn_pointer_handle_motion;
   wl_signal_add(
       &wlr_input_device->pointer->events.motion, &self->motion_listener);
+
+  self->axis_listener.notify = zn_pointer_handle_axis;
+  wl_signal_add(&wlr_input_device->pointer->events.axis, &self->axis_listener);
 
   self->button_listener.notify = zn_pointer_handle_button;
   wl_signal_add(

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -57,8 +57,6 @@ zn_pointer_handle_button(struct wl_listener* listener, void* data)
   if (event->state == WLR_BUTTON_RELEASED) {
     if (view != NULL) {
       zn_view_focus(view);
-    }else {
-      zn_view_unfocus(view);
     }
   }
 }

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -23,7 +23,8 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
 
   zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
 
-  view = zn_screen_get_view_at(cursor->screen, cursor->x, cursor->y);
+  view = zn_screen_get_view_at(
+      cursor->screen, cursor->x, cursor->y, &view_x, &view_y);
   if (!view) {
     wlr_seat_pointer_notify_clear_focus(seat);
     return;
@@ -31,8 +32,6 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
 
   surface = view->impl->get_wlr_surface(view);
   if (surface) {
-    view_x = cursor->x - view->x;
-    view_y = cursor->y - view->y;
     wlr_seat_pointer_notify_enter(seat, surface, view_x, view_y);
     wlr_seat_pointer_notify_motion(seat, event->time_msec, view_x, view_y);
   } else {

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -19,7 +19,7 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
   struct wlr_surface* surface;
   struct zn_view* view;
-  int view_x, view_y;
+  double view_x, view_y;
 
   zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
 

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -13,7 +13,7 @@ zn_render_2d_view(struct zn_view *view, struct wlr_renderer *renderer)
 {
   struct wlr_surface *wlr_surface = view->impl->get_wlr_surface(view);
   struct wlr_texture *texture = wlr_surface_get_texture(wlr_surface);
-  struct wlr_box box;
+  struct wlr_fbox fbox;
 
   float transform[9] = {
       1, 0, 0,  //
@@ -21,8 +21,8 @@ zn_render_2d_view(struct zn_view *view, struct wlr_renderer *renderer)
       0, 0, 1   //
   };
 
-  zn_view_get_box(view, &box);
-  wlr_render_texture(renderer, texture, transform, box.x, box.y, 1);
+  zn_view_get_fbox(view, &fbox);
+  wlr_render_texture(renderer, texture, transform, fbox.x, fbox.y, 1);
 }
 
 static void

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -13,6 +13,7 @@ zn_render_2d_view(struct zn_view *view, struct wlr_renderer *renderer)
 {
   struct wlr_surface *wlr_surface = view->impl->get_wlr_surface(view);
   struct wlr_texture *texture = wlr_surface_get_texture(wlr_surface);
+  struct wlr_box box;
 
   float transform[9] = {
       1, 0, 0,  //
@@ -20,7 +21,8 @@ zn_render_2d_view(struct zn_view *view, struct wlr_renderer *renderer)
       0, 0, 1   //
   };
 
-  wlr_render_texture(renderer, texture, transform, 0, 0, 1);
+  zn_view_get_box(view, &box);
+  wlr_render_texture(renderer, texture, transform, box.x, box.y, 1);
 }
 
 static void

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -2,6 +2,25 @@
 
 #include "zen-common.h"
 #include "zen/scene/screen-layout.h"
+#include "zen/scene/view.h"
+
+struct zn_view *
+zn_screen_get_view_at(struct zn_screen *self, int x, int y)
+{
+  struct wlr_box box;
+  struct zn_view *view;
+
+  wl_list_for_each(view, &self->views, link)
+  {
+    zn_view_get_box(view, &box);
+
+    if (wlr_box_contains_point(&box, x, y)) {
+      return view;
+    }
+  }
+
+  return NULL;
+}
 
 void
 zn_screen_get_screen_layout_coords(

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -13,14 +13,10 @@ zn_screen_get_view_at(
 
   wl_list_for_each_reverse(view, &self->views, link)
   {
-    struct wlr_box box;
     zn_view_get_fbox(view, &fbox);
-    box.x = fbox.x;
-    box.y = fbox.y;
-    box.width = fbox.width;
-    box.height = fbox.height;
 
-    if (wlr_box_contains_point(&box, x, y)) {
+    if (fbox.x <= x && x < fbox.x + fbox.width && fbox.y <= y &&
+        y < fbox.y + fbox.height) {
       *view_x = x - view->x;
       *view_y = y - view->y;
       return view;

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -10,7 +10,7 @@ zn_screen_get_view_at(struct zn_screen *self, int x, int y)
   struct wlr_box box;
   struct zn_view *view;
 
-  wl_list_for_each(view, &self->views, link)
+  wl_list_for_each_reverse(view, &self->views, link)
   {
     zn_view_get_box(view, &box);
 

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -5,7 +5,8 @@
 #include "zen/scene/view.h"
 
 struct zn_view *
-zn_screen_get_view_at(struct zn_screen *self, double x, double y)
+zn_screen_get_view_at(
+    struct zn_screen *self, double x, double y, double *view_x, double *view_y)
 {
   struct wlr_fbox fbox;
   struct zn_view *view;
@@ -20,6 +21,8 @@ zn_screen_get_view_at(struct zn_screen *self, double x, double y)
     box.height = fbox.height;
 
     if (wlr_box_contains_point(&box, x, y)) {
+      *view_x = x - view->x;
+      *view_y = y - view->y;
       return view;
     }
   }

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -5,14 +5,19 @@
 #include "zen/scene/view.h"
 
 struct zn_view *
-zn_screen_get_view_at(struct zn_screen *self, int x, int y)
+zn_screen_get_view_at(struct zn_screen *self, double x, double y)
 {
-  struct wlr_box box;
+  struct wlr_fbox fbox;
   struct zn_view *view;
 
   wl_list_for_each_reverse(view, &self->views, link)
   {
-    zn_view_get_box(view, &box);
+    struct wlr_box box;
+    zn_view_get_fbox(view, &fbox);
+    box.x = fbox.x;
+    box.y = fbox.y;
+    box.width = fbox.width;
+    box.height = fbox.height;
 
     if (wlr_box_contains_point(&box, x, y)) {
       return view;

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -36,6 +36,7 @@ zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
   self->x = (screen_box.width / 2) - (view_fbox.width / 2);
   self->y = (screen_box.height / 2) - (view_fbox.height / 2);
 
+  // List of mapped zn_view in z-order, from bottom to top
   wl_list_insert(screen->views.prev, &self->link);
 }
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -88,6 +88,7 @@ zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
   self->y = (screen_box.height / 2) - (view_box.height / 2);
 
   wl_list_insert(&screen->views, &self->link);
+  zn_view_focus(self);
 }
 
 void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -26,32 +26,6 @@ zn_view_is_mapped(struct zn_view *self)
 }
 
 void
-zn_view_focus(struct zn_view *self)
-{
-  struct zn_server *server = zn_server_get_singleton();
-  struct wlr_surface *current_surface =
-      server->input_manager->seat->wlr_seat->pointer_state.focused_surface;
-  struct zn_xdg_toplevel_view *xdg_toplevel_view;
-  struct zn_xwayland_view *xwayland_view;
-
-  switch (self->type) {
-    case ZN_VIEW_XDG_TOPLEVEL:
-      xdg_toplevel_view = zn_container_of(self, xdg_toplevel_view, base);
-      if (xdg_toplevel_view->wlr_xdg_toplevel->base->surface !=
-          current_surface) {
-        zn_xdg_toplevel_view_focus(xdg_toplevel_view);
-      }
-      break;
-    case ZN_VIEW_XWAYLAND:
-      xwayland_view = zn_container_of(self, xwayland_view, base);
-      if (xwayland_view->wlr_xwayland_surface->surface != current_surface) {
-        zn_xwayland_view_focus(xwayland_view);
-      }
-      break;
-  }
-}
-
-void
 zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
 {
   struct wlr_box screen_box, view_box;
@@ -62,7 +36,6 @@ zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
   self->y = (screen_box.height / 2) - (view_box.height / 2);
 
   wl_list_insert(screen->views.prev, &self->link);
-  zn_view_focus(self);
 }
 
 void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -26,16 +26,6 @@ zn_view_is_mapped(struct zn_view *self)
 }
 
 void
-zn_view_move(struct zn_view *self, int dx, int dy)
-{
-  if (!self->is_moving) {
-    return;
-  }
-  self->x += dx;
-  self->y += dy;
-}
-
-void
 zn_view_focus(struct zn_view *self)
 {
   struct zn_server *server = zn_server_get_singleton();

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -4,6 +4,17 @@
 
 #include "zen-common.h"
 
+void
+zn_view_get_box(struct zn_view *self, struct wlr_box *box)
+{
+  struct wlr_surface *surface = self->impl->get_wlr_surface(self);
+
+  box->x = self->x;
+  box->y = self->y;
+  box->width = surface->current.width;
+  box->height = surface->current.height;
+}
+
 bool
 zn_view_is_mapped(struct zn_view *self)
 {
@@ -14,6 +25,13 @@ zn_view_is_mapped(struct zn_view *self)
 void
 zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
 {
+  struct wlr_box screen_box, view_box;
+  zn_screen_get_box(screen, &screen_box);
+  zn_view_get_box(self, &view_box);
+
+  self->x = (screen_box.width / 2) - (view_box.width / 2);
+  self->y = (screen_box.height / 2) - (view_box.height / 2);
+
   wl_list_insert(&screen->views, &self->link);
 }
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -26,6 +26,32 @@ zn_view_is_mapped(struct zn_view *self)
 }
 
 void
+zn_view_unfocus(struct zn_view *self)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct wlr_surface *current_surface =
+      server->input_manager->seat->wlr_seat->pointer_state.focused_surface;
+  struct zn_xdg_toplevel_view *xdg_toplevel_view;
+  struct zn_xwayland_view *xwayland_view;
+
+  switch (self->type) {
+    case ZN_VIEW_XDG_TOPLEVEL:
+      xdg_toplevel_view = zn_container_of(self, xdg_toplevel_view, base);
+      if (xdg_toplevel_view->wlr_xdg_toplevel->base->surface !=
+          current_surface) {
+        zn_xdg_toplevel_view_unfocus(xdg_toplevel_view);
+      }
+      break;
+    case ZN_VIEW_XWAYLAND:
+      xwayland_view = zn_container_of(self, xwayland_view, base);
+      if (xwayland_view->wlr_xwayland_surface->surface != current_surface) {
+        zn_xwayland_view_unfocus(xwayland_view);
+      }
+      break;
+  }
+}
+
+void
 zn_view_focus(struct zn_view *self)
 {
   struct zn_server *server = zn_server_get_singleton();

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -8,14 +8,14 @@
 #include "zen/xwayland-view.h"
 
 void
-zn_view_get_box(struct zn_view *self, struct wlr_box *box)
+zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 {
   struct wlr_surface *surface = self->impl->get_wlr_surface(self);
 
-  box->x = self->x;
-  box->y = self->y;
-  box->width = surface->current.width;
-  box->height = surface->current.height;
+  fbox->x = self->x;
+  fbox->y = self->y;
+  fbox->width = surface->current.width;
+  fbox->height = surface->current.height;
 }
 
 bool
@@ -28,12 +28,13 @@ zn_view_is_mapped(struct zn_view *self)
 void
 zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
 {
-  struct wlr_box screen_box, view_box;
+  struct wlr_box screen_box;
+  struct wlr_fbox view_fbox;
   zn_screen_get_box(screen, &screen_box);
-  zn_view_get_box(self, &view_box);
+  zn_view_get_fbox(self, &view_fbox);
 
-  self->x = (screen_box.width / 2) - (view_box.width / 2);
-  self->y = (screen_box.height / 2) - (view_box.height / 2);
+  self->x = (screen_box.width / 2) - (view_fbox.width / 2);
+  self->y = (screen_box.height / 2) - (view_fbox.height / 2);
 
   wl_list_insert(screen->views.prev, &self->link);
 }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -26,6 +26,16 @@ zn_view_is_mapped(struct zn_view *self)
 }
 
 void
+zn_view_move(struct zn_view *self, int dx, int dy)
+{
+  if (!self->is_moving) {
+    return;
+  }
+  self->x += dx;
+  self->y += dy;
+}
+
+void
 zn_view_focus(struct zn_view *self)
 {
   struct zn_server *server = zn_server_get_singleton();

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -3,6 +3,9 @@
 #include <stdbool.h>
 
 #include "zen-common.h"
+#include "zen/seat.h"
+#include "zen/xdg-toplevel-view.h"
+#include "zen/xwayland-view.h"
 
 void
 zn_view_get_box(struct zn_view *self, struct wlr_box *box)
@@ -20,6 +23,32 @@ zn_view_is_mapped(struct zn_view *self)
 {
   // some zn_screen has this view in zn_screen::views
   return !wl_list_empty(&self->link);
+}
+
+void
+zn_view_focus(struct zn_view *self)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct wlr_surface *current_surface =
+      server->input_manager->seat->wlr_seat->pointer_state.focused_surface;
+  struct zn_xdg_toplevel_view *xdg_toplevel_view;
+  struct zn_xwayland_view *xwayland_view;
+
+  switch (self->type) {
+    case ZN_VIEW_XDG_TOPLEVEL:
+      xdg_toplevel_view = zn_container_of(self, xdg_toplevel_view, base);
+      if (xdg_toplevel_view->wlr_xdg_toplevel->base->surface !=
+          current_surface) {
+        zn_xdg_toplevel_view_focus(xdg_toplevel_view);
+      }
+      break;
+    case ZN_VIEW_XWAYLAND:
+      xwayland_view = zn_container_of(self, xwayland_view, base);
+      if (xwayland_view->wlr_xwayland_surface->surface != current_surface) {
+        zn_xwayland_view_focus(xwayland_view);
+      }
+      break;
+  }
 }
 
 void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -87,7 +87,7 @@ zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
   self->x = (screen_box.width / 2) - (view_box.width / 2);
   self->y = (screen_box.height / 2) - (view_box.height / 2);
 
-  wl_list_insert(&screen->views, &self->link);
+  wl_list_insert(screen->views.prev, &self->link);
   zn_view_focus(self);
 }
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -26,32 +26,6 @@ zn_view_is_mapped(struct zn_view *self)
 }
 
 void
-zn_view_unfocus(struct zn_view *self)
-{
-  struct zn_server *server = zn_server_get_singleton();
-  struct wlr_surface *current_surface =
-      server->input_manager->seat->wlr_seat->pointer_state.focused_surface;
-  struct zn_xdg_toplevel_view *xdg_toplevel_view;
-  struct zn_xwayland_view *xwayland_view;
-
-  switch (self->type) {
-    case ZN_VIEW_XDG_TOPLEVEL:
-      xdg_toplevel_view = zn_container_of(self, xdg_toplevel_view, base);
-      if (xdg_toplevel_view->wlr_xdg_toplevel->base->surface !=
-          current_surface) {
-        zn_xdg_toplevel_view_unfocus(xdg_toplevel_view);
-      }
-      break;
-    case ZN_VIEW_XWAYLAND:
-      xwayland_view = zn_container_of(self, xwayland_view, base);
-      if (xwayland_view->wlr_xwayland_surface->surface != current_surface) {
-        zn_xwayland_view_unfocus(xwayland_view);
-      }
-      break;
-  }
-}
-
-void
 zn_view_focus(struct zn_view *self)
 {
   struct zn_server *server = zn_server_get_singleton();

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -36,7 +36,6 @@ zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
   self->x = (screen_box.width / 2) - (view_fbox.width / 2);
   self->y = (screen_box.height / 2) - (view_fbox.height / 2);
 
-  // List of mapped zn_view in z-order, from bottom to top
   wl_list_insert(screen->views.prev, &self->link);
 }
 

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -73,6 +73,12 @@ zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view* self)
   wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, true);
 }
 
+void
+zn_xdg_toplevel_view_unfocus(struct zn_xdg_toplevel_view* self)
+{
+  wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, false);
+}
+
 struct zn_xdg_toplevel_view*
 zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel* wlr_xdg_toplevel, struct zn_server* server)

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -8,16 +8,6 @@
 static void zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self);
 
 static void
-zn_xdg_toplevel_view_handle_request_move(
-    struct wl_listener* listener, void* data)
-{
-  UNUSED(data);
-  struct zn_xdg_toplevel_view* self =
-      zn_container_of(listener, self, request_move_listener);
-  self->base.is_moving = true;
-}
-
-static void
 zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
 {
   struct zn_xdg_toplevel_view* self =
@@ -102,10 +92,6 @@ zn_xdg_toplevel_view_create(
 
   self->wlr_xdg_toplevel = wlr_xdg_toplevel;
 
-  self->request_move_listener.notify = zn_xdg_toplevel_view_handle_request_move;
-  wl_signal_add(&self->wlr_xdg_toplevel->events.request_move,
-      &self->request_move_listener);
-
   self->map_listener.notify = zn_xdg_toplevel_view_map;
   wl_signal_add(&self->wlr_xdg_toplevel->base->events.map, &self->map_listener);
 
@@ -130,7 +116,6 @@ zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self)
   wl_list_remove(&self->wlr_xdg_surface_destroy_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->unmap_listener.link);
-  wl_list_remove(&self->request_move_listener.link);
   zn_view_fini(&self->base);
   free(self);
 }

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -72,12 +72,6 @@ zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view* self)
   wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, true);
 }
 
-void
-zn_xdg_toplevel_view_unfocus(struct zn_xdg_toplevel_view* self)
-{
-  wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, false);
-}
-
 struct zn_xdg_toplevel_view*
 zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel* wlr_xdg_toplevel, struct zn_server* server)

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -66,12 +66,6 @@ static const struct zn_view_impl zn_xdg_toplevel_view_impl = {
     .get_wlr_surface = zn_xdg_toplevel_view_impl_get_wlr_surface,
 };
 
-void
-zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view* self)
-{
-  wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, true);
-}
-
 struct zn_xdg_toplevel_view*
 zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel* wlr_xdg_toplevel, struct zn_server* server)

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -8,6 +8,16 @@
 static void zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self);
 
 static void
+zn_xdg_toplevel_view_handle_request_move(
+    struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zn_xdg_toplevel_view* self =
+      zn_container_of(listener, self, request_move_listener);
+  self->base.is_moving = true;
+}
+
+static void
 zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
 {
   struct zn_xdg_toplevel_view* self =
@@ -92,6 +102,10 @@ zn_xdg_toplevel_view_create(
 
   self->wlr_xdg_toplevel = wlr_xdg_toplevel;
 
+  self->request_move_listener.notify = zn_xdg_toplevel_view_handle_request_move;
+  wl_signal_add(&self->wlr_xdg_toplevel->events.request_move,
+      &self->request_move_listener);
+
   self->map_listener.notify = zn_xdg_toplevel_view_map;
   wl_signal_add(&self->wlr_xdg_toplevel->base->events.map, &self->map_listener);
 
@@ -116,6 +130,7 @@ zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self)
   wl_list_remove(&self->wlr_xdg_surface_destroy_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->unmap_listener.link);
+  wl_list_remove(&self->request_move_listener.link);
   zn_view_fini(&self->base);
   free(self);
 }

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -5,17 +5,6 @@
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/view.h"
 
-struct zn_xdg_toplevel_view {
-  struct zn_view base;
-  struct wlr_xdg_toplevel* wlr_xdg_toplevel;  // nonnull
-
-  struct zn_server* server;
-
-  struct wl_listener map_listener;
-  struct wl_listener unmap_listener;
-  struct wl_listener wlr_xdg_surface_destroy_listener;
-};
-
 static void zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self);
 
 static void
@@ -39,6 +28,7 @@ zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
   screen = zn_container_of(scene->screen_layout->screens.next, screen, link);
 
   zn_view_map_to_screen(&self->base, screen);
+  zn_xdg_toplevel_view_focus(self);
 }
 
 static void
@@ -76,6 +66,12 @@ zn_xdg_toplevel_view_impl_get_wlr_surface(struct zn_view* view)
 static const struct zn_view_impl zn_xdg_toplevel_view_impl = {
     .get_wlr_surface = zn_xdg_toplevel_view_impl_get_wlr_surface,
 };
+
+void
+zn_xdg_toplevel_view_focus(struct zn_xdg_toplevel_view* self)
+{
+  wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, true);
+}
 
 struct zn_xdg_toplevel_view*
 zn_xdg_toplevel_view_create(

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -28,7 +28,6 @@ zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
   screen = zn_container_of(scene->screen_layout->screens.next, screen, link);
 
   zn_view_map_to_screen(&self->base, screen);
-  zn_xdg_toplevel_view_focus(self);
 }
 
 static void

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -72,12 +72,6 @@ zn_xwayland_view_focus(struct zn_xwayland_view* self)
       self->wlr_xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
 }
 
-void
-zn_xwayland_view_unfocus(struct zn_xwayland_view* self)
-{
-  wlr_xwayland_surface_activate(self->wlr_xwayland_surface, false);
-}
-
 struct zn_xwayland_view*
 zn_xwayland_view_create(
     struct wlr_xwayland_surface* xwayland_surface, struct zn_server* server)

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -72,6 +72,12 @@ zn_xwayland_view_focus(struct zn_xwayland_view* self)
       self->wlr_xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
 }
 
+void
+zn_xwayland_view_unfocus(struct zn_xwayland_view* self)
+{
+  wlr_xwayland_surface_activate(self->wlr_xwayland_surface, false);
+}
+
 struct zn_xwayland_view*
 zn_xwayland_view_create(
     struct wlr_xwayland_surface* xwayland_surface, struct zn_server* server)

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -64,14 +64,6 @@ static const struct zn_view_impl zn_xwayland_view_impl = {
     .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
 };
 
-void
-zn_xwayland_view_focus(struct zn_xwayland_view* self)
-{
-  wlr_xwayland_surface_activate(self->wlr_xwayland_surface, true);
-  wlr_xwayland_surface_restack(
-      self->wlr_xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
-}
-
 struct zn_xwayland_view*
 zn_xwayland_view_create(
     struct wlr_xwayland_surface* xwayland_surface, struct zn_server* server)

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -4,17 +4,6 @@
 #include "zen/scene/scene.h"
 #include "zen/scene/view.h"
 
-struct zn_xwayland_view {
-  struct zn_view base;
-  struct wlr_xwayland_surface* wlr_xwayland_surface;  // nonnull
-
-  struct zn_server* server;
-
-  struct wl_listener map_listener;
-  struct wl_listener unmap_listener;
-  struct wl_listener wlr_xwayland_surface_destroy_listener;
-};
-
 static void zn_xwayland_view_destroy(struct zn_xwayland_view* self);
 
 static void
@@ -74,6 +63,14 @@ zn_xwayland_view_impl_get_wlr_surface(struct zn_view* view)
 static const struct zn_view_impl zn_xwayland_view_impl = {
     .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
 };
+
+void
+zn_xwayland_view_focus(struct zn_xwayland_view* self)
+{
+  wlr_xwayland_surface_activate(self->wlr_xwayland_surface, true);
+  wlr_xwayland_surface_restack(
+      self->wlr_xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
+}
 
 struct zn_xwayland_view*
 zn_xwayland_view_create(


### PR DESCRIPTION
## Context

implement a part of #89 

## Summary

Give position information to each views, and send enter/leave/motion/axis event from pointer to client.

## How to check behavior

1. start zen with -s option
    - `weston-clickdot` is recommended for testing `motion` event
    - `weston-cliptest` is recommended for testing `axis` event
3. move the cursor or scroll on view
4. events are sended
