### PR TITLE
Move view

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -23,6 +23,9 @@ struct zn_cursor {
   struct wlr_texture* xcursor_texture;  // nullable
   struct wlr_xcursor_manager* xcursor_manager;
 
+  /**
+   * While a **non-default** grab is in use, zn_cursor::screen will not be NULL
+   */
   struct zn_cursor_grab* grab;
   struct zn_cursor_grab grab_default;
 

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -32,6 +32,10 @@ struct zn_cursor {
   struct wl_listener surface_destroy_listener;
 };
 
+void zn_cursor_start_grab(struct zn_cursor* self, struct zn_cursor_grab* grab);
+
+void zn_cursor_end_grab(struct zn_cursor* self);
+
 void zn_cursor_move_relative(struct zn_cursor* self, double dx, double dy);
 
 void zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox);

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -8,6 +8,7 @@
 struct zn_cursor_grab_move {
   struct zn_cursor_grab base;
   struct zn_view* view;
+  struct zn_screen* prev_screen;
 
   double diff_x, diff_y;
 };

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -12,6 +12,8 @@ struct zn_cursor_grab_move {
 
   double init_x, init_y;
   double diff_x, diff_y;
+
+  struct wl_listener view_unmap_listener;
 };
 
 void zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view);

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -10,6 +10,7 @@ struct zn_cursor_grab_move {
   struct zn_view* view;
   struct zn_screen* prev_screen;
 
+  struct zn_board* init_board;
   double init_x, init_y;
   double diff_x, diff_y;
 

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -1,0 +1,15 @@
+#ifndef ZN_CURSOR_GRAB_MOVE_H
+#define ZN_CURSOR_GRAB_MOVE_H
+
+#include "zen/cursor.h"
+#include "zen/input/cursor-grab.h"
+#include "zen/scene/view.h"
+
+struct zn_cursor_grab_move {
+  struct zn_cursor_grab base;
+  struct zn_view* view;
+};
+
+void zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view);
+
+#endif  //  ZN_CURSOR_GRAB_MOVE_H

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -14,6 +14,7 @@ struct zn_cursor_grab_move {
   double init_x, init_y;
   double diff_x, diff_y;
 
+  struct wl_listener prev_screen_destroy_listener;
   struct wl_listener view_unmap_listener;
 };
 

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -8,13 +8,11 @@
 struct zn_cursor_grab_move {
   struct zn_cursor_grab base;
   struct zn_view* view;
-  struct zn_screen* prev_screen;
 
   struct zn_board* init_board;
   double init_x, init_y;
   double diff_x, diff_y;
 
-  struct wl_listener prev_screen_destroy_listener;
   struct wl_listener view_unmap_listener;
 };
 

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -14,6 +14,7 @@ struct zn_cursor_grab_move {
   double diff_x, diff_y;
 
   struct wl_listener view_unmap_listener;
+  struct wl_listener init_board_destroy_listener;
 };
 
 void zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view);

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -10,6 +10,7 @@ struct zn_cursor_grab_move {
   struct zn_view* view;
   struct zn_screen* prev_screen;
 
+  double init_x, init_y;
   double diff_x, diff_y;
 };
 

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -8,6 +8,8 @@
 struct zn_cursor_grab_move {
   struct zn_cursor_grab base;
   struct zn_view* view;
+
+  double diff_x, diff_y;
 };
 
 void zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view);

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -7,7 +7,7 @@
 
 struct zn_cursor_grab_move {
   struct zn_cursor_grab base;
-  struct zn_view* view;
+  struct zn_view* view;  // nonnull
 
   struct zn_board* init_board;
   double init_x, init_y;

--- a/include/zen/input/cursor-grab.h
+++ b/include/zen/input/cursor-grab.h
@@ -17,6 +17,7 @@ struct zn_cursor_grab_interface {
   void (*axis)(
       struct zn_cursor_grab* grab, struct wlr_event_pointer_axis* event);
   void (*frame)(struct zn_cursor_grab* grab);
+  void (*rebase)(struct zn_cursor_grab* grab);
   void (*cancel)(struct zn_cursor_grab* grab);
 };
 

--- a/include/zen/input/cursor-grab.h
+++ b/include/zen/input/cursor-grab.h
@@ -17,7 +17,6 @@ struct zn_cursor_grab_interface {
   void (*axis)(
       struct zn_cursor_grab* grab, struct wlr_event_pointer_axis* event);
   void (*frame)(struct zn_cursor_grab* grab);
-  // called when zn_cursor::screen is assigned NULL
   void (*cancel)(struct zn_cursor_grab* grab);
 };
 

--- a/include/zen/input/cursor-grab.h
+++ b/include/zen/input/cursor-grab.h
@@ -17,6 +17,7 @@ struct zn_cursor_grab_interface {
   void (*axis)(
       struct zn_cursor_grab* grab, struct wlr_event_pointer_axis* event);
   void (*frame)(struct zn_cursor_grab* grab);
+  // called when zn_cursor::screen is assigned NULL
   void (*cancel)(struct zn_cursor_grab* grab);
 };
 

--- a/include/zen/input/cursor-grab.h
+++ b/include/zen/input/cursor-grab.h
@@ -17,6 +17,7 @@ struct zn_cursor_grab_interface {
   void (*axis)(
       struct zn_cursor_grab* grab, struct wlr_event_pointer_axis* event);
   void (*frame)(struct zn_cursor_grab* grab);
+  void (*cancel)(struct zn_cursor_grab* grab);
 };
 
 struct zn_cursor_grab {

--- a/include/zen/scene/board.h
+++ b/include/zen/scene/board.h
@@ -30,7 +30,8 @@ struct zn_board {
 
   struct {
     struct wl_signal
-        screen_assigned;  // (struct *zn_board_screen_assigned_event)
+        screen_assigned;       // (struct *zn_board_screen_assigned_event)
+    struct wl_signal destroy;  // (NULL)
   } events;
 };
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -38,6 +38,8 @@ struct zn_view {
   } events;
 };
 
+void zn_view_move(struct zn_view *self, double x, double y);
+
 /**
  * Add the damage of all surfaces associated with the view to the output where
  * the view id displayed.

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -38,6 +38,10 @@ struct zn_view {
   } events;
 };
 
+/**
+ * @param board must not be NULL except when this view is unmapped with
+ * `zn_view_unmap`
+ */
 void zn_view_move(
     struct zn_view *self, double x, double y, struct zn_board *new_board);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -38,7 +38,8 @@ struct zn_view {
   } events;
 };
 
