### PR TITLE
fix header include

### DIFF
--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -1,6 +1,6 @@
 #include "zen/cursor.h"
 
-#include <drm/drm_fourcc.h>
+#include <drm_fourcc.h>
 #include <linux/input.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_output_damage.h>


### PR DESCRIPTION
## Context

DRM headers seem to be located in different paths depending on the developers' environment.
I, at least, confirmed two locations.
- /usr/include/libdrm
- /usr/include/drm

`pkgconfig` absorb the difference by setting the Cflags `-I/usr/include/libdrm` or `-I/usr/include/drm`, so we should not do
```c
#include <libdrm/drm.h>
```

instead, do
```c
#include <drm.h>
```

## Summary

- [x] fix header include

## How to check behavior

No change