### PR TITLE
key binding

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install \
             libwayland-dev libwlroots-dev libpixman-1-dev libxml2-dev \
-            libopenvr-dev weston
+            libopenvr-dev libxkbcommon-dev weston
 
       - uses: actions/setup-python@v1
         with:

--- a/README.adoc
+++ b/README.adoc
@@ -39,4 +39,4 @@ $ zen-desktop
 
 == Stop ZEN Desktop
 
-Press `q` to quit.
+Press `<alt> + q` to quit.

--- a/include/zen/binding.h
+++ b/include/zen/binding.h
@@ -1,0 +1,32 @@
+#ifndef ZEN_BINDING_H
+#define ZEN_BINDING_H
+
+#include <wayland-server.h>
+
+struct zn_input_manager;
+struct zn_keyboard;
+
+typedef void (*zn_key_binding_handler_t)(
+    uint32_t time_msec, uint32_t key, void *data);
+
+struct zn_binding {
+  uint32_t key;
+  uint32_t modifiers;
+  zn_key_binding_handler_t handler;
+  void *data;
+  struct wl_list link;  // zn_input_manager::key_binding_list
+};
+
+/**
+ * @return true if the key event is handled
+ */
+bool zn_binding_notify_key(struct zn_binding *self, uint32_t time_msec,
+    uint32_t key, enum wl_keyboard_key_state state,
+    struct zn_keyboard *keyboard);
+
+struct zn_binding *zn_binding_create(uint32_t key, uint32_t modifiers,
+    zn_key_binding_handler_t handler, void *data);
+
+void zn_binding_destroy(struct zn_binding *self);
+
+#endif  //  ZEN_BINDING_H

--- a/include/zen/input-manager.h
+++ b/include/zen/input-manager.h
@@ -4,11 +4,28 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
 
+#include "zen/binding.h"
 #include "zen/input-device.h"
+#include "zen/keyboard.h"
 
 struct zn_input_manager {
   struct zn_seat* seat;
+  struct wl_list key_binding_list;  // zn_binding::link
 };
+
+/**
+ * @return true if the key event is handled as the key binding
+ */
+bool zn_input_manager_bindings_notify_key(struct zn_input_manager* self,
+    uint32_t time_msec, uint32_t key, enum wl_keyboard_key_state state,
+    struct zn_keyboard* keyboard);
+
+/**
+ * @return NULL if failed
+ */
+struct zn_binding* zn_input_manager_add_key_binding(
+    struct zn_input_manager* self, uint32_t key, uint32_t modifiers,
+    zn_key_binding_handler_t handler, void* data);
 
 void zn_input_manager_handle_new_wlr_input(
     struct zn_input_manager* self, struct wlr_input_device* wlr_input);

--- a/include/zen/keyboard.h
+++ b/include/zen/keyboard.h
@@ -7,10 +7,14 @@
 #include "zen/seat.h"
 
 struct zn_keyboard {
+  struct zn_input_device* input_device;
+
   struct wl_listener key_listener;
+  struct wl_listener modifiers_listener;
 };
 
-struct zn_keyboard* zn_keyboard_create(struct wlr_input_device* input_device);
+struct zn_keyboard* zn_keyboard_create(
+    struct zn_input_device* input_device, struct zn_seat* seat);
 
 void zn_keyboard_destroy(struct zn_keyboard* self);
 

--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,7 @@ wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protoco
 wayland_scanner_dep = dependency('wayland-scanner')
 wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
 wlroots_dep = dependency('wlroots', version: wlroots_req)
+xkbcommon_dep = dependency('xkbcommon')
 if get_option('cui-client')
   wayland_client_dep = dependency('wayland-client')
 endif

--- a/zen/binding.c
+++ b/zen/binding.c
@@ -1,0 +1,57 @@
+#include "zen/binding.h"
+
+#include <zen-common.h>
+
+#include "zen/input-manager.h"
+#include "zen/server.h"
+
+bool
+zn_binding_notify_key(struct zn_binding *self, uint32_t time_msec, uint32_t key,
+    enum wl_keyboard_key_state state, struct zn_keyboard *keyboard)
+{
+  struct wlr_keyboard *wlr_keyboard =
+      keyboard->input_device->wlr_input->keyboard;
+
+  if (state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+    return false;
+  }
+
+  if (self->key == key &&
+      self->modifiers == wlr_keyboard_get_modifiers(wlr_keyboard)) {
+    self->handler(time_msec, key, self->data);
+    return true;
+  }
+
+  return false;
+}
+
+struct zn_binding *
+zn_binding_create(uint32_t key, uint32_t modifiers,
+    zn_key_binding_handler_t handler, void *data)
+{
+  struct zn_binding *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->key = key;
+  self->modifiers = modifiers;
+  self->handler = handler;
+  self->data = data;
+  wl_list_init(&self->link);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_binding_destroy(struct zn_binding *self)
+{
+  wl_list_remove(&self->link);
+  free(self);
+}

--- a/zen/input-device.c
+++ b/zen/input-device.c
@@ -36,9 +36,13 @@ zn_input_device_create(struct zn_seat* seat, struct wlr_input_device* wlr_input)
     goto err;
   }
 
