### PR TITLE
fix #133

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -37,8 +37,6 @@ void zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox);
 void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     int hotspot_x, int hotspot_y);
 
-void zn_cursor_reset_surface(struct zn_cursor* self);
-
 void zn_cursor_set_xcursor(struct zn_cursor* self, char* name);
 
 struct zn_cursor* zn_cursor_create(void);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -15,7 +15,7 @@ struct zn_cursor {
   uint32_t width, height;
   int hotspot_x, hotspot_y;
 
-  const char* prev_name;
+  const char* xcursor_name;
   struct zn_screen* screen;     // nullable
   struct wlr_surface* surface;  // nullable
   // if surface is not NULL, this is the texture of that surface.

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -15,6 +15,7 @@ struct zn_cursor {
   uint32_t width, height;
   int hotspot_x, hotspot_y;
 
+  const char* prev_name;
   struct zn_screen* screen;     // nullable
   struct wlr_surface* surface;  // nullable
   // if surface is not NULL, this is the texture of that surface.
@@ -37,7 +38,7 @@ void zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox);
 void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     int hotspot_x, int hotspot_y);
 
-void zn_cursor_set_xcursor(struct zn_cursor* self, char* name);
+void zn_cursor_set_xcursor(struct zn_cursor* self, const char* name);
 
 struct zn_cursor* zn_cursor_create(void);
 

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -16,8 +16,9 @@ struct zn_cursor {
   int hotspot_x, hotspot_y;
 
   struct zn_screen* screen;     // nullable
-  struct wlr_texture* texture;  // nullable
   struct wlr_surface* surface;  // nullable
+  // if surface is not NULL, this is the texture of that surface. 
+  struct wlr_texture* texture;  // nullable
   struct wlr_xcursor_manager* xcursor_manager;
 
   struct zn_cursor_grab* grab;

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -14,11 +14,10 @@ struct zn_cursor {
   double x, y;
   uint32_t width, height;
   int hotspot_x, hotspot_y;
-  bool visible;
 
-  struct zn_screen* screen;  // nullable
-  struct wlr_texture* texture;
-  struct wlr_surface* surface;
+  struct zn_screen* screen;     // nullable
+  struct wlr_texture* texture;  // nullable
+  struct wlr_surface* surface;  // nullable
   struct wlr_xcursor_manager* xcursor_manager;
 
   struct zn_cursor_grab* grab;

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -12,12 +12,11 @@
 
 struct zn_cursor {
   double x, y;
-  uint32_t width, height;
   int hotspot_x, hotspot_y;
 
   struct zn_screen* screen;     // nullable
   struct wlr_surface* surface;  // nullable
-  // if surface is not NULL, this is the texture of that surface. 
+  // if surface is not NULL, this is the texture of that surface.
   struct wlr_texture* texture;  // nullable
   struct wlr_xcursor_manager* xcursor_manager;
 

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -12,6 +12,7 @@
 
 struct zn_cursor {
   double x, y;
+  uint32_t width, height;
   int hotspot_x, hotspot_y;
 
   struct zn_screen* screen;     // nullable

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -14,7 +14,6 @@ struct zn_cursor {
   double x, y;
   uint32_t width, height;
   int hotspot_x, hotspot_y;
-  int default_hotspot_x, default_hotspot_y;
   bool visible;
 
   struct zn_screen* screen;  // nullable
@@ -39,6 +38,8 @@ void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     int hotspot_x, int hotspot_y);
 
 void zn_cursor_reset_surface(struct zn_cursor* self);
+
+void zn_cursor_set_xcursor(struct zn_cursor* self, char* name);
 
 struct zn_cursor* zn_cursor_create(void);
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -41,7 +41,6 @@ default_grab_motion(
     wlr_seat_pointer_enter(seat, surface, view_x, view_y);
     wlr_seat_pointer_send_motion(seat, event->time_msec, view_x, view_y);
   } else {
-    zn_cursor_set_surface(cursor, NULL, 0, 0);
     zn_cursor_set_xcursor(cursor, "left_ptr");
     wlr_seat_pointer_clear_focus(seat);
   }
@@ -214,7 +213,6 @@ zn_cursor_handle_surface_destroy(struct wl_listener* listener, void* data)
   struct zn_cursor* self =
       zn_container_of(listener, self, surface_destroy_listener);
 
-  zn_cursor_set_surface(self, NULL, 0, 0);
   zn_cursor_set_xcursor(self, "left_ptr");
 }
 
@@ -298,9 +296,7 @@ zn_cursor_set_xcursor(struct zn_cursor* self, char* name)
   struct wlr_xcursor* xcursor;
   struct wlr_xcursor_image* image;
 
-  if (self->texture && !self->surface) {
-    wlr_texture_destroy(self->texture);
-  }
+  zn_cursor_set_surface(self, NULL, 0, 0);
 
   xcursor = wlr_xcursor_manager_get_xcursor(self->xcursor_manager, name, 1.f);
   if (xcursor == NULL) {

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -2,6 +2,7 @@
 
 #include <drm/drm_fourcc.h>
 #include <linux/input.h>
+#include <string.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_seat.h>
@@ -293,11 +294,15 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
 }
 
 void
-zn_cursor_set_xcursor(struct zn_cursor* self, char* name)
+zn_cursor_set_xcursor(struct zn_cursor* self, const char* name)
 {
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_xcursor* xcursor;
   struct wlr_xcursor_image* image;
+
+  if (self->prev_name && strcmp(self->prev_name, name) == 0) {
+    return;
+  }
 
   zn_cursor_set_surface(self, NULL, 0, 0);
 
@@ -310,6 +315,7 @@ zn_cursor_set_xcursor(struct zn_cursor* self, char* name)
 
   zn_cursor_damage_whole(self);
 
+  self->prev_name = name;
   self->hotspot_x = image->hotspot_x;
   self->hotspot_y = image->hotspot_y;
   self->texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -41,7 +41,8 @@ default_grab_motion(
     wlr_seat_pointer_enter(seat, surface, view_x, view_y);
     wlr_seat_pointer_send_motion(seat, event->time_msec, view_x, view_y);
   } else {
-    zn_cursor_reset_surface(cursor);
+    zn_cursor_set_surface(cursor, NULL, 0, 0);
+    zn_cursor_set_xcursor(cursor, "left_ptr");
     wlr_seat_pointer_clear_focus(seat);
   }
 }
@@ -223,6 +224,7 @@ zn_cursor_handle_surface_destroy(struct wl_listener* listener, void* data)
       zn_container_of(listener, self, surface_destroy_listener);
 
   zn_cursor_set_surface(self, NULL, 0, 0);
+  zn_cursor_set_xcursor(self, "left_ptr");
 }
 
 void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -98,21 +98,6 @@ static const struct zn_cursor_grab_interface default_grab_interface = {
     .frame = default_grab_frame,
 };
 
-static void
-zn_cursor_update_size(struct zn_cursor* self)
-{
-  if (!self->texture) {
-    self->width = 0;
-    self->height = 0;
-  } else if (self->surface) {
-    self->width = self->surface->current.width;
-    self->height = self->surface->current.height;
-  } else {
-    self->width = self->texture->width;
-    self->height = self->texture->height;
-  }
-}
-
 // screen_x and screen_y must be less than screen->width/height
 static void
 zn_cursor_update_position(struct zn_cursor* self, struct zn_screen* screen,
@@ -204,8 +189,6 @@ zn_cursor_handle_surface_commit(struct wl_listener* listener, void* data)
 
   zn_cursor_damage_whole(self);
 
-  zn_cursor_update_size(self);
-
   zn_cursor_damage_whole(self);
 }
 
@@ -251,8 +234,17 @@ zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox)
 {
   fbox->x = self->x - self->hotspot_x;
   fbox->y = self->y - self->hotspot_y;
-  fbox->width = self->width;
-  fbox->height = self->height;
+
+  if (!self->texture) {
+    fbox->width = 0;
+    fbox->height = 0;
+  } else if (self->surface) {
+    fbox->width = self->surface->current.width;
+    fbox->height = self->surface->current.height;
+  } else {
+    fbox->width = self->texture->width;
+    fbox->height = self->texture->height;
+  }
 }
 
 void
@@ -287,8 +279,6 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
 
   self->surface = surface;
 
-  zn_cursor_update_size(self);
-
   zn_cursor_damage_whole(self);
 }
 