-void zn_view_move(struct zn_view *self, double x, double y);
+void zn_view_move(
+    struct zn_view *self, double x, double y, struct zn_board *new_board);
 
 /**
  * Add the damage of all surfaces associated with the view to the output where

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -42,8 +42,8 @@ struct zn_view {
  * @param board must not be NULL except when this view is unmapped with
  * `zn_view_unmap`
  */
-void zn_view_move(
-    struct zn_view *self, double x, double y, struct zn_board *new_board);
+void zn_view_move(struct zn_view *self, struct zn_board *new_board,
+    double board_x, double board_y);
 
 /**
  * Add the damage of all surfaces associated with the view to the output where

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -57,8 +57,6 @@ void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 void zn_view_get_window_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
-void zn_view_change_board(struct zn_view *self, struct zn_board *new_board);
-
 bool zn_view_is_mapped(struct zn_view *self);
 
 void zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene);

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -52,6 +52,8 @@ void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 void zn_view_get_window_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
+void zn_view_change_board(struct zn_view *self, struct zn_board *new_board);
+
 bool zn_view_is_mapped(struct zn_view *self);
 
 void zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene);

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -15,6 +15,7 @@ struct zn_xdg_toplevel_view {
 
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
+  struct wl_listener move_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;
   struct wl_listener wlr_surface_commit_listener;
 };

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -15,6 +15,7 @@ struct zn_xwayland_view {
 
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
+  struct wl_listener move_listener;
   struct wl_listener wlr_xwayland_surface_destroy_listener;
   struct wl_listener wlr_surface_commit_listener;
 };

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -193,6 +193,7 @@ zn_cursor_handle_screen_destroy(struct wl_listener* listener, void* data)
     zn_cursor_update_position(self, screen, box.width / 2, box.height / 2);
     zn_cursor_damage_whole(self);
   } else {
+    self->grab->interface->cancel(self->grab);
     zn_cursor_update_position(self, NULL, 0, 0);
   }
 }

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -118,6 +118,7 @@ zn_cursor_get_pointing_surface(
 {
   struct zn_view* view;
 
+  // FIXME: take subsurfaces/popups into account
   view = zn_screen_get_view_at(
       self->screen, self->x, self->y, surface_x, surface_y);
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -91,11 +91,18 @@ default_grab_frame(struct zn_cursor_grab* grab)
   wlr_seat_pointer_send_frame(seat);
 }
 
+static void
+default_grab_cancel(struct zn_cursor_grab* grab)
+{
+  UNUSED(grab);
+}
+
 static const struct zn_cursor_grab_interface default_grab_interface = {
     .motion = default_grab_motion,
     .button = default_grab_button,
     .axis = default_grab_axis,
     .frame = default_grab_frame,
+    .cancel = default_grab_cancel,
 };
 
 static void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -147,11 +147,14 @@ zn_cursor_update_position(struct zn_cursor* self, struct zn_screen* screen,
     wl_list_remove(&self->screen_destroy_listener.link);
     wl_list_init(&self->screen_destroy_listener.link);
   }
-  if (screen != NULL) {
-    wl_signal_add(&screen->events.destroy, &self->screen_destroy_listener);
-  }
 
   self->screen = screen;
+
+  if (screen) {
+    wl_signal_add(&screen->events.destroy, &self->screen_destroy_listener);
+  } else {
+    self->grab->interface->cancel(self->grab);
+  }
 }
 
 static void
@@ -204,7 +207,6 @@ zn_cursor_handle_screen_destroy(struct wl_listener* listener, void* data)
     zn_cursor_update_position(self, screen, box.width / 2, box.height / 2);
     zn_cursor_damage_whole(self);
   } else {
-    self->grab->interface->cancel(self->grab);
     zn_cursor_update_position(self, NULL, 0, 0);
   }
 }

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -13,8 +13,8 @@
 #include "zen/scene/view.h"
 #include "zen/server.h"
 
-static struct wlr_surface* zn_cursor_get_surface_at_cursor_pos(
-    struct zn_cursor* self, double* view_x, double* view_y);
+static struct wlr_surface* zn_cursor_get_pointing_surface(
+    struct zn_cursor* self, double* surface_x, double* surface_y);
 
 static void
 default_grab_motion(
@@ -22,18 +22,18 @@ default_grab_motion(
 {
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
-  double view_x, view_y;
+  double surface_x, surface_y;
   struct wlr_surface* surface;
 
   if (!grab->cursor->screen) {
     return;
   }
 
-  surface = zn_cursor_get_surface_at_cursor_pos(grab->cursor, &view_x, &view_y);
+  surface = zn_cursor_get_pointing_surface(grab->cursor, &surface_x, &surface_y);
 
   if (surface) {
-    wlr_seat_pointer_enter(seat, surface, view_x, view_y);
-    wlr_seat_pointer_send_motion(seat, event->time_msec, view_x, view_y);
+    wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
+    wlr_seat_pointer_send_motion(seat, event->time_msec, surface_x, surface_y);
   } else {
     zn_cursor_set_xcursor(grab->cursor, "left_ptr");
     wlr_seat_pointer_clear_focus(seat);
@@ -102,12 +102,12 @@ static const struct zn_cursor_grab_interface default_grab_interface = {
 // fetch view's surface corresponding to cursor's pos
 // expect cursor::screen is non-NULL
 static struct wlr_surface*
-zn_cursor_get_surface_at_cursor_pos(
-    struct zn_cursor* self, double* view_x, double* view_y)
+zn_cursor_get_pointing_surface(
+    struct zn_cursor* self, double* surface_x, double* surface_y)
 {
   struct zn_view* view;
 
-  view = zn_screen_get_view_at(self->screen, self->x, self->y, view_x, view_y);
+  view = zn_screen_get_view_at(self->screen, self->x, self->y, surface_x, surface_y);
 
   if (view) {
     return view->impl->get_wlr_surface(view);
@@ -253,7 +253,7 @@ zn_cursor_end_grab(struct zn_cursor* self)
 {
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
-  double view_x, view_y;
+  double surface_x, surface_y;
   struct wlr_surface* surface;
 
   self->grab = &self->grab_default;
@@ -262,10 +262,10 @@ zn_cursor_end_grab(struct zn_cursor* self)
     return;
   }
 
-  surface = zn_cursor_get_surface_at_cursor_pos(self, &view_x, &view_y);
+  surface = zn_cursor_get_pointing_surface(self, &surface_x, &surface_y);
 
   if (surface) {
-    wlr_seat_pointer_enter(seat, surface, view_x, view_y);
+    wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
   }
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -264,8 +264,6 @@ zn_cursor_end_grab(struct zn_cursor* self)
 
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, view_x, view_y);
-  } else {
-    zn_cursor_set_xcursor(cursor, "left_ptr");
   }
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -222,6 +222,18 @@ zn_cursor_handle_surface_destroy(struct wl_listener* listener, void* data)
 }
 
 void
+zn_cursor_start_grab(struct zn_cursor* self, struct zn_cursor_grab* grab)
+{
+  self->grab = grab;
+}
+
+void
+zn_cursor_end_grab(struct zn_cursor* self)
+{
+  self->grab = &self->grab_default;
+}
+
+void
 zn_cursor_move_relative(struct zn_cursor* self, double dx, double dy)
 {
   struct zn_server* server = zn_server_get_singleton();

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -89,6 +89,13 @@ default_grab_frame(struct zn_cursor_grab* grab)
 }
 
 static void
+default_grab_rebase(struct zn_cursor_grab* grab)
+{
+  UNUSED(grab);
+  // TODO: implement rebase
+}
+
+static void
 default_grab_cancel(struct zn_cursor_grab* grab)
 {
   UNUSED(grab);
@@ -99,6 +106,7 @@ static const struct zn_cursor_grab_interface default_grab_interface = {
     .button = default_grab_button,
     .axis = default_grab_axis,
     .frame = default_grab_frame,
+    .rebase = default_grab_rebase,
     .cancel = default_grab_cancel,
 };
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -29,7 +29,8 @@ default_grab_motion(
     return;
   }
 
-  surface = zn_cursor_get_pointing_surface(grab->cursor, &surface_x, &surface_y);
+  surface =
+      zn_cursor_get_pointing_surface(grab->cursor, &surface_x, &surface_y);
 
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
@@ -107,7 +108,8 @@ zn_cursor_get_pointing_surface(
 {
   struct zn_view* view;
 
-  view = zn_screen_get_view_at(self->screen, self->x, self->y, surface_x, surface_y);
+  view = zn_screen_get_view_at(
+      self->screen, self->x, self->y, surface_x, surface_y);
 
   if (view) {
     return view->impl->get_wlr_surface(view);
@@ -148,13 +150,13 @@ zn_cursor_update_position(struct zn_cursor* self, struct zn_screen* screen,
     wl_list_init(&self->screen_destroy_listener.link);
   }
 
-  self->screen = screen;
-
   if (screen) {
     wl_signal_add(&screen->events.destroy, &self->screen_destroy_listener);
   } else {
     self->grab->interface->cancel(self->grab);
   }
+
+  self->screen = screen;
 }
 
 static void
@@ -245,6 +247,10 @@ zn_cursor_handle_surface_destroy(struct wl_listener* listener, void* data)
 void
 zn_cursor_start_grab(struct zn_cursor* self, struct zn_cursor_grab* grab)
 {
+  if (!self->screen) {
+    return;
+  }
+
   self->grab = grab;
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -25,6 +25,8 @@ default_grab_motion(
   double surface_x, surface_y;
   struct wlr_surface* surface;
 
+  zn_cursor_move_relative(grab->cursor, event->delta_x, event->delta_y);
+
   if (!grab->cursor->screen) {
     return;
   }

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -110,7 +110,7 @@ static const struct zn_cursor_grab_interface default_grab_interface = {
     .cancel = default_grab_cancel,
 };
 
-// fetch view's surface corresponding to cursor's pos
+// get the surface that is just under the cursor
 // expect cursor::screen is non-NULL
 static struct wlr_surface*
 zn_cursor_get_pointing_surface(

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -38,12 +38,11 @@ default_grab_motion(
 {
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
-  struct zn_cursor* cursor = server->input_manager->seat->cursor;
   double view_x, view_y;
   struct wlr_surface* surface =
       get_surface_of_view_at_cursor_pos(&view_x, &view_y);
 
-  if (!cursor->screen) {
+  if (!grab->cursor->screen) {
     return;
   }
 

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -130,6 +130,7 @@ static void
 zn_cursor_grab_move_destroy(struct zn_cursor_grab_move* self)
 {
   wl_list_remove(&self->view_unmap_listener.link);
+  wl_list_remove(&self->prev_screen_destroy_listener.link);
   free(self);
 }
 

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -12,6 +12,8 @@ move_grab_motion(
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
   struct zn_board* board = self->view->board;
 
+  zn_cursor_move_relative(grab->cursor, event->delta_x, event->delta_y);
+
   if (self->prev_screen) {
     if (grab->cursor->screen != self->prev_screen) {
       board = grab->cursor->screen->current_board;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -12,6 +12,10 @@ move_grab_motion(
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
   struct zn_board* board = self->view->board;
 
+  if (!grab->cursor->screen) {
+    return;
+  }
+
   if (grab->cursor->screen != self->prev_screen) {
     board = grab->cursor->screen->current_board;
   }

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -55,6 +55,7 @@ static const struct zn_cursor_grab_interface move_grab_interface = {
 void
 zn_cursor_grab_move_end(struct zn_cursor_grab_move* self)
 {
+  zn_cursor_set_xcursor(self->base.cursor, "left_ptr");
   zn_cursor_end_grab(self->base.cursor);
   free(self);
 }
@@ -80,5 +81,6 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
   self->base.interface = &move_grab_interface;
   self->base.cursor = cursor;
 
+  zn_cursor_set_xcursor(cursor, "grabbing");
   zn_cursor_start_grab(cursor, &self->base);
 }

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -108,6 +108,6 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
   wl_signal_add(&view->events.unmap, &self->view_unmap_listener);
 
   zn_cursor_set_xcursor(cursor, "grabbing");
-  wlr_seat_pointer_notify_clear_focus(seat);
+  wlr_seat_pointer_clear_focus(seat);
   zn_cursor_start_grab(cursor, &self->base);
 }

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -3,6 +3,7 @@
 #include "zen-common.h"
 
 static void zn_cursor_grab_move_end(struct zn_cursor_grab_move* self);
+static void move_grab_cancel(struct zn_cursor_grab* grab);
 
 static void
 move_grab_motion(
@@ -49,6 +50,13 @@ move_grab_frame(struct zn_cursor_grab* grab)
 }
 
 static void
+move_grab_rebase(struct zn_cursor_grab* grab)
+{
+  // the board which the view is located is changed
+  move_grab_cancel(grab);
+}
+
+static void
 move_grab_cancel(struct zn_cursor_grab* grab)
 {
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
@@ -61,6 +69,7 @@ static const struct zn_cursor_grab_interface move_grab_interface = {
     .button = move_grab_button,
     .axis = move_grab_axis,
     .frame = move_grab_frame,
+    .rebase = move_grab_rebase,
     .cancel = move_grab_cancel,
 };
 

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -72,6 +72,8 @@ zn_cursor_grab_move_end(struct zn_cursor_grab_move* self)
 void
 zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
 {
+  struct zn_server* server = zn_server_get_singleton();
+  struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
   struct wlr_fbox cursor_box, view_box;
   struct zn_cursor_grab_move* self;
   self = zalloc(sizeof *self);
@@ -88,10 +90,10 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
   self->diff_x = view_box.x - cursor_box.x;
   self->diff_y = view_box.y - cursor_box.y;
   self->view = view;
-  self->prev_screen = cursor->screen;
   self->base.interface = &move_grab_interface;
   self->base.cursor = cursor;
 
   zn_cursor_set_xcursor(cursor, "grabbing");
+  wlr_seat_pointer_notify_clear_focus(seat);
   zn_cursor_start_grab(cursor, &self->base);
 }

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -8,8 +8,11 @@ static void
 move_grab_motion(
     struct zn_cursor_grab* grab, struct wlr_event_pointer_motion* event)
 {
-  UNUSED(grab);
   UNUSED(event);
+  struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
+
+  zn_view_move(self->view, grab->cursor->x + self->diff_x,
+      grab->cursor->y + self->diff_y);
 }
 
 static void
@@ -54,6 +57,7 @@ zn_cursor_grab_move_end(struct zn_cursor_grab_move* self)
 void
 zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
 {
+  struct wlr_fbox cursor_box, view_box;
   struct zn_cursor_grab_move* self;
   self = zalloc(sizeof *self);
 
@@ -62,6 +66,10 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
     return;
   }
 
+  zn_cursor_get_fbox(cursor, &cursor_box);
+  zn_view_get_surface_fbox(view, &view_box);
+  self->diff_x = view_box.x - cursor_box.x;
+  self->diff_y = view_box.y - cursor_box.y;
   self->view = view;
   self->base.interface = &move_grab_interface;
   self->base.cursor = cursor;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -12,10 +12,6 @@ move_grab_motion(
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
   struct zn_board* board = self->view->board;
 
-  if (!grab->cursor->screen) {
-    return;
-  }
-
   if (self->prev_screen) {
     if (grab->cursor->screen != self->prev_screen) {
       board = grab->cursor->screen->current_board;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -11,8 +11,13 @@ move_grab_motion(
   UNUSED(event);
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
 
+  if (grab->cursor->screen != self->prev_screen) {
+    zn_view_change_board(self->view, grab->cursor->screen->current_board);
+  }
+
   zn_view_move(self->view, grab->cursor->x + self->diff_x,
       grab->cursor->y + self->diff_y);
+  self->prev_screen = grab->cursor->screen;
 }
 
 static void
@@ -71,6 +76,7 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
   self->diff_x = view_box.x - cursor_box.x;
   self->diff_y = view_box.y - cursor_box.y;
   self->view = view;
+  self->prev_screen = cursor->screen;
   self->base.interface = &move_grab_interface;
   self->base.cursor = cursor;
 

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -95,6 +95,7 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
   }
 
   zn_view_get_surface_fbox(view, &view_box);
+  self->prev_screen = cursor->screen;
   self->init_board = view->board;
   self->init_x = view_box.x;
   self->init_y = view_box.y;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -45,11 +45,20 @@ move_grab_frame(struct zn_cursor_grab* grab)
   UNUSED(grab);
 }
 
+static void
+move_grab_cancel(struct zn_cursor_grab* grab)
+{
+  struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
+  zn_view_move(self->view, self->init_x, self->init_y);
+  zn_cursor_grab_move_end(self);
+}
+
 static const struct zn_cursor_grab_interface move_grab_interface = {
     .motion = move_grab_motion,
     .button = move_grab_button,
     .axis = move_grab_axis,
     .frame = move_grab_frame,
+    .cancel = move_grab_cancel,
 };
 
 void
@@ -74,6 +83,8 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
 
   zn_cursor_get_fbox(cursor, &cursor_box);
   zn_view_get_surface_fbox(view, &view_box);
+  self->init_x = view_box.x;
+  self->init_y = view_box.y;
   self->diff_x = view_box.x - cursor_box.x;
   self->diff_y = view_box.y - cursor_box.y;
   self->view = view;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -2,7 +2,7 @@
 
 #include "zen-common.h"
 
-void zn_cursor_grab_move_end(struct zn_cursor_grab_move* self);
+static void zn_cursor_grab_move_end(struct zn_cursor_grab_move* self);
 
 static void
 move_grab_motion(
@@ -102,7 +102,7 @@ zn_cursor_grab_move_create(struct zn_cursor* cursor, struct zn_view* view)
 
   if (self == NULL) {
     zn_error("Failed to allocate memory");
-    return;
+    return NULL;
   }
 
   zn_view_get_surface_fbox(view, &view_box);
@@ -122,6 +122,8 @@ zn_cursor_grab_move_create(struct zn_cursor* cursor, struct zn_view* view)
   self->prev_screen_destroy_listener.notify =
       zn_cursor_grab_move_handle_prev_screen_destroy;
   wl_list_init(&self->prev_screen_destroy_listener.link);
+
+  return self;
 }
 
 static void

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -10,13 +10,14 @@ move_grab_motion(
 {
   UNUSED(event);
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
+  struct zn_board* board = self->view->board;
 
   if (grab->cursor->screen != self->prev_screen) {
-    zn_view_change_board(self->view, grab->cursor->screen->current_board);
+    board = grab->cursor->screen->current_board;
   }
 
   zn_view_move(self->view, grab->cursor->x + self->diff_x,
-      grab->cursor->y + self->diff_y);
+      grab->cursor->y + self->diff_y, board);
   self->prev_screen = grab->cursor->screen;
 }
 
@@ -49,7 +50,7 @@ static void
 move_grab_cancel(struct zn_cursor_grab* grab)
 {
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
-  zn_view_move(self->view, self->init_x, self->init_y);
+  zn_view_move(self->view, self->init_x, self->init_y, self->init_board);
   zn_cursor_grab_move_end(self);
 }
 
@@ -94,6 +95,7 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
   }
 
   zn_view_get_surface_fbox(view, &view_box);
+  self->init_board = view->board;
   self->init_x = view_box.x;
   self->init_y = view_box.y;
   self->diff_x = view_box.x - cursor->x;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -1,0 +1,70 @@
+#include "zen/input/cursor-grab-move.h"
+
+#include "zen-common.h"
+
+void zn_cursor_grab_move_end(struct zn_cursor_grab_move* self);
+
+static void
+move_grab_motion(
+    struct zn_cursor_grab* grab, struct wlr_event_pointer_motion* event)
+{
+  UNUSED(grab);
+  UNUSED(event);
+}
+
+static void
+move_grab_button(
+    struct zn_cursor_grab* grab, struct wlr_event_pointer_button* event)
+{
+  struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
+
+  if (event->state == WLR_BUTTON_RELEASED) {
+    zn_cursor_grab_move_end(self);
+  }
+}
+
+static void
+move_grab_axis(
+    struct zn_cursor_grab* grab, struct wlr_event_pointer_axis* event)
+{
+  UNUSED(grab);
+  UNUSED(event);
+}
+
+static void
+move_grab_frame(struct zn_cursor_grab* grab)
+{
+  UNUSED(grab);
+}
+
+static const struct zn_cursor_grab_interface move_grab_interface = {
+    .motion = move_grab_motion,
+    .button = move_grab_button,
+    .axis = move_grab_axis,
+    .frame = move_grab_frame,
+};
+
+void
+zn_cursor_grab_move_end(struct zn_cursor_grab_move* self)
+{
+  zn_cursor_end_grab(self->base.cursor);
+  free(self);
+}
+
+void
+zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
+{
+  struct zn_cursor_grab_move* self;
+  self = zalloc(sizeof *self);
+
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    return;
+  }
+
+  self->view = view;
+  self->base.interface = &move_grab_interface;
+  self->base.cursor = cursor;
+
+  zn_cursor_start_grab(cursor, &self->base);
+}

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -52,8 +52,11 @@ move_grab_frame(struct zn_cursor_grab* grab)
 static void
 move_grab_rebase(struct zn_cursor_grab* grab)
 {
-  // the board which the view is located is changed
-  move_grab_cancel(grab);
+  struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
+  struct zn_board* board = zn_screen_get_current_board(grab->cursor->screen);
+  zn_view_move(self->view, board, grab->cursor->x + self->diff_x,
+      grab->cursor->y + self->diff_y);
+  zn_cursor_grab_move_end(self);
 }
 
 static void

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -73,6 +73,16 @@ zn_cursor_grab_move_handle_view_unmap(struct wl_listener* listener, void* data)
   zn_cursor_grab_move_end(self);
 }
 
+static void
+zn_cursor_grab_move_handle_init_board_destroy(
+    struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zn_cursor_grab_move* self =
+      zn_container_of(listener, self, view_unmap_listener);
+  move_grab_cancel(&self->base);
+}
+
 static struct zn_cursor_grab_move*
 zn_cursor_grab_move_create(struct zn_cursor* cursor, struct zn_view* view)
 {
@@ -98,6 +108,11 @@ zn_cursor_grab_move_create(struct zn_cursor* cursor, struct zn_view* view)
   self->view_unmap_listener.notify = zn_cursor_grab_move_handle_view_unmap;
   wl_signal_add(&view->events.unmap, &self->view_unmap_listener);
 
+  self->init_board_destroy_listener.notify =
+      zn_cursor_grab_move_handle_init_board_destroy;
+  wl_signal_add(
+      &view->board->events.destroy, &self->init_board_destroy_listener);
+
   return self;
 }
 
@@ -105,6 +120,7 @@ static void
 zn_cursor_grab_move_destroy(struct zn_cursor_grab_move* self)
 {
   wl_list_remove(&self->view_unmap_listener.link);
+  wl_list_remove(&self->init_board_destroy_listener.link);
   free(self);
 }
 

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -84,7 +84,7 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
 {
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
-  struct wlr_fbox cursor_box, view_box;
+  struct wlr_fbox view_box;
   struct zn_cursor_grab_move* self;
   self = zalloc(sizeof *self);
 
@@ -93,12 +93,11 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
     return;
   }
 
-  zn_cursor_get_fbox(cursor, &cursor_box);
   zn_view_get_surface_fbox(view, &view_box);
   self->init_x = view_box.x;
   self->init_y = view_box.y;
-  self->diff_x = view_box.x - cursor_box.x;
-  self->diff_y = view_box.y - cursor_box.y;
+  self->diff_x = view_box.x - cursor->x;
+  self->diff_y = view_box.y - cursor->y;
   self->view = view;
   self->base.interface = &move_grab_interface;
   self->base.cursor = cursor;

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -56,7 +56,6 @@ move_grab_rebase(struct zn_cursor_grab* grab)
   struct zn_board* board = zn_screen_get_current_board(grab->cursor->screen);
   zn_view_move(self->view, board, grab->cursor->x + self->diff_x,
       grab->cursor->y + self->diff_y);
-  zn_cursor_grab_move_end(self);
 }
 
 static void

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -19,8 +19,8 @@ move_grab_motion(
     wl_list_remove(&self->prev_screen_destroy_listener.link);
   }
 
-  zn_view_move(self->view, grab->cursor->x + self->diff_x,
-      grab->cursor->y + self->diff_y, board);
+  zn_view_move(self->view, board, grab->cursor->x + self->diff_x,
+      grab->cursor->y + self->diff_y);
 
   self->prev_screen = grab->cursor->screen;
   wl_signal_add(&grab->cursor->screen->events.destroy,
@@ -56,7 +56,7 @@ static void
 move_grab_cancel(struct zn_cursor_grab* grab)
 {
   struct zn_cursor_grab_move* self = zn_container_of(grab, self, base);
-  zn_view_move(self->view, self->init_x, self->init_y, self->init_board);
+  zn_view_move(self->view, self->init_board, self->init_x, self->init_y);
   zn_cursor_grab_move_end(self);
 }
 

--- a/zen/input/pointer.c
+++ b/zen/input/pointer.c
@@ -17,7 +17,6 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
   struct wlr_event_pointer_motion* event = data;
 
-  zn_cursor_move_relative(cursor, event->delta_x, event->delta_y);
   cursor->grab->interface->motion(cursor->grab, event);
 }
 

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -11,6 +11,7 @@ _zen_desktop_srcs = [
   'xdg-toplevel-view.c',
   'xwayland-view.c',
 
+  'input/cursor-grab-move.c',
   'input/input-device.c',
   'input/input-manager.c',
   'input/keyboard.c',

--- a/zen/scene/board.c
+++ b/zen/scene/board.c
@@ -87,6 +87,7 @@ zn_board_create(struct zn_scene *scene)
   wl_list_init(&self->screen_destroy_listener.link);
 
   wl_signal_init(&self->events.screen_assigned);
+  wl_signal_init(&self->events.destroy);
 
   return self;
 
@@ -97,6 +98,7 @@ err:
 void
 zn_board_destroy(struct zn_board *self)
 {
+  wl_signal_emit(&self->events.destroy, NULL);
   zn_board_assign_to_screen(self, NULL);
   wl_list_remove(&self->view_list);
   wl_list_remove(&self->link);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -153,6 +153,7 @@ void
 zn_screen_set_current_board(struct zn_screen *self, struct zn_board *board)
 {
   struct zn_server *server = zn_server_get_singleton();
+  struct zn_cursor *cursor = server->input_manager->seat->cursor;
   struct zn_view *view;
 
   if (self->current_board == board) {
@@ -181,7 +182,9 @@ zn_screen_set_current_board(struct zn_screen *self, struct zn_board *board)
 
   self->current_board = board;
 
-  // TODO: rebase pointer
+  if (self == cursor->screen) {
+    cursor->grab->interface->rebase(cursor->grab);
+  }
 
   zn_output_add_damage_whole(self->output);
 }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -10,8 +10,8 @@
 #include "zen/xwayland-view.h"
 
 void
-zn_view_move(
-    struct zn_view *self, double x, double y, struct zn_board *new_board)
+zn_view_move(struct zn_view *self, struct zn_board *new_board, double board_x,
+    double board_y)
 {
   zn_view_damage_whole(self);
 
@@ -26,11 +26,11 @@ zn_view_move(
     self->board = new_board;
   }
 
-  self->x = x;
-  self->y = y;
+  self->x = board_x;
+  self->y = board_y;
 
   if (self->impl->configure) {
-    self->impl->configure(self, x, y);
+    self->impl->configure(self, board_x, board_y);
   }
 
   zn_view_damage_whole(self);
@@ -140,8 +140,8 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
   self->board = board;
 
   zn_view_get_window_fbox(self, &fbox);
-  zn_view_move(self, (board->width - fbox.width) / 2,
-      (board->height - fbox.height) / 2, self->board);
+  zn_view_move(self, self->board, (board->width - fbox.width) / 2,
+      (board->height - fbox.height) / 2);
 
   self->board = board;
   wl_list_insert(board->view_list.prev, &self->link);
@@ -157,7 +157,7 @@ zn_view_unmap(struct zn_view *self)
 
   zn_view_damage_whole(self);
 
-  zn_view_move(self, 0, 0, NULL);
+  zn_view_move(self, NULL, 0, 0);
 }
 
 void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -138,6 +138,8 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
 
   // TODO: handle board destruction
 
+  self->board = board;
+
   zn_view_get_window_fbox(self, &fbox);
   zn_view_move(self, (board->width - fbox.width) / 2,
       (board->height - fbox.height) / 2, self->board);

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -137,14 +137,10 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
 
   // TODO: handle board destruction
 
-  self->board = board;
-
   zn_view_get_window_fbox(self, &fbox);
-  zn_view_move(self, self->board, (board->width - fbox.width) / 2,
+  zn_view_move(self, board, (board->width - fbox.width) / 2,
       (board->height - fbox.height) / 2);
 
-  self->board = board;
-  wl_list_insert(board->view_list.prev, &self->link);
   zn_scene_set_focused_view(scene, self);
 
   zn_view_damage_whole(self);

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -99,6 +99,19 @@ zn_view_get_window_fbox(struct zn_view *self, struct wlr_fbox *fbox)
   fbox->height = view_geometry.height;
 }
 
+void
+zn_view_change_board(struct zn_view *self, struct zn_board *new_board)
+{
+  zn_view_damage_whole(self);
+
+  wl_list_remove(&self->link);
+  wl_list_init(&self->link);
+  wl_list_insert(new_board->view_list.prev, &self->link);
+  self->board = new_board;
+
+  zn_view_damage_whole(self);
+}
+
 bool
 zn_view_is_mapped(struct zn_view *self)
 {

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -9,15 +9,19 @@
 #include "zen/xdg-toplevel-view.h"
 #include "zen/xwayland-view.h"
 
-static void
+void
 zn_view_move(struct zn_view *self, double x, double y)
 {
+  zn_view_damage_whole(self);
+
   self->x = x;
   self->y = y;
 
   if (self->impl->configure) {
     self->impl->configure(self, x, y);
   }
+
+  zn_view_damage_whole(self);
 }
 
 static void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -20,6 +20,7 @@ zn_view_move(
       wl_list_remove(&self->link);
       wl_list_init(&self->link);
     }
+    // new_board is NULL only when unmapping
     if (new_board) {
       wl_list_insert(new_board->view_list.prev, &self->link);
     }
@@ -155,10 +156,7 @@ zn_view_unmap(struct zn_view *self)
 
   zn_view_damage_whole(self);
 
-  self->board = NULL;
-
-  wl_list_remove(&self->link);
-  wl_list_init(&self->link);
+  zn_view_move(self, 0, 0, NULL);
 }
 
 void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -20,7 +20,6 @@ zn_view_move(
       wl_list_remove(&self->link);
       wl_list_init(&self->link);
     }
-    // new_board is NULL only when unmapping
     if (new_board) {
       wl_list_insert(new_board->view_list.prev, &self->link);
     }

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -51,6 +51,9 @@ zn_xdg_toplevel_view_unmap(struct wl_listener* listener, void* data)
 
   zn_view_unmap(&self->base);
 
+  wl_list_remove(&self->move_listener.link);
+  wl_list_init(&self->move_listener.link);
+
   wl_list_remove(&self->wlr_surface_commit_listener.link);
   wl_list_init(&self->wlr_surface_commit_listener.link);
 }
@@ -173,6 +176,7 @@ zn_xdg_toplevel_view_destroy(struct zn_xdg_toplevel_view* self)
 {
   wl_list_remove(&self->wlr_xdg_surface_destroy_listener.link);
   wl_list_remove(&self->wlr_surface_commit_listener.link);
+  wl_list_remove(&self->move_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->unmap_listener.link);
   zn_view_fini(&self->base);

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -32,6 +32,8 @@ zn_xdg_toplevel_view_map(struct wl_listener* listener, void* data)
 
   zn_view_map_to_scene(&self->base, scene);
 
+  wl_signal_add(
+      &self->wlr_xdg_toplevel->events.request_move, &self->move_listener);
   wl_signal_add(&self->wlr_xdg_toplevel->base->surface->events.commit,
       &self->wlr_surface_commit_listener);
 }
@@ -148,8 +150,7 @@ zn_xdg_toplevel_view_create(
       &self->wlr_xdg_toplevel->base->events.unmap, &self->unmap_listener);
 
   self->move_listener.notify = zn_xdg_toplevel_view_move_handler;
-  wl_signal_add(
-      &self->wlr_xdg_toplevel->events.request_move, &self->move_listener);
+  wl_list_init(&self->move_listener.link);
 
   self->wlr_xdg_surface_destroy_listener.notify =
       zn_xdg_toplevel_view_wlr_xdg_surface_destroy_handler;

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -58,6 +58,7 @@ zn_xdg_toplevel_view_unmap(struct wl_listener* listener, void* data)
 static void
 zn_xdg_toplevel_view_move_handler(struct wl_listener* listener, void* data)
 {
+  // FIXME: pointer/button/serial validation
   UNUSED(data);
   struct zn_xdg_toplevel_view* self =
       zn_container_of(listener, self, move_listener);

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -30,6 +30,8 @@ zn_xwayland_view_map(struct wl_listener* listener, void* data)
 
   zn_view_map_to_scene(&self->base, scene);
 
+  wl_signal_add(
+      &self->wlr_xwayland_surface->events.request_move, &self->move_listener);
   wl_signal_add(&self->wlr_xwayland_surface->surface->events.commit,
       &self->wlr_surface_commit_listener);
 }
@@ -145,8 +147,7 @@ zn_xwayland_view_create(
       &self->wlr_xwayland_surface->events.unmap, &self->unmap_listener);
 
   self->move_listener.notify = zn_xwayland_view_move_handler;
-  wl_signal_add(
-      &self->wlr_xwayland_surface->events.request_move, &self->move_listener);
+  wl_list_init(&self->move_listener.link);
 
   self->wlr_xwayland_surface_destroy_listener.notify =
       zn_xwayland_view_wlr_xwayland_surface_destroy_handler;

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -1,6 +1,7 @@
 #include "zen/xwayland-view.h"
 
 #include "zen-common.h"
+#include "zen/input/cursor-grab-move.h"
 #include "zen/scene/scene.h"
 #include "zen/scene/view.h"
 
@@ -56,6 +57,10 @@ zn_xwayland_view_move_handler(struct wl_listener* listener, void* data)
   UNUSED(data);
   struct zn_xwayland_view* self =
       zn_container_of(listener, self, move_listener);
+  struct zn_server* server = zn_server_get_singleton();
+  struct zn_cursor* cursor = server->input_manager->seat->cursor;
+
+  zn_cursor_grab_move_start(cursor, &self->base);
 }
 
 static void

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -56,6 +56,7 @@ zn_xwayland_view_unmap(struct wl_listener* listener, void* data)
 static void
 zn_xwayland_view_move_handler(struct wl_listener* listener, void* data)
 {
+  // FIXME: pointer/button/serial validation
   UNUSED(data);
   struct zn_xwayland_view* self =
       zn_container_of(listener, self, move_listener);

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -30,6 +30,9 @@ zn_xwayland_view_map(struct wl_listener* listener, void* data)
 
   zn_view_map_to_scene(&self->base, scene);
 
+  wl_list_remove(&self->move_listener.link);
+  wl_list_init(&self->move_listener.link);
+
   wl_signal_add(
       &self->wlr_xwayland_surface->events.request_move, &self->move_listener);
   wl_signal_add(&self->wlr_xwayland_surface->surface->events.commit,
@@ -170,6 +173,7 @@ zn_xwayland_view_destroy(struct zn_xwayland_view* self)
 {
   wl_list_remove(&self->wlr_xwayland_surface_destroy_listener.link);
   wl_list_remove(&self->wlr_surface_commit_listener.link);
+  wl_list_remove(&self->move_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->unmap_listener.link);
   zn_view_fini(&self->base);

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -51,6 +51,14 @@ zn_xwayland_view_unmap(struct wl_listener* listener, void* data)
 }
 
 static void
+zn_xwayland_view_move_handler(struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zn_xwayland_view* self =
+      zn_container_of(listener, self, move_listener);
+}
+
+static void
 zn_xwayland_view_wlr_xwayland_surface_destroy_handler(
     struct wl_listener* listener, void* data)
 {
@@ -130,6 +138,10 @@ zn_xwayland_view_create(
   self->unmap_listener.notify = zn_xwayland_view_unmap;
   wl_signal_add(
       &self->wlr_xwayland_surface->events.unmap, &self->unmap_listener);
+
+  self->move_listener.notify = zn_xwayland_view_move_handler;
+  wl_signal_add(
+      &self->wlr_xwayland_surface->events.request_move, &self->move_listener);
 
   self->wlr_xwayland_surface_destroy_listener.notify =
       zn_xwayland_view_wlr_xwayland_surface_destroy_handler;


### PR DESCRIPTION
## Context

Move the view by the cursor.

## Summary

Add `zn_cursor_grab_move`.

## How to check behavior

1. start zen and some wayland client
2. drag the top of the view - the view is moved
3. drag between screens - the view is moved between boards