### PR TITLE
fix assigning view's position process

### DIFF
--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -24,7 +24,7 @@ enum zn_view_type {
 };
 
 struct zn_view {
-  double x, y;
+  double surface_x, surface_y;
 
   enum zn_view_type type;
 

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -40,10 +40,10 @@ zn_screen_get_view_at(
 
     if (zn_wlr_fbox_contains_point(&fbox, x, y)) {
       if (view_x != NULL) {
-        *view_x = x - view->x;
+        *view_x = x - view->surface_x;
       }
       if (view_y != NULL) {
-        *view_y = y - view->y;
+        *view_y = y - view->surface_y;
       }
       return view;
     }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -12,8 +12,13 @@
 static void
 zn_view_move(struct zn_view *self, double x, double y)
 {
-  self->x = x;
-  self->y = y;
+  struct wlr_box view_geometry;
+
+  zn_view_damage_whole(self);
+
+  self->impl->get_geometry(self, &view_geometry);
+  self->x = x - view_geometry.x;
+  self->y = y - view_geometry.y;
 
   if (self->impl->configure) {
     self->impl->configure(self, x, y);

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -9,19 +9,19 @@
 #include "zen/xdg-toplevel-view.h"
 #include "zen/xwayland-view.h"
 
-static void
-zn_view_move(struct zn_view *self, double x, double y)
+void
+zn_view_move(struct zn_view *self, double window_x, double window_y)
 {
   struct wlr_box view_geometry;
 
   zn_view_damage_whole(self);
 
   self->impl->get_geometry(self, &view_geometry);
-  self->x = x - view_geometry.x;
-  self->y = y - view_geometry.y;
+  self->surface_x = window_x - view_geometry.x;
+  self->surface_y = window_y - view_geometry.y;
 
   if (self->impl->configure) {
-    self->impl->configure(self, x, y);
+    self->impl->configure(self, window_x, window_y);
   }
 }
 
@@ -53,8 +53,8 @@ zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 {
   struct wlr_surface *surface = self->impl->get_wlr_surface(self);
 
-  fbox->x = self->x;
-  fbox->y = self->y;
+  fbox->x = self->surface_x;
+  fbox->y = self->surface_y;
   fbox->width = surface->current.width;
   fbox->height = surface->current.height;
 }
@@ -65,8 +65,8 @@ zn_view_get_window_fbox(struct zn_view *self, struct wlr_fbox *fbox)
   struct wlr_box view_geometry;
   self->impl->get_geometry(self, &view_geometry);
 
-  fbox->x = view_geometry.x + self->x;
-  fbox->y = view_geometry.y + self->y;
+  fbox->x = view_geometry.x + self->surface_x;
+  fbox->y = view_geometry.y + self->surface_y;
   fbox->width = view_geometry.width;
   fbox->height = view_geometry.height;
 }

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -52,8 +52,8 @@ zn_screen_renderer_get_surface_fbox(struct wlr_surface *surface,
     struct zn_view *view, int surface_x, int surface_y,
     struct wlr_fbox *surface_box)
 {
-  surface_box->x = view->x + surface_x;
-  surface_box->y = view->y + surface_y;
+  surface_box->x = view->surface_x + surface_x;
+  surface_box->y = view->surface_y + surface_y;
   surface_box->width = surface->current.width;
   surface_box->height = surface->current.height;
 }


### PR DESCRIPTION
## Context

See #147

## Summary

Use view's geometry.

## How to check behavior

Move the view to any position, and check that there is no difference between specified pos and appeared pos. 

try: edit `view.c@zn_view_map_to_scene` like following:
```diff
  zn_view_move(
-      self, (board->width - fbox.width) / 2, (board->height - fbox.height) / 2);
+      self, 0, 0);
       // or
+      self, (board->width - fbox.width), (board->height - fbox.height));
```
