### PR TITLE
use wlr-glew-renderer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install \
             libwayland-dev libwlroots-dev libpixman-1-dev libxml2-dev \
-            libopenvr-dev libxkbcommon-dev weston
+            libopenvr-dev libxkbcommon-dev libglu1-mesa-dev libglew-dev weston
 
       - uses: actions/setup-python@v1
         with:
@@ -28,10 +28,43 @@ jobs:
       - name: Install meson & ninja
         run: pip install meson ninja
 
+      - name: Clone wlr-glew-renderer
+        uses: actions/checkout@v2
+        with:
+          repository: zigen-project/wlr-glew-renderer
+          path: wlr-glew-renderer
+
+      - name: Build wlr-glew-renderer
+        run: meson --prefix=$(pwd)/target build && meson install -C build --skip-subprojects
+        working-directory: ./wlr-glew-renderer
+        env:
+          CC: gcc
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: wlr-glew-renderer-build-log
+          path: wlr-glew-renderer/build/meson-logs/
+
+      - name: Update PKG_CONFIG_PATH
+        run: |
+          echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/$WLR_GLEW_RENDERER_PKGCONFIG" >> $GITHUB_ENV
+        env:
+          WLR_GLEW_RENDERER_PKGCONFIG: wlr-glew-renderer/target/lib/x86_64-linux-gnu/pkgconfig
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          path: main
 
       - name: Build & Test
         run: meson build && ninja -C build test
+        working-directory: ./main
         env:
           CC: gcc
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: zen-test-log
+          path: main/build/meson-logs/

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,14 @@ XR Desktop Environment
 
 == Build & Install
 
+=== Preparation
+
+1. Build & Install wlr-glew-renderer
+
+See https://github.com/zigen-project/wlr-glew-renderer[github.com/zigen-project/wlr-glew-renderer]
+
+=== Build & Install
+
 [source, shell]
 ----
 $ git clone https://github.com/zigen-project/zen.git

--- a/meson.build
+++ b/meson.build
@@ -72,6 +72,7 @@ openvr_req = '>= 1.12.5'
 wayland_protocols_req = '>= 1.24'
 wayland_server_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
+wlr_glew_renderer_req = wlroots_req
 
 # dependencies
 
@@ -82,6 +83,7 @@ wayland_protocols_dep = dependency('wayland-protocols', version: wayland_protoco
 wayland_scanner_dep = dependency('wayland-scanner')
 wayland_server_dep = dependency('wayland-server', version: wayland_server_req)
 wlroots_dep = dependency('wlroots', version: wlroots_req)
+wlr_glew_renderer_dep = dependency('wlr-glew-renderer', version: wlr_glew_renderer_req)
 xkbcommon_dep = dependency('xkbcommon')
 if get_option('cui-client')
   wayland_client_dep = dependency('wayland-client')

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -34,6 +34,7 @@ _zen_desktop_deps = [
   pixman_dep,
   wayland_server_dep,
   wlroots_dep,
+  wlr_glew_renderer_dep,
   xkbcommon_dep,
   zen_common_dep,
   zen_openvr_immersive_backend_dep,


### PR DESCRIPTION
## Context

[wlroots](https://gitlab.freedesktop.org/wlroots/wlroots) uses GLES2 for OpenGL-based renderer. We want to use the newer OpenGL extenstion functionalities, so I created a GLEW renderer with a similar API to the existing GLES2 renderer.

Repository: [zigen-project/wlr-glew-renderer
](https://github.com/zigen-project/wlr-glew-renderer)

This pull request integrate the GLEW renderer.

## Summary

- [x] Use GLEW renderer
- [x] Update README
- [x] Update CI script

## How to check behavior

Nothing changed in this pull request.