### PR TITLE
Clang Fromat Check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: editorconfig_linting
+name: Formatting Check
 
 on:
   push:
@@ -9,11 +9,12 @@ on:
       - main
 
 jobs:
-  lint:
+  clang-foramt-check:
+    name: ClangFormat Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Editorconfig Checker
-        uses: editorconfig-checker/action-editorconfig-checker@v1
+      - name: ClangFormat Check
+        run: find . -regex ".*\.\(c\|h\|cc\)" | xargs clang-format --dry-run -Werror

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -121,8 +121,7 @@ static void
 zn_xwayland_view_impl_restack(struct zn_view* view, enum xcb_stack_mode_t mode)
 {
   struct zn_xwayland_view* self = zn_container_of(view, self, base);
-  wlr_xwayland_surface_restack(
-      self->wlr_xwayland_surface, NULL, mode);
+  wlr_xwayland_surface_restack(self->wlr_xwayland_surface, NULL, mode);
 }
 
 static const struct zn_view_impl zn_xwayland_view_impl = {


### PR DESCRIPTION
## Context

We have been using an unused format checker (editorconfig) in GitHub Actions.
Use clang-format for formatting check.

## Summary

- [x] configure format checker in GitHub Actions.
- [x] fix existing format error 

## How to check behavior

None
