### PR TITLE
replace #ifndef and #define by #pragma once

### DIFF
--- a/common/include/zen-common.h
+++ b/common/include/zen-common.h
@@ -1,8 +1,5 @@
-#ifndef ZEN_COMMON_H
-#define ZEN_COMMON_H
+#pragma once
 
 #include "zen-common/log.h"
 #include "zen-common/timespec-util.h"
 #include "zen-common/util.h"
-
-#endif  //  ZEN_COMMON_H

--- a/common/include/zen-common/log.h
+++ b/common/include/zen-common/log.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_LOG_H
-#define ZEN_LOG_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,5 +63,3 @@ bool _zn_assert(bool condition, const char *format, ...) ATTRIB_PRINTF(2, 3);
 #ifdef __cplusplus
 }
 #endif
-
-#endif  //  ZEN_LOG_H

--- a/common/include/zen-common/timespec-util.h
+++ b/common/include/zen-common/timespec-util.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_TIMESPEC_UTIL_H
-#define ZEN_TIMESPEC_UTIL_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,5 +40,3 @@ timespec_to_nsec(const struct timespec *a)
 #ifdef __cplusplus
 }
 #endif
-
-#endif  //  ZEN_TIMESPEC_UTIL_H

--- a/common/include/zen-common/util.h
+++ b/common/include/zen-common/util.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_UTIL_H
-#define ZEN_UTIL_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,5 +48,3 @@ zalloc(size_t size)
 #ifdef __cplusplus
 }
 #endif
-
-#endif  //  ZEN_UTIL_H

--- a/include/zen/backend/immersive.h
+++ b/include/zen/backend/immersive.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_IMMERSIVE_BACKEND_H
-#define ZEN_IMMERSIVE_BACKEND_H
+#pragma once
 
 #include <wayland-server-core.h>
 
@@ -27,5 +26,3 @@ void zn_immersive_backend_destroy(struct zn_immersive_backend* self);
 #ifdef __cplusplus
 }
 #endif
-
-#endif  //  ZEN_IMMERSIVE_BACKEND_H

--- a/include/zen/binding.h
+++ b/include/zen/binding.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_BINDING_H
-#define ZEN_BINDING_H
+#pragma once
 
 #include <wayland-server.h>
 
@@ -28,5 +27,3 @@ struct zn_binding *zn_binding_create(uint32_t key, uint32_t modifiers,
     zn_key_binding_handler_t handler, void *data);
 
 void zn_binding_destroy(struct zn_binding *self);
-
-#endif  //  ZEN_BINDING_H

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_CURSOR_H
-#define ZEN_CURSOR_H
+#pragma once
 
 #include <wayland-server.h>
 #include <wlr/render/wlr_texture.h>
@@ -51,5 +50,3 @@ void zn_cursor_set_xcursor(struct zn_cursor* self, const char* name);
 struct zn_cursor* zn_cursor_create(void);
 
 void zn_cursor_destroy(struct zn_cursor* self);
-
-#endif  // ZEN_CURSOR_H

--- a/include/zen/display-system.h
+++ b/include/zen/display-system.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_DISPLAY_SYSTEM_H
-#define ZEN_DISPLAY_SYSTEM_H
+#pragma once
 
 #include <wayland-server-core.h>
 #include <zen-desktop-protocol.h>
@@ -25,5 +24,3 @@ void zn_display_system_applied(
 struct zn_display_system* zn_display_system_create(struct wl_display* display);
 
 void zn_display_system_destroy(struct zn_display_system* self);
-
-#endif  //  ZEN_DISPLAY_SYSTEM_H

--- a/include/zen/input/cursor-grab-move.h
+++ b/include/zen/input/cursor-grab-move.h
@@ -1,5 +1,4 @@
-#ifndef ZN_CURSOR_GRAB_MOVE_H
-#define ZN_CURSOR_GRAB_MOVE_H
+#pragma once
 
 #include "zen/cursor.h"
 #include "zen/input/cursor-grab.h"
@@ -18,5 +17,3 @@ struct zn_cursor_grab_move {
 };
 
 void zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view);
-
-#endif  //  ZN_CURSOR_GRAB_MOVE_H

--- a/include/zen/input/cursor-grab.h
+++ b/include/zen/input/cursor-grab.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_CURSOR_GRUB_H
-#define ZEN_CURSOR_GRUB_H
+#pragma once
 
 #include <wayland-server.h>
 #include <wlr/interfaces/wlr_pointer.h>
@@ -25,5 +24,3 @@ struct zn_cursor_grab {
   const struct zn_cursor_grab_interface* interface;
   struct zn_cursor* cursor;
 };
-
-#endif  // ZEN_CURSOR_GRUB_H

