### PR TITLE
insert new views to the tail of the view_list

### DIFF
--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -97,7 +97,7 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
       self, (board->width - fbox.width) / 2, (board->height - fbox.height) / 2);
 
   self->board = board;
-  wl_list_insert(&board->view_list, &self->link);
+  wl_list_insert((&board->view_list)->prev, &self->link);
   zn_scene_set_focused_view(scene, self);
 
   zn_view_damage_whole(self);


### PR DESCRIPTION
## Context
#125
## Summary
When a new view is mapped to the scene with `zn_view_map_to_scene`, insert the view to the tail of the `view_list` so that the newest view is shown on the top of the view stack.
## How to check behavior
Run
```
zen-desktop -c weston-terminal
WAYLAND_DISPLAY=wayland-1 weston-flower
```
and confirm that the weston-flower client is shown on top of the terrminal.