### PR TITLE
Set cursor surface

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -21,6 +21,8 @@ struct zn_cursor {
 
 void zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy);
 
+void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface);
+
 struct zn_cursor* zn_cursor_create(void);
 
 void zn_cursor_destroy(struct zn_cursor* self);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -11,6 +11,7 @@
 
 struct zn_cursor {
   int x, y;
+  bool visible;
   struct zn_screen* screen;  // nullable
   struct wlr_texture* texture;
   struct wlr_surface* surface;

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -13,10 +13,12 @@ struct zn_cursor {
   int x, y;
   struct zn_screen* screen;  // nullable
   struct wlr_texture* texture;
+  struct wlr_surface* surface;
   struct wlr_xcursor_manager* xcursor_manager;
 
   struct wl_listener new_screen_listener;
   struct wl_listener destroy_screen_listener;
+  struct wl_listener destroy_surface_listener;
 };
 
 void zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -26,6 +26,8 @@ void zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy);
 
 void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface);
 
+void zn_cursor_reset_surface(struct zn_cursor* self);
+
 struct zn_cursor* zn_cursor_create(void);
 
 void zn_cursor_destroy(struct zn_cursor* self);

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -2,9 +2,13 @@
 #define ZEN_SCREEN_H
 
 #include <wayland-server-core.h>
+#include <wlr/types/wlr_surface.h>
 
 #include "zen/output.h"
 #include "zen/scene/screen-layout.h"
+
+typedef void (*zn_screen_for_each_visible_surface_callback_t)(
+    struct wlr_surface *surface, void* data);
 
 struct zn_screen {
   int x, y;
@@ -20,6 +24,9 @@ struct zn_screen {
     struct wl_signal destroy;  // (NULL)
   } events;
 };
+
+void zn_screen_for_each_visible_surface(struct zn_screen *self,
+    zn_screen_for_each_visible_surface_callback_t callback, void* data);
 
 struct zn_view *zn_screen_get_view_at(
     struct zn_screen *self, double x, double y, double *view_x, double *view_y);

--- a/include/zen/seat.h
+++ b/include/zen/seat.h
@@ -16,6 +16,8 @@ struct zn_seat {
   struct {
     struct wl_signal destroy;
   } events;
+
+  struct wl_listener request_set_cursor_listener;
 };
 
 void zn_seat_add_device(

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -95,6 +95,12 @@ zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy)
   zn_cursor_update_position(self, new_screen, screen_x, screen_y);
 }
 
+void
+zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface)
+{
+  self->texture = wlr_surface_get_texture(surface);
+}
+
 struct zn_cursor*
 zn_cursor_create(void)
 {

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -118,6 +118,7 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface)
     wl_signal_add(&surface->events.destroy, &self->destroy_surface_listener);
   }
 
+  self->visible = surface != NULL;
   self->surface = surface;
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -98,7 +98,11 @@ zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy)
 void
 zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface)
 {
-  self->texture = wlr_surface_get_texture(surface);
+  if (surface == NULL) {
+    self->texture = NULL;
+  } else {
+    self->texture = wlr_surface_get_texture(surface);
+  }
 }
 
 struct zn_cursor*

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -163,6 +163,7 @@ zn_cursor_create(void)
   wl_list_init(&self->destroy_screen_listener.link);
 
   self->screen = NULL;
+  self->visible = true;
 
   return self;
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -122,6 +122,15 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface)
   self->surface = surface;
 }
 
+void
+zn_cursor_reset_surface(struct zn_cursor* self)
+{
+  if (self->surface != NULL) {
+    zn_cursor_set_surface(self, NULL);
+  }
+  self->visible = true;
+}
+
 struct zn_cursor*
 zn_cursor_create(void)
 {

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -80,7 +80,6 @@ zn_cursor_handle_destroy_surface(struct wl_listener* listener, void* data)
   struct zn_cursor* self =
       zn_container_of(listener, self, destroy_surface_listener);
 
-  wl_list_remove(&self->destroy_surface_listener.link);
   zn_cursor_set_surface(self, NULL);
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -81,7 +81,7 @@ zn_cursor_handle_destroy_surface(struct wl_listener* listener, void* data)
       zn_container_of(listener, self, destroy_surface_listener);
 
   wl_list_remove(&self->destroy_surface_listener.link);
-  self->surface = NULL;
+  zn_cursor_set_surface(self, NULL);
 }
 
 void

--- a/zen/output.c
+++ b/zen/output.c
@@ -10,6 +10,7 @@
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/screen.h"
 #include "zen/scene/view.h"
+#include "zen/seat.h"
 
 static void zn_output_destroy(struct zn_output *self);
 
@@ -57,6 +58,8 @@ zn_output_damage_frame_handler(struct wl_listener *listener, void *data)
 {
   struct zn_output *self =
       zn_container_of(listener, self, damage_frame_listener);
+  struct zn_server *server = zn_server_get_singleton();
+  struct zn_cursor *cursor = server->input_manager->seat->cursor;
   struct zn_view *view;
   struct timespec now;
   UNUSED(data);
@@ -71,6 +74,10 @@ zn_output_damage_frame_handler(struct wl_listener *listener, void *data)
 
   wl_list_for_each(view, &self->screen->views, link)
       wlr_surface_send_frame_done(view->impl->get_wlr_surface(view), &now);
+
+  if (cursor->screen == self->screen && cursor->surface != NULL) {
+    wlr_surface_send_frame_done(cursor->surface, &now);
+  }
 }
 
 struct zn_output *

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -26,6 +26,7 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   view = zn_screen_get_view_at(
       cursor->screen, cursor->x, cursor->y, &view_x, &view_y);
   if (!view) {
+    zn_cursor_reset_surface(cursor);
     wlr_seat_pointer_notify_clear_focus(seat);
     return;
   }
