### PR TITLE
fix #126

### DIFF
--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -11,6 +11,7 @@ struct zn_view;
 
 struct zn_view_impl {
   struct wlr_surface *(*get_wlr_surface)(struct zn_view *view);
+  void (*set_position)(struct zn_view *view, double x, double y);
   void (*for_each_popup_surface)(struct zn_view *view,
       wlr_surface_iterator_func_t iterator, void *user_data);
 };

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -11,7 +11,7 @@ struct zn_view;
 
 struct zn_view_impl {
   struct wlr_surface *(*get_wlr_surface)(struct zn_view *view);
-  void (*set_position)(struct zn_view *view, double x, double y);
+  void (*configure)(struct zn_view *view, double x, double y);
   void (*for_each_popup_surface)(struct zn_view *view,
       wlr_surface_iterator_func_t iterator, void *user_data);
 };

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -9,6 +9,17 @@
 #include "zen/xdg-toplevel-view.h"
 #include "zen/xwayland-view.h"
 
+static void
+zn_view_move(struct zn_view *self, double x, double y)
+{
+  self->x = x;
+  self->y = y;
+
+  if (self->impl->set_position) {
+    self->impl->set_position(self, x, y);
+  }
+}
+
 void
 zn_view_damage(struct zn_view *self)
 {
@@ -70,8 +81,8 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
   // TODO: handle board destruction
 
   zn_view_get_fbox(self, &fbox);
-  self->x = (board->width - fbox.width) / 2;
-  self->y = (board->height - fbox.height) / 2;
+  zn_view_move(
+      self, (board->width - fbox.width) / 2, (board->height - fbox.height) / 2);
 
   self->board = board;
   wl_list_insert(&board->view_list, &self->link);

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -15,8 +15,8 @@ zn_view_move(struct zn_view *self, double x, double y)
   self->x = x;
   self->y = y;
 
-  if (self->impl->set_position) {
-    self->impl->set_position(self, x, y);
+  if (self->impl->configure) {
+    self->impl->configure(self, x, y);
   }
 }
 

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -69,7 +69,7 @@ zn_xwayland_view_impl_get_wlr_surface(struct zn_view* view)
 }
 
 static void
-zn_xwayland_view_impl_set_position(struct zn_view* view, double x, double y)
+zn_xwayland_view_impl_configure(struct zn_view* view, double x, double y)
 {
   struct zn_xwayland_view* self = zn_container_of(view, self, base);
   struct wlr_fbox box;
@@ -81,7 +81,7 @@ zn_xwayland_view_impl_set_position(struct zn_view* view, double x, double y)
 
 static const struct zn_view_impl zn_xwayland_view_impl = {
     .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
-    .set_position = zn_xwayland_view_impl_set_position,
+    .configure = zn_xwayland_view_impl_configure,
 };
 
 struct zn_xwayland_view*

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -68,8 +68,20 @@ zn_xwayland_view_impl_get_wlr_surface(struct zn_view* view)
   return self->wlr_xwayland_surface->surface;
 }
 
+static void
+zn_xwayland_view_impl_set_position(struct zn_view* view, double x, double y)
+{
+  struct zn_xwayland_view* self = zn_container_of(view, self, base);
+  struct wlr_fbox box;
+
+  zn_view_get_fbox(view, &box);
+  wlr_xwayland_surface_configure(
+      self->wlr_xwayland_surface, x, y, box.width, box.height);
+}
+
 static const struct zn_view_impl zn_xwayland_view_impl = {
     .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
+    .set_position = zn_xwayland_view_impl_set_position,
 };
 
 struct zn_xwayland_view*


### PR DESCRIPTION
## Context

In X client, the cursor event looks to be sent to wrong view.

See #126 

![the cursor event looks to be sent to wrong view](https://user-images.githubusercontent.com/36789813/187024134-1b1b7add-4f14-4e42-b8fb-0ffa044f21a5.png)

## Summary

Call `wlr_xwayland_surface_configure()` when the view is moved.

![the cursor event looks to be sent to correct view](https://user-images.githubusercontent.com/36789813/187024153-a600946b-ac58-4cdf-ba74-65ba84990d14.png)

## How to check behavior

1. start zen with more than two of X client
2. move views somehow
3. move the cursor

### move views (recommend; OPTIONAL)

remove `static` from `zn_view_move`, create function like following:

```c
static void
zn_scene_rearrange_view(uint32_t time_msec, uint32_t key, void* data)
{
  UNUSED(time_msec);
  UNUSED(key);
  UNUSED(data);
  extern void zn_view_move(struct zn_view* self, double x, double y);
  struct zn_board* board = zn_scene_get_focus_board(zn_server_get_singleton()->scene);
  struct zn_view* view;
  struct wlr_fbox box;
  double x = 0;

  wl_list_for_each(view, &board->view_list, link)
  {
    zn_view_get_fbox(view, &box);
    zn_view_damage_whole(view);
    zn_view_move(view, x, 0);
    zn_view_damage_whole(view);
    x += box.width - 100;
  }
}
```

and add key binding:

```c
  zn_input_manager_add_key_binding(
      server->input_manager, KEY_R, WLR_MODIFIER_LOGO, zn_scene_rearrange_view, self);
```