### PR TITLE
Refactoring VrSystem

### DIFF
--- a/zen/backend/openvr/meson.build
+++ b/zen/backend/openvr/meson.build
@@ -1,5 +1,6 @@
 _zen_openvr_immersive_backend_srcs =[
   'immersive-backend.cc',
+  'openvr.cc',
   'vr-system.cc',
 ]
 

--- a/zen/backend/openvr/openvr.cc
+++ b/zen/backend/openvr/openvr.cc
@@ -1,0 +1,212 @@
+#include "openvr.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <openvr/openvr.h>
+#include <unistd.h>
+
+namespace zen {
+
+OpenVr::~OpenVr()
+{
+  if (worker_event_source_) {
+    wl_event_source_remove(worker_event_source_);
+  }
+}
+
+bool
+OpenVr::Init(struct wl_event_loop *loop)
+{
+  if (pipe2(pipe_, O_CLOEXEC) == -1) {
+    return false;
+  }
+
+  worker_event_source_ = wl_event_loop_add_fd(
+      loop, pipe_[0], WL_EVENT_READABLE,
+      []([[maybe_unused]] int fd, [[maybe_unused]] uint32_t mask,
+          void *data) -> int {
+        auto that = static_cast<OpenVr *>(data);
+        return that->HandleWorkerEvent();
+      },
+      this);
+
+  return true;
+}
+
+bool
+OpenVr::Connect()
+{
+  std::unique_lock<std::mutex> lock(connection_status_.mutex, std::defer_lock);
+
+  if (worker_thread_.joinable()) {
+    Disconnect();
+  }
+
+  // no polling thread exist
+  connection_status_.value = ConnectionStatus::kNone;
+
+  worker_thread_ = std::thread([this] { this->Worker(); });
+
+  lock.lock();
+
+  connection_status_.cond.wait(lock,
+      [this] { return connection_status_.value != ConnectionStatus::kNone; });
+
+  return connection_status_.value == ConnectionStatus::kSuccess;
+}
+
+void
+OpenVr::RequestPoll(std::function<void(PollResult *result)> callback)
+{
+  polling_callback_ = callback;
+  PushCommand(Command::kPoll);
+}
+
+void
+OpenVr::Disconnect()
+{
+  PushCommand(Command::kDisconnect);
+  if (worker_thread_.joinable()) worker_thread_.join();
+
+  while (!command_.queue.empty()) {
+    command_.queue.pop();
+  }
+  connection_status_.value = ConnectionStatus::kNone;
+  polling_objects_.should_quit = false;
+}
+
+int
+OpenVr::HandleWorkerEvent()
+{
+  Event event;
+  if (read(pipe_[0], &event, sizeof(event)) != sizeof(event)) {
+    zn_abort("Failed to get result of openvr polling thread");
+    return 0;
+  }
+
+  switch (event) {
+    case Event::kPollDone:
+      HandlePollDone();
+      break;
+
+    default:
+      break;
+  }
+
+  return 0;
+}
+
+void
+OpenVr::HandlePollDone()
+{
+  PollResult result;
+  {
+    std::lock_guard<std::mutex> lock(polling_objects_.mutex);
+
+    result.should_quit = polling_objects_.should_quit;
+  }
+
+  polling_callback_(&result);
+}
+
+void
+OpenVr::Worker()
+{
+  Command cmd;
+  bool running = true;
+
+  {  // connecting phase
+    std::lock_guard<std::mutex> lock(connection_status_.mutex);
+    auto init_error = vr::VRInitError_None;
+    std::ignore = vr::VR_Init(&init_error, vr::VRApplication_Scene);
+    if (init_error != vr::VRInitError_None) {
+      connection_status_.value = ConnectionStatus::kFailure;
+    } else {
+      connection_status_.value = ConnectionStatus::kSuccess;
+    }
+  }
+
+  connection_status_.cond.notify_one();
+
+  while (running) {
+    cmd = FetchCommand();
+    switch (cmd) {
+      case Command::kPoll:
+        WorkerPoll();
+        break;
+
+      case Command::kDisconnect:
+        running = false;
+        break;
+
+      default:
+        assert(false && "Unexpected OpenVr::Command");
+        running = false;
+        break;
+    }
+  }
+
+  vr::VR_Shutdown();
+}
+
+void
+OpenVr::WorkerPoll()
+{
+  vr::TrackedDevicePose_t
+      tracked_device_post_list[vr::k_unMaxTrackedDeviceCount];
+  vr::VREvent_t vr_event;
+  vr::IVRCompositor *compositor = vr::VRCompositor();
+  vr::IVRSystem *system = vr::VRSystem();
+  bool should_quit = false;
+  Event event = Event::kPollDone;
+
+  compositor->WaitGetPoses(
+      tracked_device_post_list, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+
+  system->PollNextEvent(&vr_event, sizeof(vr_event));
+
+  switch (vr_event.eventType) {
+    case vr::VREvent_Quit:         // fall through
+    case vr::VREvent_ProcessQuit:  // fall through
+    case vr::VREvent_DriverRequestedQuit:
+      should_quit = true;
+      break;
+
+    default:
+      break;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(polling_objects_.mutex);
+    polling_objects_.should_quit = should_quit;
+  }
+
+  // Nothing we can do if failed
+  std::ignore = write(pipe_[1], &event, sizeof(event));
+}
+
+void
+OpenVr::PushCommand(Command command)
+{
+  {
+    std::lock_guard<std::mutex> lock(command_.mutex);
+    command_.queue.push(command);
+  }
+  command_.cond.notify_one();
+}
+
+OpenVr::Command
+OpenVr::FetchCommand()
+{
+  std::unique_lock<std::mutex> lock(command_.mutex);
+  Command cmd;
+
+  command_.cond.wait(lock, [this] { return !command_.queue.empty(); });
+
+  cmd = command_.queue.front();
+  command_.queue.pop();
+
+  return cmd;
+}
+
+}  // namespace zen

--- a/zen/backend/openvr/openvr.h
+++ b/zen/backend/openvr/openvr.h
@@ -1,0 +1,102 @@
+#ifndef ZEN_OPENVR_BACKEND_OPENVR_H
+#define ZEN_OPENVR_BACKEND_OPENVR_H
+
+#include <wayland-server-core.h>
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#include "zen-common.h"
+
+namespace zen {
+
+class OpenVr
+{
+ public:
+  OpenVr() = default;
+  ~OpenVr();
+  DISABLE_MOVE_AND_COPY(OpenVr)
+
+  struct PollResult {
+    bool should_quit;
+  };
+
+  bool Init(struct wl_event_loop *loop);
+
+  /** start worker thread and block until connected to OpenVR or failed */
+  bool Connect();
+
+  /** Request worker thread to poll OpenVR events and HMD poses. `callback` will
+   * be called in main thread after the polling finishes. non blocking */
+  void RequestPoll(std::function<void(PollResult *result)> callback);
+
+  /** block until swapped */
+  // TODO: void Swap();
+
+  /** Finish OpenVR session and block until the worker thread joined */
+  void Disconnect();
+
+ private:
+  enum class Command {
+    kPoll,
+    kDisconnect,
+  };
+
+  enum class ConnectionStatus {
+    kNone,
+    kSuccess,
+    kFailure,
+  };
+
+  enum class Event : uint8_t {
+    kPollDone,
+  };
+
+  int HandleWorkerEvent();  // call in the main thread
+
+  void HandlePollDone();  // call in the main thread
+
+  void Worker();  // worker thread
+
+  void WorkerPoll();  // call in the worker thread
+
+  void PushCommand(Command command);  // call in the main thread
+
+  Command FetchCommand();  // call in the worker thread
+
+  std::thread worker_thread_;
+
+  // send Event from worker thread (pipe_[1]) to main thread (pipe_[0])
+  int pipe_[2];
+
+  std::function<void(PollResult *result)> polling_callback_;
+
+  struct wl_event_source *worker_event_source_ = nullptr;
+
+  struct {
+    // pushed by the main thread, consumed by the worker thread
+    std::queue<Command> queue;
+    std::mutex mutex;
+    std::condition_variable cond;
+  } command_;
+
+  struct {
+    // set by the worker thread, consumed by the main thread
+    ConnectionStatus value = ConnectionStatus::kNone;
+    std::mutex mutex;
+    std::condition_variable cond;
+  } connection_status_;
+
+  struct {
+    // set by the worker thread, consumed by the main thread
+    bool should_quit = false;
+    std::mutex mutex;
+  } polling_objects_;
+};
+
+}  // namespace zen
+
+#endif  //  ZEN_OPENVR_BACKEND_OPENVR_H

--- a/zen/backend/openvr/vr-system.cc
+++ b/zen/backend/openvr/vr-system.cc
@@ -9,123 +9,52 @@ namespace zen {
 bool
 VrSystem::Init(struct wl_event_loop *loop)
 {
-  if (pipe2(pipe_, O_CLOEXEC) == -1) return false;
-
-  wl_event_loop_add_fd(
-      loop, pipe_[0], WL_EVENT_READABLE,
-      []([[maybe_unused]] int fd, [[maybe_unused]] uint32_t mask,
-          void *data) -> int {
-        auto that = static_cast<VrSystem *>(data);
-        return that->HandlePollInThreadResult();
-      },
-      this);
-
-  return true;
+  return openvr_.Init(loop);
 }
 
 bool
 VrSystem::Connect()
 {
-  auto init_error = vr::VRInitError_None;
-
-  if (poll_thread_.joinable()) poll_thread_.join();
-  std::ignore = vr::VR_Init(&init_error, vr::VRApplication_Scene);
-  if (init_error != vr::VRInitError_None) {
-    zn_warn("Failed to init OpenVR: %s",
-        vr::VR_GetVRInitErrorAsEnglishDescription(init_error));
-    goto err;
-  }
-
-  return true;
-
-err:
-  return false;
+  return openvr_.Connect();
 }
 
 void
 VrSystem::Disconnect()
 {
-  this->StopRepaintLoop();
-  if (poll_thread_.joinable()) poll_thread_.join();
-  vr::VR_Shutdown();
+  openvr_.Disconnect();
+  is_repaint_loop_running_ = false;
   if (callbacks.Disconnected) callbacks.Disconnected();
-}
-
-int
-VrSystem::HandlePollInThreadResult()
-{
-  VrSystem::PollInThreadResult res;
-
-  if (read(pipe_[0], &res, sizeof(res)) != sizeof(res)) {
-    zn_abort("Failed to get result of openvr polling thread");
-    return 0;
-  }
-
-  switch (res) {
-    case VrSystem::PollInThreadResult::kShouldStopOpenVr:
-      this->Disconnect();
-      break;
-
-    case VrSystem::PollInThreadResult::kReadyForNextRepaint:
-      // TODO: render and IVRCompositor::Submit here
-      if (is_repaint_loop_running_) this->PollInThread();
-      break;
-    default:
-      break;
-  }
-
-  return 0;
-}
-
-void
-VrSystem::PollInThread()
-{
-  if (poll_thread_.joinable()) poll_thread_.join();
-  poll_thread_ = std::thread([this]() {
-    vr::TrackedDevicePose_t
-        tracked_device_post_list[vr::k_unMaxTrackedDeviceCount];
-    vr::VREvent_t event;
-    vr::IVRCompositor *compositor = vr::VRCompositor();
-    vr::IVRSystem *system = vr::VRSystem();
-    VrSystem::PollInThreadResult res;
-
-    compositor->WaitGetPoses(
-        tracked_device_post_list, vr::k_unMaxTrackedDeviceCount, NULL, 0);
-
-    system->PollNextEvent(&event, sizeof(event));
-
-    switch (event.eventType) {
-      case vr::VREvent_Quit:         // fall through
-      case vr::VREvent_ProcessQuit:  // fall through
-      case vr::VREvent_DriverRequestedQuit:
-        res = VrSystem::PollInThreadResult::kShouldStopOpenVr;
-
-        // just return even if write fails
-        std::ignore =
-            write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
-        return;
-
-      default:
-        break;
-    }
-
-    res = VrSystem::PollInThreadResult::kReadyForNextRepaint;
-    std::ignore = write(pipe_[1], &res, sizeof(VrSystem::PollInThreadResult));
-  });
 }
 
 void
 VrSystem::StartRepaintLoop()
 {
+  auto callback =
+      std::bind(&VrSystem::HandlePollResult, this, std::placeholders::_1);
+
   if (is_repaint_loop_running_) return;
+
+  openvr_.RequestPoll(callback);
+
   is_repaint_loop_running_ = true;
-  this->PollInThread();
 }
 
 void
-VrSystem::StopRepaintLoop()
+VrSystem::HandlePollResult(OpenVr::PollResult *result)
 {
-  is_repaint_loop_running_ = false;
+  auto callback =
+      std::bind(&VrSystem::HandlePollResult, this, std::placeholders::_1);
+
+  if (is_repaint_loop_running_ == false) return;
+
+  if (result->should_quit) {
+    Disconnect();
+    return;
+  }
+
+  // TODO: render and swap here
+
+  openvr_.RequestPoll(callback);
 }
 
 }  // namespace zen

--- a/zen/backend/openvr/vr-system.h
+++ b/zen/backend/openvr/vr-system.h
@@ -1,12 +1,11 @@
 #ifndef ZEN_OPENVR_BACKEND_VR_SYSTEM_H
 #define ZEN_OPENVR_BACKEND_VR_SYSTEM_H
 
-#include <openvr/openvr.h>
 #include <wayland-server-core.h>
 
 #include <functional>
-#include <thread>
 
+#include "openvr.h"
 #include "zen-common.h"
 
 namespace zen {
@@ -28,18 +27,10 @@ class VrSystem
   } callbacks;
 
  private:
-  enum class PollInThreadResult : uint8_t {
-    kReadyForNextRepaint = 0,
-    kShouldStopOpenVr = 1,
-  };
+  void HandlePollResult(OpenVr::PollResult *result);
 
-  int HandlePollInThreadResult();
-  void PollInThread();
-  void StopRepaintLoop();
-
+  OpenVr openvr_;
   bool is_repaint_loop_running_ = false;
-  int pipe_[2];  // use pipe_[0] in main thread, pipe_[1] in polling thread
-  std::thread poll_thread_;
 };
 
 }  // namespace zen


### PR DESCRIPTION
## Context

With previous implementation, we call the OpenVR API across multiple threads.
Whether it works or not depends on the implementation of OpenVR, which is unknown for us.

During implementing immersive renderer, I found it doesn't work, so I decided to use OpenVR API in a single thread.

Instead, the OpenGL context must be switched between threads. (This is because textures created in the main thread need to be submitted in the OpenVR thread).

## Summary

- [x] Stop using OpenVR API across multiple thread.

## How to check behavior

No behavioral change.
