### PR TITLE
board

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,25 @@ $ sudo chvt <number>
 $ zen-desktop
 ```
 
-== Stop ZEN Desktop
+== Key bindings
 
-Press `<alt> + q` to quit.
+We cannot customize these bindings for now.
+
+.Key bindings
+[%autowidth.stretch]
+|===
+|bindings|description
+
+|<mod> + <shift> + →
+|Move to next board
+
+|<mod> + <shift> + ←
+|Move to previous board
+
+|<mod> + <shift> + n
+|Create new board
+
+|<alt> + q
+|Terminate ZEN Desktop (for development convenience)
+
+|===

--- a/include/zen/scene/board.h
+++ b/include/zen/scene/board.h
@@ -1,0 +1,45 @@
+#ifndef ZEN_BOARD_H
+#define ZEN_BOARD_H
+
+#include <wayland-server-core.h>
+
+#include "zen/scene/scene.h"
+#include "zen/scene/screen.h"
+
+struct zn_board_screen_assigned_event {
+  struct zn_screen *prev_screen;
+  struct zn_screen *current_screen;
+};
+
+struct zn_board {
+  double width, height;
+
+  struct zn_scene *scene;
+
+  // List of mapped zn_view in z-order, from bottom to top
+  struct wl_list view_list;  // zn_view::link
+
+  struct wl_list link;  // zn_scene::board_list
+
+  /** Be careful with the data consistency. When the `zn_board::screen` is not
+   * NULL, `screen_link` should belongs to the screen's board_list. */
+  struct wl_list screen_link;  // zn_screen::board_list
+  struct zn_screen *screen;    // nullable, screen which this board belongs.
+
+  struct wl_listener screen_destroy_listener;
+
+  struct {
+    struct wl_signal
+        screen_assigned;  // (struct *zn_board_screen_assigned_event)
+  } events;
+};
+
+bool zn_board_is_dangling(struct zn_board *self);
+
+void zn_board_assign_to_screen(struct zn_board *self, struct zn_screen *screen);
+
+struct zn_board *zn_board_create(struct zn_scene *scene);
+
+void zn_board_destroy(struct zn_board *self);
+
+#endif  //  ZEN_BOARD_H

--- a/include/zen/scene/scene.h
+++ b/include/zen/scene/scene.h
@@ -7,7 +7,15 @@
 
 struct zn_scene {
   struct zn_screen_layout* screen_layout;
+
+  struct wl_list board_list;  // zn_board::link, non empty
 };
+
+struct zn_board* zn_scene_get_focus_board(struct zn_scene* self);
+
+void zn_scene_reassign_boards(struct zn_scene* self);
+
+void zn_scene_setup_bindings(struct zn_scene* self);
 
 struct zn_scene* zn_scene_create(void);
 

--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -3,10 +3,13 @@
 
 #include <wayland-server-core.h>
 
-// if include screen.h, fail to compile
+#include "zen/scene/scene.h"
+
 struct zn_screen;
 
 struct zn_screen_layout {
+  struct zn_scene* scene;
+
   struct wl_list screens;  // zn_screen::link
 
   struct {
@@ -26,7 +29,7 @@ void zn_screen_layout_add(
 void zn_screen_layout_remove(
     struct zn_screen_layout* self, struct zn_screen* screen);
 
-struct zn_screen_layout* zn_screen_layout_create(void);
+struct zn_screen_layout* zn_screen_layout_create(struct zn_scene* scene);
 
 void zn_screen_layout_destroy(struct zn_screen_layout* self);
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_surface.h>
 
 #include "zen/output.h"
+#include "zen/scene/board.h"
 #include "zen/scene/screen-layout.h"
 
 typedef void (*zn_screen_for_each_visible_surface_callback_t)(
@@ -15,8 +16,9 @@ struct zn_screen {
   struct zn_output *output;  // zn_output owns zn_screen, nonnull
   struct zn_screen_layout *screen_layout;
 
-  // List of mapped zn_view in z-order, from bottom to top
-  struct wl_list views;  // zn_view::link;
+  struct wl_list board_list;       // zn_board::screen_link, non empty
+  struct zn_board *current_board;  // non null
+  struct wl_listener current_board_screen_assigned_listener;
 
   struct wl_list link;  // zn_screen_layout::screens;
 
@@ -30,6 +32,21 @@ void zn_screen_for_each_visible_surface(struct zn_screen *self,
 
 struct zn_view *zn_screen_get_view_at(
     struct zn_screen *self, double x, double y, double *view_x, double *view_y);
+
+void zn_screen_switch_to_next_board(struct zn_screen *self);
+
+void zn_screen_switch_to_prev_board(struct zn_screen *self);
+
+/**
+ * @param board must not be NULL and must be an element of self->board_list
+ */
+void zn_screen_set_current_board(
+    struct zn_screen *self, struct zn_board *board);
+
+/**
+ * @return struct zn_board* cannot be NULL
+ */
+struct zn_board *zn_screen_get_current_board(struct zn_screen *self);
 
 void zn_screen_get_screen_layout_coords(
     struct zn_screen *self, int x, int y, int *dst_x, int *dst_y);

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -5,7 +5,7 @@
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell.h>
 
-#include "zen/scene/screen.h"
+#include "zen/scene/scene.h"
 
 struct zn_view;
 
@@ -25,14 +25,14 @@ struct zn_view {
 
   const struct zn_view_impl *impl;
 
-  struct wl_list link;  // zn_screen::views;
+  struct wl_list link;  // zn_board::view_list;
 };
 
 void zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 bool zn_view_is_mapped(struct zn_view *self);
 
-void zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen);
+void zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene);
 
 void zn_view_unmap(struct zn_view *self);
 

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -14,6 +14,7 @@ _zen_desktop_srcs = [
   'xdg-toplevel-view.c',
   'xwayland-view.c',
 
+  'scene/board.c',
   'scene/scene.c',
   'scene/screen.c',
   'scene/screen-layout.c',

--- a/zen/output.c
+++ b/zen/output.c
@@ -6,6 +6,7 @@
 
 #include "zen-common.h"
 #include "zen/render-2d.h"
+#include "zen/scene/board.h"
 #include "zen/scene/scene.h"
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/screen.h"

--- a/zen/output.c
+++ b/zen/output.c
@@ -6,7 +6,6 @@
 
 #include "zen-common.h"
 #include "zen/render-2d.h"
-#include "zen/scene/board.h"
 #include "zen/scene/scene.h"
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/screen.h"

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -4,6 +4,7 @@
 #include <wlr/types/wlr_surface.h>
 
 #include "zen/output.h"
+#include "zen/scene/board.h"
 #include "zen/scene/screen.h"
 #include "zen/scene/view.h"
 #include "zen/seat.h"
@@ -57,8 +58,9 @@ zn_render_2d_screen(struct zn_screen *screen, struct wlr_renderer *renderer)
   struct zn_view *view;
   struct zn_server *server = zn_server_get_singleton();
   struct zn_cursor *cursor = server->input_manager->seat->cursor;
+  struct zn_board *board = zn_screen_get_current_board(screen);
 
-  wl_list_for_each(view, &screen->views, link)
+  wl_list_for_each(view, &board->view_list, link)
       zn_render_2d_view(view, renderer);
 
   zn_render_2d_cursor(cursor, screen, renderer);

--- a/zen/scene/board.c
+++ b/zen/scene/board.c
@@ -1,0 +1,99 @@
+#include "zen/scene/board.h"
+
+#include "zen-common.h"
+
+static void
+zn_board_screen_destroy_handler(struct wl_listener *listener, void *data)
+{
+  struct zn_board *self =
+      zn_container_of(listener, self, screen_destroy_listener);
+  UNUSED(data);
+
+  zn_board_assign_to_screen(self, NULL);
+}
+
+static void
+zn_board_resize(struct zn_board *self, double width, double height)
+{
+  self->width = width;
+  self->height = height;
+  // TODO: move views inside the resized board
+}
+
+bool
+zn_board_is_dangling(struct zn_board *self)
+{
+  return self->screen == NULL;
+}
+
+void
+zn_board_assign_to_screen(struct zn_board *self, struct zn_screen *screen)
+{
+  struct zn_board_screen_assigned_event event;
+  if (self->screen == screen) {
+    return;
+  }
+
+  if (!zn_board_is_dangling(self)) {
+    wl_list_remove(&self->screen_link);
+    wl_list_init(&self->screen_link);
+
+    wl_list_remove(&self->screen_destroy_listener.link);
+    wl_list_init(&self->screen_destroy_listener.link);
+  }
+
+  if (screen) {
+    struct wlr_box box;
+
+    wl_list_insert(screen->board_list.prev, &self->screen_link);
+    wl_signal_add(&screen->events.destroy, &self->screen_destroy_listener);
+
+    zn_screen_get_box(screen, &box);
+    zn_board_resize(self, box.width, box.height);
+  }
+
+  event.prev_screen = self->screen;
+  event.current_screen = screen;
+
+  self->screen = screen;
+
+  wl_signal_emit(&self->events.screen_assigned, &event);
+}
+
+struct zn_board *
+zn_board_create(struct zn_scene *scene)
+{
+  struct zn_board *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->width = 1920;
+  self->height = 1080;
+
+  self->scene = scene;
+  wl_list_init(&self->view_list);
+  wl_list_insert(scene->board_list.prev, &self->link);
+  wl_list_init(&self->screen_link);
+  self->screen = NULL;
+  self->screen_destroy_listener.notify = zn_board_screen_destroy_handler;
+  wl_list_init(&self->screen_destroy_listener.link);
+  wl_signal_init(&self->events.screen_assigned);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_board_destroy(struct zn_board *self)
+{
+  zn_board_assign_to_screen(self, NULL);
+  wl_list_remove(&self->view_list);
+  wl_list_remove(&self->link);
+  free(self);
+}

--- a/zen/scene/board.c
+++ b/zen/scene/board.c
@@ -75,12 +75,17 @@ zn_board_create(struct zn_scene *scene)
   self->height = 1080;
 
   self->scene = scene;
+
   wl_list_init(&self->view_list);
+
   wl_list_insert(scene->board_list.prev, &self->link);
+
   wl_list_init(&self->screen_link);
   self->screen = NULL;
+
   self->screen_destroy_listener.notify = zn_board_screen_destroy_handler;
   wl_list_init(&self->screen_destroy_listener.link);
+
   wl_signal_init(&self->events.screen_assigned);
 
   return self;

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -62,6 +62,10 @@ zn_scene_get_focus_board(struct zn_scene* self)
 {
   struct zn_screen* screen = zn_scene_get_focus_screen(self);
 
+  if (screen == NULL) {
+    return NULL;
+  }
+
   return zn_screen_get_current_board(screen);
 }
 

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -1,11 +1,147 @@
 #include "zen/scene/scene.h"
 
+#include <linux/input.h>
+
 #include "zen-common.h"
+#include "zen/scene/board.h"
+#include "zen/scene/screen-layout.h"
+#include "zen/scene/screen.h"
+
+/**
+ * @return struct zn_screen* can be NULL
+ */
+static struct zn_screen*
+zn_scene_get_focus_screen(struct zn_scene* self)
+{
+  struct zn_server* server = zn_server_get_singleton();
+  UNUSED(self);
+
+  return server->input_manager->seat->cursor->screen;
+}
+
+static void
+zn_scene_move_board_binding_handler(
+    uint32_t time_msec, uint32_t key, void* data)
+{
+  struct zn_scene* scene = data;
+  struct zn_screen* screen = zn_scene_get_focus_screen(scene);
+  UNUSED(time_msec);
+
+  if (screen == NULL) return;
+
+  if (key == KEY_RIGHT) {
+    zn_screen_switch_to_next_board(screen);
+  } else if (key == KEY_LEFT) {
+    zn_screen_switch_to_prev_board(screen);
+  }
+}
+
+static void
+zn_scene_new_board_binding_handler(uint32_t time_msec, uint32_t key, void* data)
+{
+  struct zn_scene* self = data;
+  struct zn_screen* screen = zn_scene_get_focus_screen(self);
+  struct zn_board* board;
+  UNUSED(time_msec);
+  UNUSED(key);
+
+  if (screen == NULL) return;
+
+  board = zn_board_create(self);
+  if (board == NULL) {
+    zn_error("Failed to creaet a new board");
+    return;
+  }
+
+  zn_board_assign_to_screen(board, screen);
+  zn_screen_set_current_board(screen, board);
+}
+
+struct zn_board*
+zn_scene_get_focus_board(struct zn_scene* self)
+{
+  struct zn_screen* screen = zn_scene_get_focus_screen(self);
+
+  return zn_screen_get_current_board(screen);
+}
+
+static struct zn_board*
+zn_scene_ensure_dangling_board(struct zn_scene* self)
+{
+  struct zn_board* board;
+  wl_list_for_each(board, &self->board_list, link)
+  {
+    if (zn_board_is_dangling(board)) {
+      return board;
+    }
+  }
+
+  return zn_board_create(self);
+}
+
+/** Keep this idempotent. */
+void
+zn_scene_reassign_boards(struct zn_scene* self)
+{
+  struct zn_screen* screen;
+  struct zn_board* board;
+
+  // assign a board to a screen without board
+  wl_list_for_each(screen, &self->screen_layout->screens, link)
+  {
+    struct zn_board* board;
+    if (!wl_list_empty(&screen->board_list)) {
+      continue;
+    }
+
+    board = zn_scene_ensure_dangling_board(self);
+    if (board == NULL) {
+      zn_error("Failed to create a board");
+      continue;
+    }
+
+    zn_board_assign_to_screen(board, screen);
+    zn_screen_set_current_board(screen, board);
+  }
+
+  // assign dangling board to a screen
+  screen = NULL;
+  if (!wl_list_empty(&self->screen_layout->screens)) {
+    screen = zn_container_of(self->screen_layout->screens.next, screen, link);
+  }
+
+  if (screen) {
+    wl_list_for_each(board, &self->board_list, link)
+    {
+      if (zn_board_is_dangling(board)) {
+        zn_board_assign_to_screen(board, screen);
+      }
+    }
+  }
+}
+
+void
+zn_scene_setup_bindings(struct zn_scene* self)
+{
+  struct zn_server* server = zn_server_get_singleton();
+  zn_input_manager_add_key_binding(server->input_manager, KEY_RIGHT,
+      WLR_MODIFIER_SHIFT | WLR_MODIFIER_LOGO,
+      zn_scene_move_board_binding_handler, self);
+
+  zn_input_manager_add_key_binding(server->input_manager, KEY_LEFT,
+      WLR_MODIFIER_SHIFT | WLR_MODIFIER_LOGO,
+      zn_scene_move_board_binding_handler, self);
+
+  zn_input_manager_add_key_binding(server->input_manager, KEY_N,
+      WLR_MODIFIER_LOGO | WLR_MODIFIER_SHIFT,
+      zn_scene_new_board_binding_handler, self);
+}
 
 struct zn_scene*
 zn_scene_create(void)
 {
   struct zn_scene* self;
+  struct zn_board* board;
 
   self = zalloc(sizeof *self);
   if (self == NULL) {
@@ -13,13 +149,24 @@ zn_scene_create(void)
     goto err;
   }
 
-  self->screen_layout = zn_screen_layout_create();
+  self->screen_layout = zn_screen_layout_create(self);
   if (self->screen_layout == NULL) {
     zn_error("Failed to create zn_screen_layout");
     goto err_free;
   }
 
+  wl_list_init(&self->board_list);
+
+  board = zn_board_create(self);
+  if (board == NULL) {
+    zn_error("Failed to create a initial board");
+    goto err_screen_layout;
+  }
+
   return self;
+
+err_screen_layout:
+  zn_screen_layout_destroy(self->screen_layout);
 
 err_free:
   free(self);
@@ -31,6 +178,13 @@ err:
 void
 zn_scene_destroy(struct zn_scene* self)
 {
+  struct zn_board *board, *tmp;
+
+  wl_list_for_each_safe(board, tmp, &self->board_list, link)
+  {
+    zn_board_destroy(board);
+  }
+
   zn_screen_layout_destroy(self->screen_layout);
 
   free(self);

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -53,6 +53,8 @@ zn_screen_layout_add(
   }
 
   wl_signal_emit(&self->events.new_screen, new_screen);
+
+  zn_scene_reassign_boards(self->scene);
 }
 
 void
@@ -60,10 +62,12 @@ zn_screen_layout_remove(struct zn_screen_layout* self, struct zn_screen* screen)
 {
   UNUSED(self);
   wl_list_remove(&screen->link);
+
+  zn_scene_reassign_boards(self->scene);
 }
 
 struct zn_screen_layout*
-zn_screen_layout_create(void)
+zn_screen_layout_create(struct zn_scene* scene)
 {
   struct zn_screen_layout* self;
   self = zalloc(sizeof *self);
@@ -73,6 +77,7 @@ zn_screen_layout_create(void)
     goto err;
   }
 
+  self->scene = scene;
   wl_list_init(&self->screens);
   wl_signal_init(&self->events.new_screen);
 

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -1,19 +1,21 @@
 #include "zen/scene/screen.h"
 
 #include "zen-common.h"
+#include "zen/scene/board.h"
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/view.h"
 #include "zen/seat.h"
 
 void
 zn_screen_for_each_visible_surface(struct zn_screen *self,
-    zn_screen_for_each_visible_surface_callback_t callback, void* data)
+    zn_screen_for_each_visible_surface_callback_t callback, void *data)
 {
   struct zn_server *server = zn_server_get_singleton();
   struct zn_cursor *cursor = server->input_manager->seat->cursor;
+  struct zn_board *board = zn_screen_get_current_board(self);
   struct zn_view *view;
 
-  wl_list_for_each(view, &self->views, link)
+  wl_list_for_each(view, &board->view_list, link)
   {
     callback(view->impl->get_wlr_surface(view), data);
   }
@@ -29,8 +31,9 @@ zn_screen_get_view_at(
 {
   struct wlr_fbox fbox;
   struct zn_view *view;
+  struct zn_board *board = zn_screen_get_current_board(self);
 
-  wl_list_for_each_reverse(view, &self->views, link)
+  wl_list_for_each_reverse(view, &board->view_list, link)
   {
     zn_view_get_fbox(view, &fbox);
 
@@ -43,6 +46,134 @@ zn_screen_get_view_at(
   }
 
   return NULL;
+}
+
+void
+zn_screen_switch_to_next_board(struct zn_screen *self)
+{
+  struct zn_board *board, *next_board = NULL,
+                          *current_board = zn_screen_get_current_board(self);
+  bool found = false;
+
+  wl_list_for_each(board, &self->board_list, screen_link)
+  {
+    if (next_board == NULL) {
+      next_board = board;
+    }
+
+    if (found) {
+      next_board = board;
+      break;
+    }
+
+    if (board == current_board) {
+      found = true;
+    }
+  }
+
+  if (!zn_assert(found,
+          "Couldn't find zn_screen's current board in zn_screen::board_list")) {
+    return;
+  }
+
+  zn_screen_set_current_board(self, next_board);
+}
+
+void
+zn_screen_switch_to_prev_board(struct zn_screen *self)
+{
+  struct zn_board *board, *next_board = NULL,
+                          *current_board = zn_screen_get_current_board(self);
+  bool found = false;
+
+  wl_list_for_each_reverse(board, &self->board_list, screen_link)
+  {
+    if (next_board == NULL) {
+      next_board = board;
+    }
+
+    if (found) {
+      next_board = board;
+      break;
+    }
+
+    if (board == current_board) {
+      found = true;
+    }
+  }
+
+  if (!zn_assert(found,
+          "Couldn't find zn_screen's current board in zn_screen::board_list")) {
+    return;
+  }
+
+  zn_screen_set_current_board(self, next_board);
+}
+
+static void
+zn_screen_current_board_screen_assigned_handler(
+    struct wl_listener *listener, void *data)
+{
+  struct zn_screen *self =
+      zn_container_of(listener, self, current_board_screen_assigned_listener);
+  struct zn_board_screen_assigned_event *event = data;
+  struct zn_board *board = NULL;
+
+  if (event->current_screen == self) {
+    return;
+  }
+
+  if (!wl_list_empty(&self->board_list)) {
+    board = zn_container_of(self->board_list.next, board, screen_link);
+  }
+
+  /* board can be NULL here only when destroying this screen */
+  zn_screen_set_current_board(self, board);
+}
+
+/** check if self has given board in its board_list */
+static bool
+zn_screen_has_board(struct zn_screen *self, struct zn_board *target_board)
+{
+  struct zn_board *board;
+  wl_list_for_each(board, &self->board_list, screen_link)
+  {
+    if (board == target_board) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void
+zn_screen_set_current_board(struct zn_screen *self, struct zn_board *board)
+{
+  if (self->current_board == board) {
+    return;
+  }
+
+  if (self->current_board) {
+    wl_list_remove(&self->current_board_screen_assigned_listener.link);
+    wl_list_init(&self->current_board_screen_assigned_listener.link);
+  }
+
+  if (board) {
+    if (!zn_assert(zn_screen_has_board(self, board),
+            "Tried to set current board but the board doesn't belong to the "
+            "screen.")) {
+      return;
+    }
+    wl_signal_add(&board->events.screen_assigned,
+        &self->current_board_screen_assigned_listener);
+  }
+
+  self->current_board = board;
+}
+
+struct zn_board *
+zn_screen_get_current_board(struct zn_screen *self)
+{
+  return self->current_board;
 }
 
 void
@@ -76,8 +207,12 @@ zn_screen_create(
 
   self->output = output;
   self->screen_layout = screen_layout;
-  wl_list_init(&self->views);
   wl_signal_init(&self->events.destroy);
+  wl_list_init(&self->board_list);
+  self->current_board = NULL;
+  self->current_board_screen_assigned_listener.notify =
+      zn_screen_current_board_screen_assigned_handler;
+  wl_list_init(&self->current_board_screen_assigned_listener.link);
 
   zn_screen_layout_add(screen_layout, self);
 
@@ -91,8 +226,8 @@ void
 zn_screen_destroy(struct zn_screen *self)
 {
   wl_signal_emit(&self->events.destroy, NULL);
+  wl_list_remove(&self->current_board_screen_assigned_listener.link);
 
-  wl_list_remove(&self->views);
   zn_screen_layout_remove(self->screen_layout, self);
   free(self);
 }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 #include "zen-common.h"
+#include "zen/scene/board.h"
 #include "zen/seat.h"
 #include "zen/xdg-toplevel-view.h"
 #include "zen/xwayland-view.h"
@@ -21,22 +22,35 @@ zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 bool
 zn_view_is_mapped(struct zn_view *self)
 {
-  // some zn_screen has this view in zn_screen::views
+  // check if some zn_board has this view in zn_board::view_list
   return !wl_list_empty(&self->link);
 }
 
 void
-zn_view_map_to_screen(struct zn_view *self, struct zn_screen *screen)
+zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
 {
-  struct wlr_box screen_box;
-  struct wlr_fbox view_fbox;
-  zn_screen_get_box(screen, &screen_box);
-  zn_view_get_fbox(self, &view_fbox);
+  struct zn_board *board;
+  struct wlr_fbox fbox;
 
-  self->x = (screen_box.width / 2) - (view_fbox.width / 2);
-  self->y = (screen_box.height / 2) - (view_fbox.height / 2);
+  board = zn_scene_get_focus_board(scene);
 
-  wl_list_insert(screen->views.prev, &self->link);
+  if (board == NULL && zn_assert(!wl_list_empty(&scene->board_list),
+                           "zn_scene::board_list should not be empty")) {
+    board = zn_container_of(scene->board_list.next, board, link);
+  }
+
+  if (board == NULL) {
+    zn_error("Failed to find a board to which view is mapped");
+    return;
+  }
+
+  // TODO: handle board destruction
+
+  zn_view_get_fbox(self, &fbox);
+  self->x = (board->width - fbox.width) / 2;
+  self->y = (board->height - fbox.height) / 2;
+
+  wl_list_insert(&board->view_list, &self->link);
 }
 
 void

--- a/zen/server.c
+++ b/zen/server.c
@@ -266,6 +266,8 @@ zn_server_create(struct wl_display *display)
   setenv("DISPLAY", self->xwayland->display_name, true);
   zn_debug("DISPLAY=%s", self->xwayland->display_name);
 
+  zn_scene_setup_bindings(self->scene);
+
   self->new_input_listener.notify = zn_server_new_input_handler;
   wl_signal_add(&self->backend->events.new_input, &self->new_input_listener);
 

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -13,21 +13,12 @@ zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
   struct zn_xdg_toplevel_view* self =
       zn_container_of(listener, self, map_listener);
   struct zn_scene* scene = self->server->scene;
-  struct zn_screen* screen;
   UNUSED(data);
 
   if (!zn_assert(!zn_view_is_mapped(&self->base), "Tried to map a mapped view"))
     return;
 
-  if (wl_list_empty(&scene->screen_layout->screens)) {
-    // TODO: handle this properly
-    zn_warn("View is mapped but no screen found");
-    return;
-  }
-
-  screen = zn_container_of(scene->screen_layout->screens.next, screen, link);
-
-  zn_view_map_to_screen(&self->base, screen);
+  zn_view_map_to_scene(&self->base, scene);
 }
 
 static void

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -11,21 +11,12 @@ zn_xwayland_view_map(struct wl_listener* listener, void* data)
 {
   struct zn_xwayland_view* self = zn_container_of(listener, self, map_listener);
   struct zn_scene* scene = self->server->scene;
-  struct zn_screen* screen;
   UNUSED(data);
 
   if (!zn_assert(!zn_view_is_mapped(&self->base), "Tried to map a mapped view"))
     return;
 
-  if (wl_list_empty(&scene->screen_layout->screens)) {
-    // TODO: handle this properly
-    zn_warn("View is mapped but no screen found");
-    return;
-  }
-
-  screen = zn_container_of(scene->screen_layout->screens.next, screen, link);
-
-  zn_view_map_to_screen(&self->base, screen);
+  zn_view_map_to_scene(&self->base, scene);
 }
 
 static void


### PR DESCRIPTION
## Context

See https://github.com/zigen-project/zen/issues/111

## Summary

- [x] create the concept of board 
  - A screen has many boards
  - A screen must have at least one board
  - A board must be owned by one screen if there are some screen.
  - If there is no screen, all boards must be owned by no screen. (**dangling board**)
  - A boards has many views
  - A mapped view must be owned by one board.
  - A screen must have current board, which is shown to a display.
- [x] handle screen creation/destruction
  - When a screen is created
    - if there is no dangling board (another screen exists), create a new board and assign it to the screen.
    - if there is dangling board, assign one of the dangling board to the screen.
  - When a screen is destroyed
    - if there are screens remaining, assign destroyed screen's boards to the remaining screen.
    - if there is no screen remaining, the boards will be dangling boards. 
- [x] move between boards
  - `<mod> + <shift> + →`: move to the next board on the screen which cursor is on.  
  - `<mod> + <shift> + ←`: move to the previous board on the screen which cursor is on.  
- [x] enable to create new board
- [x] update README

## How to check behavior

1. build
2. start `zen-desktop`

### Single monitor

3. start a client
an application will be shown
4. create a new board `<mod> + <shift> + n`
new board will be created and empty board will be shown
5. start another client
an application will be shown
6. move between boards `<mod> + <shift> + ←/→`
you can see an application previously created

### Multi monitor

3. Connect multiple monitor (or you have already done this)
4. move cursor to one of your screen
5. start a client
the client will appear on the screen which the cursor is on.
6. move the cursor to another screen, and start a client
the client will appear on the screen which the cursor is on.
7. remove all but one screen
removed screen's boards will be moved to the remaining one board.
9. move between boards `<mod> + <shift> + ←/→`
you can see all boards.

### Find bugs!

remove all screen, start client while no output connected, create new board while no output connected, etc...