### PR TITLE
Use default hotspot

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -13,6 +13,7 @@ struct zn_cursor {
   double x, y;
   uint32_t width, height;
   int hotspot_x, hotspot_y;
+  int default_hotspot_x, default_hotspot_y;
   bool visible;
 
   struct zn_screen* screen;  // nullable

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -165,8 +165,11 @@ zn_cursor_move_relative(struct zn_cursor* self, double dx, double dy)
 void
 zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox)
 {
-  fbox->x = self->x - self->hotspot_x;
-  fbox->y = self->y - self->hotspot_y;
+  int hotspot_x = self->surface ? self->hotspot_x : self->default_hotspot_x;
+  int hotspot_y = self->surface ? self->hotspot_y : self->default_hotspot_y;
+
+  fbox->x = self->x - hotspot_x;
+  fbox->y = self->y - hotspot_y;
   fbox->width = self->width;
   fbox->height = self->height;
 }
@@ -243,8 +246,8 @@ zn_cursor_create(void)
   }
   image = xcursor->images[0];
 
-  self->hotspot_x = image->hotspot_x;
-  self->hotspot_y = image->hotspot_y;
+  self->hotspot_x = self->default_hotspot_x = image->hotspot_x;
+  self->hotspot_y = self->default_hotspot_y = image->hotspot_y;
   self->texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,
       image->width * 4, image->width, image->height, image->buffer);
 


### PR DESCRIPTION
## Context

When the cursor's surface is NULL, default texture is used on rendering, but it use wrong hotspot.

## Summary

Set default hotspot when the cursor's surface is NULL.

## How to check behavior

None
