### PR TITLE
handle when focus_surface is NULL

### DIFF
--- a/zen/seat.c
+++ b/zen/seat.c
@@ -13,8 +13,10 @@ zn_seat_handle_request_set_cursor(struct wl_listener* listener, void* data)
   struct wlr_seat_pointer_request_set_cursor_event* event = data;
   struct wlr_surface* focused_surface =
       self->wlr_seat->pointer_state.focused_surface;
-  struct wl_client* focused_client =
-      wl_resource_get_client(focused_surface->resource);
+  struct wl_client* focused_client = NULL;
+  if (focused_surface != NULL) {
+    focused_client = wl_resource_get_client(focused_surface->resource);
+  }
 
   if (event->seat_client->client == focused_client) {
     zn_cursor_set_surface(self->cursor, event->surface);


### PR DESCRIPTION
## Context

Bug fix.

When starting X client, the compositor crushes.

## Summary

Fixed the bug.

## How to check behavior

Same as https://github.com/zigen-project/zen/pull/107.