+  self->seat = seat;
+  self->wlr_input = wlr_input;
+  wlr_input->data = self;
+
   switch (wlr_input->type) {
     case WLR_INPUT_DEVICE_KEYBOARD:
-      self->keyboard = zn_keyboard_create(wlr_input);
+      self->keyboard = zn_keyboard_create(self, seat);
       if (self->keyboard == NULL) {
         zn_error("Failed to create zn_keyboard");
         goto err_free;
@@ -57,10 +61,6 @@ zn_input_device_create(struct zn_seat* seat, struct wlr_input_device* wlr_input)
     case WLR_INPUT_DEVICE_SWITCH:
       break;
   }
-
-  self->seat = seat;
-  self->wlr_input = wlr_input;
-  wlr_input->data = self;
 
   self->wlr_input_destroy_listener.notify =
       zn_input_device_wlr_input_destroy_handler;

--- a/zen/input-manager.c
+++ b/zen/input-manager.c
@@ -4,8 +4,43 @@
 #include <wlr/types/wlr_input_device.h>
 
 #include "zen-common.h"
+#include "zen/binding.h"
 #include "zen/input-device.h"
 #include "zen/seat.h"
+
+bool
+zn_input_manager_bindings_notify_key(struct zn_input_manager* self,
+    uint32_t time_msec, uint32_t key, enum wl_keyboard_key_state state,
+    struct zn_keyboard* keyboard)
+{
+  struct zn_binding *binding, *tmp;
+
+  wl_list_for_each_safe(binding, tmp, &self->key_binding_list, link)
+  {
+    if (zn_binding_notify_key(binding, time_msec, key, state, keyboard)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+struct zn_binding*
+zn_input_manager_add_key_binding(struct zn_input_manager* self, uint32_t key,
+    uint32_t modifiers, zn_key_binding_handler_t handler, void* data)
+{
+  struct zn_binding* binding;
+
+  binding = zn_binding_create(key, modifiers, handler, data);
+  if (binding == NULL) {
+    zn_error("Failed to create a key binding");
+    return NULL;
+  }
+
+  wl_list_insert(&self->key_binding_list, &binding->link);
+
+  return binding;
+}
 
 void
 zn_input_manager_handle_new_wlr_input(
@@ -37,6 +72,8 @@ zn_input_manager_create(struct wl_display* display)
     goto err_free;
   }
 
+  wl_list_init(&self->key_binding_list);
+
   return self;
 
 err_free:
@@ -49,6 +86,13 @@ err:
 void
 zn_input_manager_destroy(struct zn_input_manager* self)
 {
+  struct zn_binding *binding, *tmp;
+
+  wl_list_for_each_safe(binding, tmp, &self->key_binding_list, link)
+  {
+    zn_binding_destroy(binding);
+  }
+
   zn_seat_destroy(self->seat);
   free(self);
 }

--- a/zen/keyboard.c
+++ b/zen/keyboard.c
@@ -1,31 +1,52 @@
 #include "zen/keyboard.h"
 
-#include <linux/input.h>
 #include <wlr/types/wlr_seat.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include "zen-common.h"
 #include "zen/server.h"
 
 static void
+zn_keyboard_handle_modifiers(struct wl_listener* listener, void* data)
+{
+  struct zn_keyboard* self =
+      zn_container_of(listener, self, modifiers_listener);
+  struct wlr_input_device* wlr_input = self->input_device->wlr_input;
+  struct wlr_seat* wlr_seat = self->input_device->seat->wlr_seat;
+  UNUSED(data);
+
+  wlr_seat_set_keyboard(wlr_seat, wlr_input);
+  wlr_seat_keyboard_notify_modifiers(wlr_seat, &wlr_input->keyboard->modifiers);
+}
+
+static void
 zn_keyboard_handle_key(struct wl_listener* listener, void* data)
 {
-  struct zn_server* server = zn_server_get_singleton();
+  struct zn_keyboard* self = zn_container_of(listener, self, key_listener);
   struct wlr_event_keyboard_key* event = data;
-  UNUSED(listener);
+  struct zn_server* server = zn_server_get_singleton();
+  struct wlr_seat* wlr_seat = self->input_device->seat->wlr_seat;
+  bool handled;
 
-  // Terminate the program with a keyboard event for development convenience.
-  if (event->keycode == KEY_Q && event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
-    zn_server_terminate(server, EXIT_SUCCESS);
+  handled = zn_input_manager_bindings_notify_key(server->input_manager,
+      event->time_msec, event->keycode, event->state, self);
+
+  if (!handled) {
+    wlr_seat_set_keyboard(wlr_seat, self->input_device->wlr_input);
+    wlr_seat_keyboard_notify_key(
+        wlr_seat, event->time_msec, event->keycode, event->state);
+  }
 }
 
 struct zn_keyboard*
-zn_keyboard_create(struct wlr_input_device* wlr_input_device)
+zn_keyboard_create(struct zn_input_device* input_device, struct zn_seat* seat)
 {
   struct zn_keyboard* self;
+  struct wlr_input_device* wlr_input = input_device->wlr_input;
 
-  if (!zn_assert(wlr_input_device->type == WLR_INPUT_DEVICE_KEYBOARD,
+  if (!zn_assert(wlr_input->type == WLR_INPUT_DEVICE_KEYBOARD,
           "Wrong type - expect: %d, actual: %d", WLR_INPUT_DEVICE_KEYBOARD,
-          wlr_input_device->type)) {
+          wlr_input->type)) {
     goto err;
   }
 
@@ -35,8 +56,27 @@ zn_keyboard_create(struct wlr_input_device* wlr_input_device)
     goto err;
   }
 
+  self->input_device = input_device;
+
+  {
+    struct xkb_context* context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    struct xkb_keymap* keymap =
+        xkb_keymap_new_from_names(context, NULL, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    wlr_keyboard_set_keymap(wlr_input->keyboard, keymap);
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(context);
+  }
+
+  wlr_keyboard_set_repeat_info(wlr_input->keyboard, 25, 600);
+
+  self->modifiers_listener.notify = zn_keyboard_handle_modifiers;
+  wl_signal_add(
+      &wlr_input->keyboard->events.modifiers, &self->modifiers_listener);
+
   self->key_listener.notify = zn_keyboard_handle_key;
-  wl_signal_add(&wlr_input_device->keyboard->events.key, &self->key_listener);
+  wl_signal_add(&wlr_input->keyboard->events.key, &self->key_listener);
+
+  wlr_seat_set_keyboard(seat->wlr_seat, input_device->wlr_input);
 
   return self;
 
@@ -47,6 +87,14 @@ err:
 void
 zn_keyboard_destroy(struct zn_keyboard* self)
 {
+  struct wlr_seat* wlr_seat = self->input_device->seat->wlr_seat;
+  struct wlr_keyboard* wlr_keyboard = self->input_device->wlr_input->keyboard;
+
+  if (wlr_seat_get_keyboard(wlr_seat) == wlr_keyboard) {
+    wlr_seat_set_keyboard(wlr_seat, NULL);
+  }
+
   wl_list_remove(&self->key_listener.link);
+  wl_list_remove(&self->modifiers_listener.link);
   free(self);
 }

--- a/zen/main.c
+++ b/zen/main.c
@@ -1,4 +1,5 @@
 #include <getopt.h>
+#include <linux/input.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,6 +38,17 @@ zn_terminate(int exit_code)
 {
   struct zn_server *server = zn_server_get_singleton();
   zn_server_terminate(server, exit_code);
+}
+
+static void
+zn_terminate_binding_handler(uint32_t time_msec, uint32_t key, void *data)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  UNUSED(time_msec);
+  UNUSED(key);
+  UNUSED(data);
+
+  zn_server_terminate(server, EXIT_SUCCESS);
 }
 
 static int
@@ -169,6 +181,10 @@ main(int argc, char *argv[])
     zn_error("Failed to create a zen server");
     goto err_signal;
   }
+
+  // Terminate the program with a keyboard event for development convenience.
+  zn_input_manager_add_key_binding(server->input_manager, KEY_Q,
+      WLR_MODIFIER_ALT, zn_terminate_binding_handler, NULL);
 
   if (startup_command) {
     startup_command_pid = launch_startup_command(startup_command);

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -1,4 +1,5 @@
 _zen_desktop_srcs = [
+  'binding.c',
   'cursor.c',
   'display-system.c',
   'input-device.c',
@@ -29,6 +30,7 @@ _zen_desktop_deps = [
   pixman_dep,
   wayland_server_dep,
   wlroots_dep,
+  xkbcommon_dep,
   zen_common_dep,
   zen_openvr_immersive_backend_dep,
 ]


### PR DESCRIPTION
## Context

Keyboard shortcut is short-hand way to check GUI shell functionalities we will implement from now on (switching focus, moving between virtual desktop, etc.).

So I implemented keyboard shortcut basis first.

## Summary

Developers can add keyboard shortcut using

```c
struct zn_binding* zn_input_manager_add_key_binding(
    struct zn_input_manager* self, uint32_t key, uint32_t modifiers,
    zn_key_binding_handler_t handler, void* data);
```

`key` and `modifiers` are shortcut bindings to be used.

When `key` is pressed with `modifiers`, `handler` will be called with `data` in its argument.

See `main.c` for example.

## How to check behavior

1. build
2. start `zen-desktop`
3. press `<alt> + q`

zen-desktop will be terminated gracefully.

4. (option) try to create another keyboard shortcut.

## Notice

Termination shortcut is changed to `<alt> + q`