### PR TITLE
fix #133

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -41,8 +41,6 @@ void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
 
 void zn_cursor_set_xcursor(struct zn_cursor* self, const char* name);
 
-void zn_cursor_reset_surface(struct zn_cursor* self);
-
 struct zn_cursor* zn_cursor_create(void);
 
 void zn_cursor_destroy(struct zn_cursor* self);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -39,6 +39,8 @@ void zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox);
 void zn_cursor_set_surface(struct zn_cursor* self, struct wlr_surface* surface,
     int hotspot_x, int hotspot_y);
 
+void zn_cursor_set_xcursor(struct zn_cursor* self, const char* name);
+
 void zn_cursor_reset_surface(struct zn_cursor* self);
 
 struct zn_cursor* zn_cursor_create(void);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -18,7 +18,7 @@ struct zn_cursor {
   bool visible;
 
   struct zn_screen* screen;  // nullable
-  struct wlr_texture* texture;
+  struct wlr_texture* xcursor_texture;
   struct wlr_surface* surface;
   struct wlr_xcursor_manager* xcursor_manager;
 

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -14,12 +14,13 @@ struct zn_cursor {
   double x, y;
   uint32_t width, height;
   int hotspot_x, hotspot_y;
-  int default_hotspot_x, default_hotspot_y;
   bool visible;
 
   struct zn_screen* screen;  // nullable
-  struct wlr_texture* xcursor_texture;
-  struct wlr_surface* surface;
+
+  struct wlr_surface* surface;          // nullable
+  const char* xcursor_name;             // nullable
+  struct wlr_texture* xcursor_texture;  // nullable
   struct wlr_xcursor_manager* xcursor_manager;
 
   struct zn_cursor_grab* grab;

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -144,8 +144,11 @@ static void
 zn_cursor_damage_whole(struct zn_cursor* self)
 {
   struct wlr_fbox fbox;
-  zn_cursor_get_fbox(self, &fbox);
-  zn_output_add_damage_box(self->screen->output, &fbox);
+
+  if (self->screen) {
+    zn_cursor_get_fbox(self, &fbox);
+    zn_output_add_damage_box(self->screen->output, &fbox);
+  }
 }
 
 static void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -113,8 +113,8 @@ zn_cursor_update_size(struct zn_cursor* self)
     return;
   }
 
-  self->width = self->texture->width;
-  self->height = self->texture->height;
+  self->width = self->xcursor_texture->width;
+  self->height = self->xcursor_texture->height;
 }
 
 // screen_x and screen_y must be less than screen->width/height
@@ -335,8 +335,9 @@ zn_cursor_create(void)
 
   self->hotspot_x = self->default_hotspot_x = image->hotspot_x;
   self->hotspot_y = self->default_hotspot_y = image->hotspot_y;
-  self->texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,
-      image->width * 4, image->width, image->height, image->buffer);
+  self->xcursor_texture =
+      wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,
+          image->width * 4, image->width, image->height, image->buffer);
 
   self->new_screen_listener.notify = zn_cursor_handle_new_screen;
   wl_signal_add(&screen_layout->events.new_screen, &self->new_screen_listener);
@@ -376,7 +377,7 @@ zn_cursor_destroy(struct zn_cursor* self)
   wl_list_remove(&self->screen_destroy_listener.link);
   wl_list_remove(&self->surface_commit_listener.link);
   wl_list_remove(&self->surface_destroy_listener.link);
-  wlr_texture_destroy(self->texture);
+  wlr_texture_destroy(self->xcursor_texture);
   wlr_xcursor_manager_destroy(self->xcursor_manager);
   free(self);
 }

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -184,7 +184,7 @@ zn_screen_renderer_render_cursor(struct zn_screen *screen,
   if (cursor->surface != NULL) {
     texture = wlr_surface_get_texture(cursor->surface);
   } else {
-    texture = cursor->texture;
+    texture = cursor->xcursor_texture;
   }
 
   if (texture == NULL) {


### PR DESCRIPTION
## Context
See #133 (and this is a rebuilded version of #139)

## Summary
Added `zn_cursor_set_xcursor()`.

## How to check behavior
None