--- a/include/zen/input/input-device.h
+++ b/include/zen/input/input-device.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_INPUT_DEVICE_H
-#define ZEN_INPUT_DEVICE_H
+#pragma once
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
@@ -23,5 +22,3 @@ struct zn_input_device* zn_input_device_create(
     struct zn_seat* seat, struct wlr_input_device* wlr_input);
 
 void zn_input_device_destroy(struct zn_input_device* self);
-
-#endif  // ZEN_INPUT_DEVICE_H

--- a/include/zen/input/input-manager.h
+++ b/include/zen/input/input-manager.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_INPUT_MANAGER_H
-#define ZEN_INPUT_MANAGER_H
+#pragma once
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
@@ -33,5 +32,3 @@ void zn_input_manager_handle_new_wlr_input(
 struct zn_input_manager* zn_input_manager_create(struct wl_display* display);
 
 void zn_input_manager_destroy(struct zn_input_manager* self);
-
-#endif  // ZEN_INPUT_MANAGER_H

--- a/include/zen/input/keyboard.h
+++ b/include/zen/input/keyboard.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_KEYBOARD_H
-#define ZEN_KEYBOARD_H
+#pragma once
 
 #include <wayland-server.h>
 
@@ -17,5 +16,3 @@ struct zn_keyboard* zn_keyboard_create(
     struct zn_input_device* input_device, struct zn_seat* seat);
 
 void zn_keyboard_destroy(struct zn_keyboard* self);
-
-#endif  // ZEN_KEYBOARD_H

--- a/include/zen/input/pointer.h
+++ b/include/zen/input/pointer.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_POINTER_H
-#define ZEN_POINTER_H
+#pragma once
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_input_device.h>
@@ -14,5 +13,3 @@ struct zn_pointer {
 struct zn_pointer* zn_pointer_create(struct wlr_input_device* input_device);
 
 void zn_pointer_destroy(struct zn_pointer* self);
-
-#endif  // ZEN_POINTER_H

--- a/include/zen/input/seat.h
+++ b/include/zen/input/seat.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_SEAT_H
-#define ZEN_SEAT_H
+#pragma once
 
 #include <wayland-server.h>
 
@@ -30,5 +29,3 @@ struct zn_seat* zn_seat_create(
     struct wl_display* display, const char* seat_name);
 
 void zn_seat_destroy(struct zn_seat* self);
-
-#endif  // ZEN_SEAT_H

--- a/include/zen/output.h
+++ b/include/zen/output.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_OUTPUT_H
-#define ZEN_OUTPUT_H
+#pragma once
 
 #include <wlr/types/wlr_output.h>
 
@@ -37,5 +36,3 @@ void zn_output_update_global(struct zn_output *self);
 
 struct zn_output *zn_output_create(
     struct wlr_output *wlr_output, struct zn_server *server);
-
-#endif  //  ZEN_OUTPUT_H

--- a/include/zen/scene/board.h
+++ b/include/zen/scene/board.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_BOARD_H
-#define ZEN_BOARD_H
+#pragma once
 
 #include <wayland-server-core.h>
 
@@ -42,5 +41,3 @@ void zn_board_assign_to_screen(struct zn_board *self, struct zn_screen *screen);
 struct zn_board *zn_board_create(struct zn_scene *scene);
 
 void zn_board_destroy(struct zn_board *self);
-
-#endif  //  ZEN_BOARD_H

--- a/include/zen/scene/scene.h
+++ b/include/zen/scene/scene.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_SCENE_H
-#define ZEN_SCENE_H
+#pragma once
 
 #include <wayland-server-core.h>
 
@@ -26,5 +25,3 @@ void zn_scene_setup_bindings(struct zn_scene* self);
 struct zn_scene* zn_scene_create(void);
 
 void zn_scene_destroy(struct zn_scene* self);
-
-#endif  //  ZEN_SCENE_H

--- a/include/zen/scene/screen-layout.h
+++ b/include/zen/scene/screen-layout.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_SCREEN_LAYOUT_H
-#define ZEN_SCREEN_LAYOUT_H
+#pragma once
 
 #include <wayland-server-core.h>
 
@@ -33,5 +32,3 @@ void zn_screen_layout_remove(
 struct zn_screen_layout* zn_screen_layout_create(struct zn_scene* scene);
 
 void zn_screen_layout_destroy(struct zn_screen_layout* self);
-
-#endif  //  ZEN_SCREEN_LAYOUT_H

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_SCREEN_H
-#define ZEN_SCREEN_H
+#pragma once
 
 #include <wayland-server-core.h>
 #include <wlr/types/wlr_surface.h>
@@ -57,5 +56,3 @@ struct zn_screen *zn_screen_create(
     struct zn_screen_layout *screen_layout, struct zn_output *output);
 
 void zn_screen_destroy(struct zn_screen *self);
-
-#endif  //  ZEN_SCREEN_H

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_VIEW_H
-#define ZEN_VIEW_H
+#pragma once
 
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
@@ -67,5 +66,3 @@ void zn_view_init(struct zn_view *self, enum zn_view_type type,
     const struct zn_view_impl *impl);
 
 void zn_view_fini(struct zn_view *self);
-
-#endif  //  ZEN_XDG_VIEW_H

--- a/include/zen/screen-renderer.h
+++ b/include/zen/screen-renderer.h
@@ -1,9 +1,6 @@
-#ifndef ZEN_SCREEN_RENDERER_H
-#define ZEN_SCREEN_RENDERER_H
+#pragma once
 
 #include "zen/scene/screen.h"
 
 void zn_screen_renderer_render(struct zn_screen *screen,
     struct wlr_renderer *renderer, pixman_region32_t *damage);
-
-#endif  //  ZEN_SCREEN_RENDERER_H

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_SERVER_H
-#define ZEN_SERVER_H
+#pragma once
 
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
@@ -55,5 +54,3 @@ void zn_server_terminate(struct zn_server *self, int exit_code);
 struct zn_server *zn_server_create(struct wl_display *display);
 
 void zn_server_destroy(struct zn_server *self);
-
-#endif  //  ZEN_SERVER_H

--- a/include/zen/wlr/box.h
+++ b/include/zen/wlr/box.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_BOX_H
-#define ZEN_BOX_H
+#pragma once
 
 #include <wlr/util/box.h>
 
@@ -7,5 +6,3 @@ bool zn_wlr_fbox_contains_point(const struct wlr_fbox* box, double x, double y);
 
 void zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,
     double* dest_x, double* dest_y);
-
-#endif  // ZEN_BOX_H

--- a/include/zen/xdg-toplevel-view.h
+++ b/include/zen/xdg-toplevel-view.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_XDG_TOPLEVEL_VIEW_H
-#define ZEN_XDG_TOPLEVEL_VIEW_H
+#pragma once
 
 #include <wlr/types/wlr_xdg_shell.h>
 
@@ -22,5 +21,3 @@ struct zn_xdg_toplevel_view {
 
 struct zn_xdg_toplevel_view *zn_xdg_toplevel_view_create(
     struct wlr_xdg_toplevel *xdg_toplevel, struct zn_server *server);
-
-#endif  //  ZEN_XDG_TOPLEVEL_VIEW_H

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_XWAYLAND_VIEW_H
-#define ZEN_XWAYLAND_VIEW_H
+#pragma once
 
 #include <wlr/xwayland.h>
 
@@ -22,5 +21,3 @@ struct zn_xwayland_view {
 
 struct zn_xwayland_view *zn_xwayland_view_create(
     struct wlr_xwayland_surface *xwayland_surface, struct zn_server *server);
-
-#endif  //  ZEN_XWAYLAND_VIEW_H

--- a/tests/test-runner.h
+++ b/tests/test-runner.h
@@ -1,5 +1,4 @@
-#ifndef TEST_RUNNDER_H
-#define TEST_RUNNDER_H
+#pragma once
 
 struct test {
   const char *name;
@@ -23,5 +22,3 @@ struct test {
       __attribute__((used, section("test_section"))) = {#name, name, 0}; \
                                                                          \
   static void name(void)
-
-#endif  //  TEST_RUNNDER_H

--- a/zen/backend/openvr/vr-system.h
+++ b/zen/backend/openvr/vr-system.h
@@ -1,5 +1,4 @@
-#ifndef ZEN_OPENVR_BACKEND_VR_SYSTEM_H
-#define ZEN_OPENVR_BACKEND_VR_SYSTEM_H
+#pragma once
 
 #include <openvr/openvr.h>
 #include <wayland-server-core.h>
@@ -43,5 +42,3 @@ class VrSystem
 };
 
 }  // namespace zen
-
-#endif  //  ZEN_OPENVR_BACKEND_VR_SYSTEM_H


### PR DESCRIPTION
## Context

<!--
Please provide a link to the relevant issue if exists so that reviewers can
quickly understand the context.

example:
See zigen-project/.github#8
-->

<!--
If the issue is not well described, add more information here (justification,
pull request links, etc.).
-->

- The existing include guard method is cumbersome and can result in duplicate #define strings due to programmer error.
- Replace the method(using `#ifndef`, `#define`, `#endif`) by [#pragma once](https://en.wikipedia.org/wiki/Pragma_once)

## Summary

<!--
Please write what you did here. If you have made changes to the appearance, it
would be helpful to include images as well.
-->

- Replace the method(using `#ifndef`, `#define`, `#endif`) by [#pragma once](https://en.wikipedia.org/wiki/Pragma_once)
- This pr will be merged after #145 are merged.
  - modify in the same way header files added in #145 .

## How to check behavior

- Check if compilation succeeds.
- Compare `zen-desktop` binary size before and after change.
- run `zen-desktop -s weston-terminal` and it is performing broadly as expected.

<!--
If you added a new feature, please write a way for other developers to easily
check the behavior you have changed or added so that they can catch up with the
changes.
-->
