### PR TITLE
fix X client could not launch

### DIFF
--- a/zen/seat.c
+++ b/zen/seat.c
@@ -13,8 +13,13 @@ zn_seat_handle_request_set_cursor(struct wl_listener* listener, void* data)
   struct wlr_seat_pointer_request_set_cursor_event* event = data;
   struct wlr_surface* focused_surface =
       self->wlr_seat->pointer_state.focused_surface;
-  struct wl_client* focused_client =
-      wl_resource_get_client(focused_surface->resource);
+  struct wl_client* focused_client;
+
+  if (focused_surface == NULL) {
+    return;
+  }
+
+  focused_client = wl_resource_get_client(focused_surface->resource);
 
   if (event->seat_client->client == focused_client) {
     zn_cursor_set_surface(self->cursor, event->surface);


### PR DESCRIPTION
## Context

After commit 3489290 (by #107), zen is crashed with SIGSEGV when the X client is launched.

## Summary

NULL check at `zn_seat_handle_request_set_cursor()`

## How to check behavior

1. run zen-desktop with -s option (launch X client)
2. work without terminating