@@ -314,7 +304,6 @@ zn_cursor_set_xcursor(struct zn_cursor* self, char* name)
   self->hotspot_y = image->hotspot_y;
   self->texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,
       image->width * 4, image->width, image->height, image->buffer);
-  zn_cursor_update_size(self);
 
   zn_cursor_damage_whole(self);
 }
@@ -345,7 +334,6 @@ zn_cursor_create(void)
   self->screen = NULL;
 
   zn_cursor_set_xcursor(self, "left_ptr");
-  zn_cursor_update_size(self);
 
   self->new_screen_listener.notify = zn_cursor_handle_new_screen;
   wl_signal_add(&screen_layout->events.new_screen, &self->new_screen_listener);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -266,7 +266,7 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     wlr_texture_destroy(self->texture);
   }
 
-  self->prev_name = NULL;
+  self->xcursor_name = NULL;
 
   if (self->surface != NULL) {
     wl_list_remove(&self->surface_destroy_listener.link);
@@ -302,7 +302,7 @@ zn_cursor_set_xcursor(struct zn_cursor* self, const char* name)
   struct wlr_xcursor* xcursor;
   struct wlr_xcursor_image* image;
 
-  if (self->prev_name && strcmp(self->prev_name, name) == 0) {
+  if (self->xcursor_name && strcmp(self->xcursor_name, name) == 0) {
     return;
   }
 
@@ -317,7 +317,7 @@ zn_cursor_set_xcursor(struct zn_cursor* self, const char* name)
 
   zn_cursor_damage_whole(self);
 
-  self->prev_name = name;
+  self->xcursor_name = name;
   self->hotspot_x = image->hotspot_x;
   self->hotspot_y = image->hotspot_y;
   self->texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -273,7 +273,7 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     wl_signal_add(&surface->events.destroy, &self->surface_destroy_listener);
     wl_signal_add(&surface->events.commit, &self->surface_commit_listener);
   } else {
-    zn_cursor_set_xcursor(self, "grab");
+    zn_cursor_set_xcursor(self, "left_ptr");
   }
 
   zn_cursor_damage_whole(self);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -251,6 +251,8 @@ void
 zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     int hotspot_x, int hotspot_y)
 {
+  zn_cursor_damage_whole(self);
+
   if (self->texture && !self->surface) {
     wlr_texture_destroy(self->texture);
   }
@@ -261,8 +263,6 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     wl_list_remove(&self->surface_commit_listener.link);
     wl_list_init(&self->surface_commit_listener.link);
   }
