### PR TITLE
remove dev branch from CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - dev
   pull_request:
     branches:
       - main
-      - dev
 
 jobs:
   test-with-gcc:


### PR DESCRIPTION
## Context

We rename `dev` branch to `main` and set it default branch.

We should update CI settings.

## Summary

- [x] remove dev branch from CI configuration

## How to check behavior

none