@@ -35,6 +36,7 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
     wlr_seat_pointer_notify_enter(seat, surface, view_x, view_y);
     wlr_seat_pointer_notify_motion(seat, event->time_msec, view_x, view_y);
   } else {
+    zn_cursor_reset_surface(cursor);
     wlr_seat_pointer_notify_clear_focus(seat);
   }
 }

--- a/zen/pointer.c
+++ b/zen/pointer.c
@@ -25,13 +25,13 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
 
   view = zn_screen_get_view_at(
       cursor->screen, cursor->x, cursor->y, &view_x, &view_y);
-  if (!view) {
-    zn_cursor_reset_surface(cursor);
-    wlr_seat_pointer_notify_clear_focus(seat);
-    return;
+
+  if (view != NULL) {
+    surface = view->impl->get_wlr_surface(view);
+  } else {
+    surface = NULL;
   }
 
-  surface = view->impl->get_wlr_surface(view);
   if (surface) {
     wlr_seat_pointer_notify_enter(seat, surface, view_x, view_y);
     wlr_seat_pointer_notify_motion(seat, event->time_msec, view_x, view_y);

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -29,6 +29,7 @@ static void
 zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
     struct wlr_renderer *renderer)
 {
+  struct wlr_texture *texture;
   float transform[9] = {
       1, 0, 0,  //
       0, 1, 0,  //
@@ -36,8 +37,12 @@ zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
   };
 
   if (cursor->screen == screen && cursor->texture) {
-    wlr_render_texture(
-        renderer, cursor->texture, transform, cursor->x, cursor->y, 1.f);
+    if (cursor->surface != NULL) {
+      texture = wlr_surface_get_texture(cursor->surface);
+    } else {
+      texture = cursor->texture;
+    }
+    wlr_render_texture(renderer, texture, transform, cursor->x, cursor->y, 1.f);
   }
 }
 

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -36,16 +36,17 @@ zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
       0, 0, 1   //
   };
 
-  if (!cursor->visible) {
+  if (!cursor->visible || cursor->screen != screen) {
     return;
   }
 
-  if (cursor->screen == screen && cursor->texture) {
-    if (cursor->surface != NULL) {
-      texture = wlr_surface_get_texture(cursor->surface);
-    } else {
-      texture = cursor->texture;
-    }
+  if (cursor->surface != NULL) {
+    texture = wlr_surface_get_texture(cursor->surface);
+  } else {
+    texture = cursor->texture;
+  }
+
+  if (cursor->texture) {
     wlr_render_texture(renderer, texture, transform, cursor->x, cursor->y, 1.f);
   }
 }

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -36,6 +36,10 @@ zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
       0, 0, 1   //
   };
 
+  if (!cursor->visible) {
+    return;
+  }
+
   if (cursor->screen == screen && cursor->texture) {
     if (cursor->surface != NULL) {
       texture = wlr_surface_get_texture(cursor->surface);

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -46,7 +46,7 @@ zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
     texture = cursor->texture;
   }
 
-  if (cursor->texture) {
+  if (texture != NULL) {
     wlr_render_texture(renderer, texture, transform, cursor->x, cursor->y, 1.f);
   }
 }

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -3,6 +3,25 @@
 #include "zen-common.h"
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/view.h"
+#include "zen/seat.h"
+
+void
+zn_screen_for_each_visible_surface(struct zn_screen *self,
+    zn_screen_for_each_visible_surface_callback_t callback, void* data)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct zn_cursor *cursor = server->input_manager->seat->cursor;
+  struct zn_view *view;
+
+  wl_list_for_each(view, &self->views, link)
+  {
+    callback(view->impl->get_wlr_surface(view), data);
+  }
+
+  if (cursor->screen == self && cursor->surface != NULL) {
+    callback(cursor->surface, data);
+  }
+}
 
 struct zn_view *
 zn_screen_get_view_at(

--- a/zen/seat.c
+++ b/zen/seat.c
@@ -11,8 +11,12 @@ zn_seat_handle_request_set_cursor(struct wl_listener* listener, void* data)
   struct zn_seat* self =
       zn_container_of(listener, self, request_set_cursor_listener);
   struct wlr_seat_pointer_request_set_cursor_event* event = data;
+  struct wlr_surface* focused_surface =
+      self->wlr_seat->pointer_state.focused_surface;
+  struct wl_client* focused_client =
+      wl_resource_get_client(focused_surface->resource);
 
-  if (event->seat_client == self->wlr_seat->pointer_state.focused_client) {
+  if (event->seat_client->client == focused_client) {
     zn_cursor_set_surface(self->cursor, event->surface);
   }
 }

--- a/zen/seat.c
+++ b/zen/seat.c
@@ -12,7 +12,9 @@ zn_seat_handle_request_set_cursor(struct wl_listener* listener, void* data)
       zn_container_of(listener, self, request_set_cursor_listener);
   struct wlr_seat_pointer_request_set_cursor_event* event = data;
 
-  zn_cursor_set_surface(self->cursor, event->surface);
+  if (event->seat_client == self->wlr_seat->pointer_state.focused_client) {
+    zn_cursor_set_surface(self->cursor, event->surface);
+  }
 }
 
 static void


### PR DESCRIPTION
## Context

In other DE, the cursor's appearance is changed when move cursor on view such as resize cursor. But zen can't.

## Summary

Listening wlr_seat's `request_set_cursor` event.

## How to check behavior

1. start zen with -s option (`weston-dnd` is recommended)
2. move the cursor to corners of view or object in view
3. cursor's appearance will be changed
