### PR TITLE
damage

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -11,19 +11,24 @@
 
 struct zn_cursor {
   double x, y;
+  uint32_t width, height;
   int hotspot_x, hotspot_y;
   bool visible;
+
   struct zn_screen* screen;  // nullable
   struct wlr_texture* texture;
   struct wlr_surface* surface;
   struct wlr_xcursor_manager* xcursor_manager;
 
   struct wl_listener new_screen_listener;
-  struct wl_listener destroy_screen_listener;
-  struct wl_listener destroy_surface_listener;
+  struct wl_listener screen_destroy_listener;
+  struct wl_listener surface_commit_listener;
+  struct wl_listener surface_destroy_listener;
 };
 
 void zn_cursor_move_relative(struct zn_cursor* self, double dx, double dy);
+
+void zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox);
 
 void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     int hotspot_x, int hotspot_y);

--- a/include/zen/output.h
+++ b/include/zen/output.h
@@ -22,6 +22,15 @@ struct zn_output {
   struct wl_listener damage_frame_listener;
 };
 
+/**
+ * @param fbox in effective coordinate
+ */
+void zn_output_add_damage_box(
+    struct zn_output *self, struct wlr_fbox *effective_box);
+
+void zn_output_box_effective_to_transformed_coords(struct zn_output *self,
+    struct wlr_fbox *effective, struct wlr_box *transformed);
+
 void zn_output_update_global(struct zn_output *self);
 
 struct zn_output *zn_output_create(

--- a/include/zen/render-2d.h
+++ b/include/zen/render-2d.h
@@ -3,7 +3,7 @@
 
 #include "zen/scene/screen.h"
 
-void zn_render_2d_screen(
-    struct zn_screen *screen, struct wlr_renderer *renderer);
+void zn_render_2d_screen(struct zn_screen *screen,
+    struct wlr_renderer *renderer, pixman_region32_t *damage);
 
 #endif  //  ZEN_RENDER_2D_H

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -25,8 +25,17 @@ struct zn_view {
 
   const struct zn_view_impl *impl;
 
-  struct wl_list link;  // zn_board::view_list;
+  struct wl_list link;     // zn_board::view_list;
+  struct zn_board *board;  // non null, when mapped
 };
+
+/**
+ * Add the damage of all surfaces associated with the view to the output where
+ * the view id displayed.
+ */
+void zn_view_damage(struct zn_view *self);
+
+void zn_view_damage_whole(struct zn_view *self);
 
 void zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -16,6 +16,7 @@ struct zn_xdg_toplevel_view {
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;
+  struct wl_listener wlr_surface_commit_listener;
 };
 
 struct zn_xdg_toplevel_view *zn_xdg_toplevel_view_create(

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -16,6 +16,7 @@ struct zn_xwayland_view {
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
   struct wl_listener wlr_xwayland_surface_destroy_listener;
+  struct wl_listener wlr_surface_commit_listener;
 };
 
 struct zn_xwayland_view *zn_xwayland_view_create(

--- a/zen/input/pointer.c
+++ b/zen/input/pointer.c
@@ -21,6 +21,10 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   struct zn_view* view;
   double view_x, view_y;
 
+  if (cursor->screen == NULL) {
+    return;
+  }
+
   zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
 
   view = zn_screen_get_view_at(

--- a/zen/render-2d.c
+++ b/zen/render-2d.c
@@ -1,8 +1,10 @@
 #include "zen/render-2d.h"
 
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_matrix.h>
 #include <wlr/types/wlr_surface.h>
 
+#include "zen-common.h"
 #include "zen/input/seat.h"
 #include "zen/output.h"
 #include "zen/scene/board.h"
@@ -10,35 +12,97 @@
 #include "zen/scene/view.h"
 
 static void
-zn_render_2d_view(struct zn_view *view, struct wlr_renderer *renderer)
+zn_render_2d_scissor_output(struct zn_output *output, pixman_box32_t *rect)
 {
-  struct wlr_surface *wlr_surface = view->impl->get_wlr_surface(view);
-  struct wlr_texture *texture = wlr_surface_get_texture(wlr_surface);
-  struct wlr_fbox fbox;
-
-  float transform[9] = {
-      1, 0, 0,  //
-      0, 1, 0,  //
-      0, 0, 1   //
+  struct wlr_output *wlr_output = output->wlr_output;
+  struct wlr_renderer *renderer = wlr_output->renderer;
+  int output_width, output_height;
+  enum wl_output_transform transform;
+  struct wlr_box box = {
+      .x = rect->x1,
+      .y = rect->y1,
+      .width = rect->x2 - rect->x1,
+      .height = rect->y2 - rect->y1,
   };
 
-  zn_view_get_fbox(view, &fbox);
-  wlr_render_texture(renderer, texture, transform, fbox.x, fbox.y, 1);
+  wlr_output_transformed_resolution(wlr_output, &output_width, &output_height);
+
+  transform = wlr_output_transform_invert(wlr_output->transform);
+  wlr_box_transform(&box, &box, transform, output_width, output_height);
+
+  wlr_renderer_scissor(renderer, &box);
 }
 
 static void
-zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
-    struct wlr_renderer *renderer)
+zn_render_2d_view(struct zn_screen *screen, struct zn_view *view,
+    struct wlr_renderer *renderer, pixman_region32_t *screen_damage)
+{
+  struct zn_output *output = screen->output;
+  struct wlr_surface *wlr_surface = view->impl->get_wlr_surface(view);
+  struct wlr_texture *texture = wlr_surface_get_texture(wlr_surface);
+  struct wlr_fbox fbox;
+  struct wlr_box transformed_box;
+  pixman_region32_t render_damage;
+  pixman_box32_t *rects;
+  float matrix[9];
+  int rect_count;
+
+  zn_view_get_fbox(view, &fbox);
+  zn_output_box_effective_to_transformed_coords(
+      output, &fbox, &transformed_box);
+
+  pixman_region32_init(&render_damage);
+  pixman_region32_union_rect(&render_damage, &render_damage, transformed_box.x,
+      transformed_box.y, transformed_box.width, transformed_box.width);
+
+  pixman_region32_intersect(&render_damage, &render_damage, screen_damage);
+
+  if (!pixman_region32_not_empty(&render_damage)) {
+    goto render_damage_finish;
+  }
+
+  wlr_matrix_project_box(matrix, &transformed_box, WL_OUTPUT_TRANSFORM_NORMAL,
+      0, output->wlr_output->transform_matrix);
+
+  rects = pixman_region32_rectangles(&render_damage, &rect_count);
+  for (int i = 0; i < rect_count; i++) {
+    zn_render_2d_scissor_output(screen->output, &rects[i]);
+    wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0f);
+  }
+
+render_damage_finish:
+  pixman_region32_fini(&render_damage);
+}
+
+static void
+zn_render_2d_cursor(struct zn_screen *screen, struct zn_cursor *cursor,
+    struct wlr_renderer *renderer, pixman_region32_t *screen_damage)
 {
   struct wlr_texture *texture;
-  float transform[9] = {
-      1, 0, 0,  //
-      0, 1, 0,  //
-      0, 0, 1   //
-  };
+  struct wlr_fbox fbox;
+  struct wlr_box transformed_box;
+  struct zn_output *output = screen->output;
+  pixman_region32_t render_damage;
+  pixman_box32_t *rects;
+  int rect_count;
+  float matrix[9];
 
   if (!cursor->visible || cursor->screen != screen) {
     return;
+  }
+
+  zn_cursor_get_fbox(cursor, &fbox);
+  zn_output_box_effective_to_transformed_coords(
+      output, &fbox, &transformed_box);
+
+  pixman_region32_init(&render_damage);
+  pixman_region32_union_rect(&render_damage, &render_damage, transformed_box.x,
+      transformed_box.y, transformed_box.width, transformed_box.height);
+
+  pixman_region32_intersect(&render_damage, &render_damage, screen_damage);
+
+  if (!pixman_region32_not_empty(&render_damage)) {
+    goto render_damage_finish;
   }
 
   if (cursor->surface != NULL) {
@@ -47,22 +111,63 @@ zn_render_2d_cursor(struct zn_cursor *cursor, struct zn_screen *screen,
     texture = cursor->texture;
   }
 
-  if (texture != NULL) {
-    wlr_render_texture(renderer, texture, transform,
-        cursor->x - cursor->hotspot_x, cursor->y - cursor->hotspot_y, 1.f);
+  if (texture == NULL) {
+    goto render_damage_finish;
   }
+
+  wlr_matrix_project_box(matrix, &transformed_box, WL_OUTPUT_TRANSFORM_NORMAL,
+      0, output->wlr_output->transform_matrix);
+
+  rects = pixman_region32_rectangles(&render_damage, &rect_count);
+  for (int i = 0; i < rect_count; i++) {
+    zn_render_2d_scissor_output(screen->output, &rects[i]);
+    wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0f);
+  }
+
+render_damage_finish:
+  pixman_region32_fini(&render_damage);
 }
 
 void
-zn_render_2d_screen(struct zn_screen *screen, struct wlr_renderer *renderer)
+zn_render_2d_screen(struct zn_screen *screen, struct wlr_renderer *renderer,
+    pixman_region32_t *damage)
 {
   struct zn_view *view;
   struct zn_server *server = zn_server_get_singleton();
   struct zn_cursor *cursor = server->input_manager->seat->cursor;
+  struct zn_output *output = screen->output;
   struct zn_board *board = zn_screen_get_current_board(screen);
+  struct wlr_output *wlr_output = output->wlr_output;
+  pixman_region32_t screen_damage;
+  pixman_box32_t *rects;
+  int output_width, output_height, rect_count;
+
+  wlr_renderer_begin(renderer, wlr_output->width, wlr_output->height);
+
+  pixman_region32_init(&screen_damage);
+
+  wlr_output_transformed_resolution(wlr_output, &output_width, &output_height);
+  pixman_region32_union_rect(
+      &screen_damage, &screen_damage, 0, 0, output_width, output_height);
+  pixman_region32_intersect(&screen_damage, &screen_damage, damage);
+
+  if (!pixman_region32_not_empty(&screen_damage)) {
+    goto out_commit;
+  }
+
+  rects = pixman_region32_rectangles(&screen_damage, &rect_count);
+  for (int i = 0; i < rect_count; i++) {
+    zn_render_2d_scissor_output(output, &rects[i]);
+    wlr_renderer_clear(renderer, (float[]){0.2, 0.3, 0.2, 1});
+  }
 
   wl_list_for_each(view, &board->view_list, link)
-      zn_render_2d_view(view, renderer);
+      zn_render_2d_view(screen, view, renderer, &screen_damage);
 
-  zn_render_2d_cursor(cursor, screen, renderer);
+  zn_render_2d_cursor(screen, cursor, renderer, &screen_damage);
+
+out_commit:
+  wlr_renderer_end(renderer);
+  wlr_output_commit(wlr_output);
+  pixman_region32_fini(&screen_damage);
 }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -1,12 +1,36 @@
 #include "zen/scene/view.h"
 
 #include <stdbool.h>
+#include <wlr/types/wlr_output_damage.h>
 
 #include "zen-common.h"
-#include "zen/scene/board.h"
 #include "zen/input/seat.h"
+#include "zen/scene/board.h"
 #include "zen/xdg-toplevel-view.h"
 #include "zen/xwayland-view.h"
+
+void
+zn_view_damage(struct zn_view *self)
+{
+  // FIXME: iterate all surfaces, and add damage more precisely
+  zn_view_damage_whole(self);
+}
+
+void
+zn_view_damage_whole(struct zn_view *self)
+{
+  struct wlr_fbox fbox;
+  struct zn_board *board = self->board;
+  struct zn_screen *screen = board ? board->screen : NULL;
+
+  if (screen == NULL) {
+    return;
+  }
+
+  zn_view_get_fbox(self, &fbox);
+
+  zn_output_add_damage_box(screen->output, &fbox);
+}
 
 void
 zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox)
@@ -22,8 +46,7 @@ zn_view_get_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 bool
 zn_view_is_mapped(struct zn_view *self)
 {
-  // check if some zn_board has this view in zn_board::view_list
-  return !wl_list_empty(&self->link);
+  return self->board != NULL;
 }
 
 void
@@ -50,12 +73,18 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
   self->x = (board->width - fbox.width) / 2;
   self->y = (board->height - fbox.height) / 2;
 
+  self->board = board;
   wl_list_insert(&board->view_list, &self->link);
+
+  zn_view_damage_whole(self);
 }
 
 void
 zn_view_unmap(struct zn_view *self)
 {
+  zn_view_damage_whole(self);
+
+  self->board = NULL;
   wl_list_remove(&self->link);
   wl_list_init(&self->link);
 }
@@ -66,6 +95,8 @@ zn_view_init(struct zn_view *self, enum zn_view_type type,
 {
   self->type = type;
   self->impl = impl;
+
+  self->board = NULL;
   wl_list_init(&self->link);
 }
 

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -8,6 +8,17 @@
 static void zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self);
 
 static void
+zn_xdg_toplevel_view_wlr_surface_commit_handler(
+    struct wl_listener* listener, void* data)
+{
+  struct zn_xdg_toplevel_view* self =
+      zn_container_of(listener, self, wlr_surface_commit_listener);
+  UNUSED(data);
+
+  zn_view_damage(&self->base);
+}
+
+static void
 zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
 {
   struct zn_xdg_toplevel_view* self =
@@ -19,6 +30,9 @@ zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
     return;
 
   zn_view_map_to_scene(&self->base, scene);
+
+  wl_signal_add(&self->wlr_xdg_toplevel->base->surface->events.commit,
+      &self->wlr_surface_commit_listener);
 }
 
 static void
@@ -33,6 +47,9 @@ zn_xdg_toplevel_view_unmap(struct wl_listener* listener, void* data)
     return;
 
   zn_view_unmap(&self->base);
+
+  wl_list_remove(&self->wlr_surface_commit_listener.link);
+  wl_list_init(&self->wlr_surface_commit_listener.link);
 }
 
 static void
@@ -88,6 +105,10 @@ zn_xdg_toplevel_view_create(
   wl_signal_add(&wlr_xdg_toplevel->base->events.destroy,
       &self->wlr_xdg_surface_destroy_listener);
 
+  self->wlr_surface_commit_listener.notify =
+      zn_xdg_toplevel_view_wlr_surface_commit_handler;
+  wl_list_init(&self->wlr_surface_commit_listener.link);
+
   return self;
 
 err:
@@ -98,6 +119,7 @@ static void
 zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self)
 {
   wl_list_remove(&self->wlr_xdg_surface_destroy_listener.link);
+  wl_list_remove(&self->wlr_surface_commit_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->unmap_listener.link);
   zn_view_fini(&self->base);

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -7,6 +7,17 @@
 static void zn_xwayland_view_destroy(struct zn_xwayland_view* self);
 
 static void
+zn_xwayland_view_wlr_surface_commit_handler(
+    struct wl_listener* listener, void* data)
+{
+  struct zn_xwayland_view* self =
+      zn_container_of(listener, self, wlr_surface_commit_listener);
+  UNUSED(data);
+
+  zn_view_damage(&self->base);
+}
+
+static void
 zn_xwayland_view_map(struct wl_listener* listener, void* data)
 {
   struct zn_xwayland_view* self = zn_container_of(listener, self, map_listener);
@@ -17,6 +28,9 @@ zn_xwayland_view_map(struct wl_listener* listener, void* data)
     return;
 
   zn_view_map_to_scene(&self->base, scene);
+
+  wl_signal_add(&self->wlr_xwayland_surface->surface->events.commit,
+      &self->wlr_surface_commit_listener);
 }
 
 static void
@@ -31,6 +45,9 @@ zn_xwayland_view_unmap(struct wl_listener* listener, void* data)
     return;
 
   zn_view_unmap(&self->base);
+
+  wl_list_remove(&self->wlr_surface_commit_listener.link);
+  wl_list_init(&self->wlr_surface_commit_listener.link);
 }
 
 static void
@@ -86,6 +103,10 @@ zn_xwayland_view_create(
   wl_signal_add(&self->wlr_xwayland_surface->events.destroy,
       &self->wlr_xwayland_surface_destroy_listener);
 
+  self->wlr_surface_commit_listener.notify =
+      zn_xwayland_view_wlr_surface_commit_handler;
+  wl_list_init(&self->wlr_surface_commit_listener.link);
+
   return self;
 
 err:
@@ -96,6 +117,7 @@ static void
 zn_xwayland_view_destroy(struct zn_xwayland_view* self)
 {
   wl_list_remove(&self->wlr_xwayland_surface_destroy_listener.link);
+  wl_list_remove(&self->wlr_surface_commit_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->unmap_listener.link);
   zn_view_fini(&self->base);


### PR DESCRIPTION
## Context

Damage is the area of an image buffer that has changed.
By handling damage precisely, we can reduce repainting cost greatly.

## Summary

- [x] use effective / transformed coordinates neatly
- [x] handle cursor damage
- [x] handle view damage

## Leaving Issues

- #122 
implement precise view damage handling. We will do this after merging #108.
- #123
enable to change output scale / transform (at least for behavior checking during development)

## How to check behavior

No visible change is made.

Check behavior by modifying the code.

### Check output scale / transform

1. In `output.c#wlr_output_create`, between `wlr_output_enable` and `if (wlr_output_commit(..) == false) {`, insert 
```c
  wlr_output_set_transform(self->wlr_output, WL_OUTPUT_TRANSFORM_90);
  wlr_output_set_scale(self->wlr_output, 0.5);
```
2. build
3. run `zen-desktop`

You can use the output by rotate it 90 degrees clockwise.

### Check damage

1. Make `view.c@zn_view_damage_whole` empty.
```c
void
zn_view_damage_whole(struct zn_view *self)
{
  UNUSED(self);
}
```
This will stop notifying view's damage.

2. build
3. run `zen-desktop`
4. run some client.
5. move the cursor around.

You can see the client only the part the cursor has passed, which means that only the region cursor has passed is repainted, and rest region of the screen is not repainted.