### PR TITLE
Send keyboard events

### DIFF
--- a/zen/server.c
+++ b/zen/server.c
@@ -336,7 +336,6 @@ err:
 void
 zn_server_destroy(struct zn_server *self)
 {
-  zn_scene_set_focused_view(self->scene, NULL);
   wlr_xwayland_destroy(self->xwayland);
   zn_input_manager_destroy(self->input_manager);
   zn_display_system_destroy(self->display_system);

--- a/zen/server.c
+++ b/zen/server.c
@@ -336,6 +336,7 @@ err:
 void
 zn_server_destroy(struct zn_server *self)
 {
+  zn_scene_set_focused_view(self->scene, NULL);
   wlr_xwayland_destroy(self->xwayland);
   zn_input_manager_destroy(self->input_manager);
   zn_display_system_destroy(self->display_system);


### PR DESCRIPTION
## Context

Send keyboard events to client

## Summary

focus seat_keyboard to the view's surface

## How to check behavior

1. start zen with any client (reccomend: `weston-terminal`)
2. press any key (try also Tab or arrow key)
3. keyboard events will be sent
