### PR TITLE
add key binding for switching virtual terminal

### DIFF
--- a/zen/main.c
+++ b/zen/main.c
@@ -51,6 +51,29 @@ zn_terminate_binding_handler(uint32_t time_msec, uint32_t key, void *data)
   zn_server_terminate(server, EXIT_SUCCESS);
 }
 
+static void
+zn_switch_vt_handler(uint32_t time_msec, uint32_t key, void* data)
+{
+  UNUSED(data);
+  UNUSED(time_msec);
+
+  if (!zn_assert(KEY_F1 <= key && key <= KEY_F10,
+          "Don't assign this keybind to outside F1-F10")) {
+    return;
+  }
+
+  const unsigned int vt = key - KEY_F1 + 1;
+  struct zn_server* server = zn_server_get_singleton();
+  struct wlr_session* session = wlr_backend_get_session(server->backend);
+
+  if (!session) {
+    return;
+  }
+
+  wlr_session_change_vt(session, vt);
+}
+
+
 static int
 on_term_signal(int signal_number, void *data)
 {
@@ -185,6 +208,11 @@ main(int argc, char *argv[])
   // Terminate the program with a keyboard event for development convenience.
   zn_input_manager_add_key_binding(server->input_manager, KEY_Q,
       WLR_MODIFIER_ALT, zn_terminate_binding_handler, NULL);
+
+  for (int i = KEY_F1; i <= KEY_F10; ++i) {
+    zn_input_manager_add_key_binding(server->input_manager, i,
+        WLR_MODIFIER_CTRL | WLR_MODIFIER_ALT, zn_switch_vt_handler, NULL);
+  }
 
   if (startup_command) {
     startup_command_pid = launch_startup_command(startup_command);

--- a/zen/main.c
+++ b/zen/main.c
@@ -52,7 +52,7 @@ zn_terminate_binding_handler(uint32_t time_msec, uint32_t key, void *data)
 }
 
 static void
-zn_switch_vt_handler(uint32_t time_msec, uint32_t key, void* data)
+zn_switch_vt_handler(uint32_t time_msec, uint32_t key, void *data)
 {
   UNUSED(data);
   UNUSED(time_msec);
@@ -63,8 +63,8 @@ zn_switch_vt_handler(uint32_t time_msec, uint32_t key, void* data)
   }
 
   const unsigned int vt = key - KEY_F1 + 1;
-  struct zn_server* server = zn_server_get_singleton();
-  struct wlr_session* session = wlr_backend_get_session(server->backend);
+  struct zn_server *server = zn_server_get_singleton();
+  struct wlr_session *session = wlr_backend_get_session(server->backend);
 
   if (!session) {
     return;
@@ -72,7 +72,6 @@ zn_switch_vt_handler(uint32_t time_msec, uint32_t key, void* data)
 
   wlr_session_change_vt(session, vt);
 }
-
 
 static int
 on_term_signal(int signal_number, void *data)

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -73,28 +73,6 @@ zn_scene_new_board_binding_handler(uint32_t time_msec, uint32_t key, void* data)
   zn_screen_set_current_board(screen, board);
 }
 
-static void
-zn_scene_switch_vt_handler(uint32_t time_msec, uint32_t key, void* data)
-{
-  UNUSED(data);
-  UNUSED(time_msec);
-
-  if (!zn_assert(KEY_F1 <= key && key <= KEY_F10,
-          "Don't assign this keybind to outside F1-F10")) {
-    return;
-  }
-
-  const unsigned int vt = key - KEY_F1 + 1;
-  struct zn_server* server = zn_server_get_singleton();
-  struct wlr_session* session = wlr_backend_get_session(server->backend);
-
-  if (!session) {
-    return;
-  }
-
-  wlr_session_change_vt(session, vt);
-}
-
 void
 zn_scene_set_focused_view(struct zn_scene* self, struct zn_view* view)
 {
@@ -210,14 +188,6 @@ zn_scene_setup_bindings(struct zn_scene* self)
   zn_input_manager_add_key_binding(server->input_manager, KEY_N,
       WLR_MODIFIER_LOGO | WLR_MODIFIER_SHIFT,
       zn_scene_new_board_binding_handler, self);
-
-  if (wlr_backend_is_multi(server->backend)) {
-    for (int i = KEY_F1; i <= KEY_F10; ++i) {
-      zn_input_manager_add_key_binding(server->input_manager, i,
-          WLR_MODIFIER_CTRL | WLR_MODIFIER_ALT, zn_scene_switch_vt_handler,
-          NULL);
-    }
-  }
 }
 
 static void

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -78,6 +78,12 @@ zn_scene_switch_vt_handler(uint32_t time_msec, uint32_t key, void* data)
 {
   UNUSED(data);
   UNUSED(time_msec);
+
+  if (!zn_assert(KEY_F1 <= key && key <= KEY_F10,
+          "Don't assign this keybind to outside F1-F10")) {
+    return;
+  }
+
   const unsigned int vt = key - KEY_F1 + 1;
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_session* session = wlr_backend_get_session(server->backend);

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -3,8 +3,6 @@
 #include <cairo.h>
 #include <drm_fourcc.h>
 #include <linux/input.h>
-#include <wlr/backend/drm.h>
-#include <wlr/backend/multi.h>
 
 #include "zen-common.h"
 #include "zen-config.h"


### PR DESCRIPTION
## Context

At other DE, when press Ctrl+Alt+F1~, it switches to virtual terminal (tty).

## Summary

Implement switching vt by `wlr_session_change_vt`

## How to check behavior

1. start zen
2. press Ctrl+Alt+F([1-9]|10)
3. switch to virtual terminal
