### PR TITLE
Cursor hotspot

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -11,6 +11,7 @@
 
 struct zn_cursor {
   int x, y;
+  int hotspot_x, hotspot_y;
   bool visible;
   struct zn_screen* screen;  // nullable
   struct wlr_texture* texture;
@@ -24,7 +25,8 @@ struct zn_cursor {
 
 void zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy);
 
-void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface);
+void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
+    int hotspot_x, int hotspot_y);
 
 void zn_cursor_reset_surface(struct zn_cursor* self);
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -106,7 +106,8 @@ zn_cursor_move_relative(struct zn_cursor* self, int dx, int dy)
 }
 
 void
-zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface)
+zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
+    int hotspot_x, int hotspot_y)
 {
   if (self->surface != NULL) {
     wl_list_remove(&self->destroy_surface_listener.link);
@@ -117,6 +118,8 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface)
     wl_signal_add(&surface->events.destroy, &self->destroy_surface_listener);
   }
 
+  self->hotspot_x = hotspot_x;
+  self->hotspot_y = hotspot_y;
   self->visible = surface != NULL;
   self->surface = surface;
 }
@@ -160,6 +163,8 @@ zn_cursor_create(void)
   }
   image = xcursor->images[0];
 
+  self->hotspot_x = image->hotspot_x;
+  self->hotspot_y = image->hotspot_y;
   self->texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,
       image->width * 4, image->width, image->height, image->buffer);
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -80,7 +80,7 @@ zn_cursor_handle_destroy_surface(struct wl_listener* listener, void* data)
   struct zn_cursor* self =
       zn_container_of(listener, self, destroy_surface_listener);
 
-  zn_cursor_set_surface(self, NULL);
+  zn_cursor_set_surface(self, NULL, 0, 0);
 }
 
 void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -128,7 +128,7 @@ void
 zn_cursor_reset_surface(struct zn_cursor* self)
 {
   if (self->surface != NULL) {
-    zn_cursor_set_surface(self, NULL);
+    zn_cursor_set_surface(self, NULL, 0, 0);
   }
   self->visible = true;
 }

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -47,7 +47,8 @@ zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
   }
 
   if (texture != NULL) {
-    wlr_render_texture(renderer, texture, transform, cursor->x, cursor->y, 1.f);
+    wlr_render_texture(renderer, texture, transform,
+        cursor->x - cursor->hotspot_x, cursor->y - cursor->hotspot_y, 1.f);
   }
 }
 

--- a/zen/seat.c
+++ b/zen/seat.c
@@ -19,7 +19,8 @@ zn_seat_handle_request_set_cursor(struct wl_listener* listener, void* data)
   }
 
   if (event->seat_client->client == focused_client) {
-    zn_cursor_set_surface(self->cursor, event->surface);
+    zn_cursor_set_surface(
+      self->cursor, event->surface, event->hotspot_x, event->hotspot_y);
   }
 }
 


### PR DESCRIPTION
## Context

Fix #100

## Summary

Dealing hotspot at cursor.

## How to check behavior

1. start zen with -s option (`weston-clickdot` is recommended)
2. move the cursor within view
3. cursor will point to exact point