### PR TITLE
damage whole screen when switching board

### DIFF
--- a/include/zen/output.h
+++ b/include/zen/output.h
@@ -28,6 +28,8 @@ struct zn_output {
 void zn_output_add_damage_box(
     struct zn_output *self, struct wlr_fbox *effective_box);
 
+void zn_output_add_damage_whole(struct zn_output *self);
+
 void zn_output_box_effective_to_transformed_coords(struct zn_output *self,
     struct wlr_fbox *effective, struct wlr_box *transformed);
 

--- a/zen/output.c
+++ b/zen/output.c
@@ -50,6 +50,12 @@ zn_output_add_damage_box(struct zn_output *self, struct wlr_fbox *effective_box)
   wlr_output_damage_add_box(self->damage, &box);
 }
 
+void
+zn_output_add_damage_whole(struct zn_output *self)
+{
+  wlr_output_damage_add_whole(self->damage);
+}
+
 static int
 zn_output_repaint_timer_handler(void *data)
 {

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -168,6 +168,10 @@ zn_screen_set_current_board(struct zn_screen *self, struct zn_board *board)
   }
 
   self->current_board = board;
+
+  // TODO: rebase pointer
+
+  zn_output_add_damage_whole(self->output);
 }
 
 struct zn_board *


### PR DESCRIPTION
## Context

#136 

## Summary

- [x] add damage to whole output when switching board.

## How to check behavior

1. Check that views stay displayed when switching board.
2. build
3. start `zen-desktop` 
4. Check that views do not stay displayed when switching board. 