### PR TITLE
handle output disconnection

### DIFF
--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -231,8 +231,8 @@ err:
 void
 zn_screen_destroy(struct zn_screen *self)
 {
-  wl_signal_emit(&self->events.destroy, NULL);
   wl_list_remove(&self->current_board_screen_assigned_listener.link);
+  wl_signal_emit(&self->events.destroy, NULL);
 
   zn_screen_layout_remove(self->screen_layout, self);
   free(self);


### PR DESCRIPTION
## Context

Now an error occurs when removing output.

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7e37622 in wlr_output_transformed_resolution (output=0x555000dc914b, width=0x7fffffffd320, height=0x7fffffffd324) at ../types/output/output.c:466
466		if (output->transform % 2 == 0) {
#0  0x00007ffff7e37622 in wlr_output_transformed_resolution (output=0x555000dc914b, width=0x7fffffffd320, height=0x7fffffffd324) at ../types/output/output.c:466
#1  0x00007ffff7e6132d in wlr_output_damage_add_whole (output_damage=0x55555594b500) at ../types/wlr_output_damage.c:199
#2  0x000055555555e029 in wl_signal_emit (data=0x7fffffffd340, signal=0x5555556dee98) at /usr/include/wayland-server-core.h:481
#3  zn_board_assign_to_screen (self=0x5555556dee30, screen=<optimized out>) at ../zen/scene/board.c:60
#4  0x000055555555ebc8 in wl_signal_emit (data=0x0, signal=0x555555922ec0) at /usr/include/wayland-server-core.h:481
#5  zn_screen_destroy (self=0x555555922e60) at ../zen/scene/screen.c:246
#6  0x000055555555b7fa in zn_output_destroy (self=0x555555944d90) at ../zen/output.c:196
#7  zn_output_wlr_output_destroy_handler (listener=0x555555944db8, data=<optimized out>) at ../zen/output.c:42
#8  0x00007ffff7e7d547 in wlr_signal_emit_safe (signal=0x555555957ed0, data=0x555555957cb0) at ../util/signal.c:29
#9  0x00007ffff7e374a4 in wlr_output_destroy (output=0x555555957cb0) at ../types/output/output.c:429
#10 0x00007ffff7e17445 in disconnect_drm_connector (conn=0x555555957cb0) at ../backend/drm/drm.c:1540
#11 0x00007ffff7e16cab in scan_drm_connectors (drm=0x5555555908c0, event=0x7fffffffd78c) at ../backend/drm/drm.c:1384
#12 0x00007ffff7e115a1 in handle_dev_change (listener=0x5555555909a8, data=0x7fffffffd788) at ../backend/drm/backend.c:139
#13 0x00007ffff7e7d547 in wlr_signal_emit_safe (signal=0x555555590c00, data=0x7fffffffd788) at ../util/signal.c:29
#14 0x00007ffff7e2ff48 in handle_udev_event (fd=12, mask=1, data=0x55555558a460) at ../backend/session/session.c:214
#15 0x00007ffff7ee259d in wl_event_source_fd_dispatch (source=0x55555558cf30, ep=0x7fffffffd810) at ../src/event-loop.c:112
#16 0x00007ffff7ee3d12 in wl_event_loop_dispatch (loop=0x555555571b90, timeout=-1) at ../src/event-loop.c:1027
#17 0x00007ffff7ee0217 in wl_display_run (display=0x55555558a1d0) at ../src/wayland-server.c:1408
#18 0x000055555555c6cd in zn_server_run (self=self@entry=0x55555558a2c0) at ../zen/server.c:150
#19 0x000055555555a504 in main (argc=<optimized out>, argv=<optimized out>) at ../zen/main.c:194
```

## Summary

Fix destruction process of screen.

## How to check behavior

Confirm that no error occurs when disconnecting monitors.