### PR TITLE
restack view

### DIFF
--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -4,6 +4,7 @@
 #include <wayland-server.h>
 #include <wlr/types/wlr_surface.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <xcb/xproto.h>
 
 #include "zen/scene/scene.h"
 
@@ -16,6 +17,8 @@ struct zn_view_impl {
   void (*for_each_popup_surface)(struct zn_view *view,
       wlr_surface_iterator_func_t iterator, void *user_data);  // nullable
   void (*set_activated)(struct zn_view *view, bool activate);
+  void (*restack)(
+      struct zn_view *view, enum xcb_stack_mode_t mode);  // nullable
 };
 
 enum zn_view_type {
@@ -37,6 +40,8 @@ struct zn_view {
     struct wl_signal unmap;
   } events;
 };
+
+void zn_view_bring_to_front(struct zn_view *self);
 
 /**
  * @param board must not be NULL except when this view is unmapped with

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -83,6 +83,7 @@ zn_scene_set_focused_view(struct zn_scene* self, struct zn_view* view)
 
   if (view != NULL) {
     view->impl->set_activated(view, true);
+    zn_view_bring_to_front(view);
     wl_signal_add(&view->events.unmap, &self->unmap_focused_view_listener);
   }
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -10,6 +10,19 @@
 #include "zen/xwayland-view.h"
 
 void
+zn_view_bring_to_front(struct zn_view *self)
+{
+  wl_list_remove(&self->link);
+  wl_list_insert(self->board->view_list.prev, &self->link);
+
+  if (self->impl->restack) {
+    self->impl->restack(self, XCB_STACK_MODE_ABOVE);
+  }
+
+  zn_view_damage_whole(self);
+}
+
+void
 zn_view_move(struct zn_view *self, struct zn_board *new_board, double board_x,
     double board_y)
 {
@@ -150,6 +163,10 @@ void
 zn_view_unmap(struct zn_view *self)
 {
   wl_signal_emit(&self->events.unmap, NULL);
+
+  if (self->impl->restack) {
+    self->impl->restack(self, XCB_STACK_MODE_BELOW);
+  }
 
   zn_view_damage_whole(self);
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -164,10 +164,6 @@ zn_view_unmap(struct zn_view *self)
 {
   wl_signal_emit(&self->events.unmap, NULL);
 
-  if (self->impl->restack) {
-    self->impl->restack(self, XCB_STACK_MODE_BELOW);
-  }
-
   zn_view_damage_whole(self);
 
   zn_view_move(self, NULL, 0, 0);

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -117,11 +117,20 @@ zn_xwayland_view_impl_configure(struct zn_view* view, double x, double y)
       self->wlr_xwayland_surface, x, y, box.width, box.height);
 }
 
+static void
+zn_xwayland_view_impl_restack(struct zn_view* view, enum xcb_stack_mode_t mode)
+{
+  struct zn_xwayland_view* self = zn_container_of(view, self, base);
+  wlr_xwayland_surface_restack(
+      self->wlr_xwayland_surface, NULL, mode);
+}
+
 static const struct zn_view_impl zn_xwayland_view_impl = {
     .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
     .get_geometry = zn_xwayland_view_impl_get_geometry,
     .set_activated = zn_xwayland_view_impl_set_activated,
     .configure = zn_xwayland_view_impl_configure,
+    .restack = zn_xwayland_view_impl_restack,
 };
 
 struct zn_xwayland_view*


### PR DESCRIPTION
## Context

Currently, the view is focused when clicked, but its order isn't changed.

## Summary

Change the order of the view when the view is clicked.

## How to check behavior

1. start zen with more than two clients
2. click the view one by one