-
-  zn_cursor_damage_whole(self);
 
   if (surface != NULL) {
     wl_signal_add(&surface->events.destroy, &self->surface_destroy_listener);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -301,7 +301,6 @@ zn_cursor_set_xcursor(struct zn_cursor* self, char* name)
   xcursor = wlr_xcursor_manager_get_xcursor(self->xcursor_manager, name, 1.f);
   if (xcursor == NULL) {
     zn_error("Failed to get xcursor");
-    self->texture = NULL;
     return;
   }
   image = xcursor->images[0];

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -266,6 +266,8 @@ zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     wlr_texture_destroy(self->texture);
   }
 
+  self->prev_name = NULL;
+
   if (self->surface != NULL) {
     wl_list_remove(&self->surface_destroy_listener.link);
     wl_list_init(&self->surface_destroy_listener.link);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -101,12 +101,15 @@ static const struct zn_cursor_grab_interface default_grab_interface = {
 static void
 zn_cursor_update_size(struct zn_cursor* self)
 {
-  if (self->texture) {
-    self->width = self->texture->width;
-    self->height = self->texture->height;
-  } else {
+  if (!self->texture) {
     self->width = 0;
     self->height = 0;
+  } else if (self->surface) {
+    self->width = self->surface->current.width;
+    self->height = self->surface->current.height;
+  } else {
+    self->width = self->texture->width;
+    self->height = self->texture->height;
   }
 }
 

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -154,7 +154,6 @@ zn_screen_renderer_render_cursor(struct zn_screen *screen,
     struct zn_cursor *cursor, struct wlr_renderer *renderer,
     pixman_region32_t *screen_damage)
 {
-  struct wlr_texture *texture;
   struct wlr_fbox fbox;
   struct wlr_box transformed_box;
   struct zn_output *output = screen->output;
@@ -163,7 +162,7 @@ zn_screen_renderer_render_cursor(struct zn_screen *screen,
   int rect_count;
   float matrix[9];
 
-  if (!cursor->visible || cursor->screen != screen) {
+  if (!cursor->texture || cursor->screen != screen) {
     return;
   }
 
@@ -181,23 +180,13 @@ zn_screen_renderer_render_cursor(struct zn_screen *screen,
     goto render_damage_finish;
   }
 
-  if (cursor->surface != NULL) {
-    texture = wlr_surface_get_texture(cursor->surface);
-  } else {
-    texture = cursor->texture;
-  }
-
-  if (texture == NULL) {
-    goto render_damage_finish;
-  }
-
   wlr_matrix_project_box(matrix, &transformed_box, WL_OUTPUT_TRANSFORM_NORMAL,
       0, output->wlr_output->transform_matrix);
 
   rects = pixman_region32_rectangles(&render_damage, &rect_count);
   for (int i = 0; i < rect_count; i++) {
     zn_screen_renderer_scissor_output(screen->output, &rects[i]);
-    wlr_render_texture_with_matrix(renderer, texture, matrix, 1.0f);
+    wlr_render_texture_with_matrix(renderer, cursor->texture, matrix, 1.0f);
   }
 
 render_damage_finish:

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -162,7 +162,9 @@ zn_screen_renderer_render_cursor(struct zn_screen *screen,
   int rect_count;
   float matrix[9];
 
-  if (!cursor->texture || cursor->screen != screen) {
+  if (!cursor->texture ||
+      (cursor->surface && !wlr_surface_has_buffer(cursor->surface)) ||
+      cursor->screen != screen) {
     return;
   }
 


### PR DESCRIPTION
## Context

See #133

## Summary

Added `zn_cursor_set_xcursor()`, and remove cursor::visible from zn_cursor. The visiblity is expressed by whether or not cursor::texture is NULL.

## How to check behavior

None
