### PR TITLE
enable to input xdg popup

### DIFF
--- a/include/zen/scene/scene.h
+++ b/include/zen/scene/scene.h
@@ -8,7 +8,7 @@
 struct zn_scene {
   struct zn_screen_layout* screen_layout;
 
-  struct zn_view* focused_view;
+  struct zn_view* focused_view;  // nullable
 
   struct wl_list board_list;  // zn_board::link, non empty
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -7,9 +7,6 @@
 #include "zen/scene/board.h"
 #include "zen/scene/screen-layout.h"
 
-typedef void (*zn_screen_for_each_visible_surface_callback_t)(
-    struct wlr_surface *surface, void *data);
-
 struct zn_screen {
   double x, y;
   struct zn_output *output;  // zn_output owns zn_screen, nonnull
@@ -26,8 +23,7 @@ struct zn_screen {
   } events;
 };
 
-void zn_screen_for_each_visible_surface(struct zn_screen *self,
-    zn_screen_for_each_visible_surface_callback_t callback, void *data);
+void zn_screen_send_frame_done_for_each_visible_surface(struct zn_screen *self);
 
 struct zn_view *zn_screen_get_view_at(
     struct zn_screen *self, double x, double y, double *view_x, double *view_y);

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -29,11 +29,13 @@ struct zn_screen {
 void zn_screen_for_each_visible_surface(struct zn_screen *self,
     zn_screen_for_each_visible_surface_callback_t callback, void *data);
 
+/**
+ * @param surface_x can be NULL
+ * @param surface_y can be NULL
+ * @param view can be NULL
+ */
 struct wlr_surface *zn_screen_get_surface_at(struct zn_screen *self, double x,
-    double y, double *surface_x, double *surface_y);
-
-struct zn_view *zn_screen_get_view_at(
-    struct zn_screen *self, double x, double y, double *view_x, double *view_y);
+    double y, double *surface_x, double *surface_y, struct zn_view **view);
 
 void zn_screen_switch_to_next_board(struct zn_screen *self);
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -29,6 +29,8 @@ struct zn_screen {
 void zn_screen_for_each_visible_surface(struct zn_screen *self,
     zn_screen_for_each_visible_surface_callback_t callback, void *data);
 
+struct wlr_surface *zn_screen_get_surface_at(struct zn_screen *self, double x, double y, double *surface_x, double *surface_y);
+
 struct zn_view *zn_screen_get_view_at(
     struct zn_screen *self, double x, double y, double *view_x, double *view_y);
 

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -7,6 +7,9 @@
 #include "zen/scene/board.h"
 #include "zen/scene/screen-layout.h"
 
+typedef void (*zn_screen_for_each_visible_surface_callback_t)(
+    struct wlr_surface *surface, void *user_data);
+
 struct zn_screen {
   double x, y;
   struct zn_output *output;  // zn_output owns zn_screen, nonnull
@@ -23,7 +26,8 @@ struct zn_screen {
   } events;
 };
 
-void zn_screen_send_frame_done_for_each_visible_surface(struct zn_screen *self);
+void zn_screen_for_each_visible_surface(struct zn_screen *self,
+    zn_screen_for_each_visible_surface_callback_t callback, void *data);
 
 struct zn_view *zn_screen_get_view_at(
     struct zn_screen *self, double x, double y, double *view_x, double *view_y);

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -29,7 +29,8 @@ struct zn_screen {
 void zn_screen_for_each_visible_surface(struct zn_screen *self,
     zn_screen_for_each_visible_surface_callback_t callback, void *data);
 
-struct wlr_surface *zn_screen_get_surface_at(struct zn_screen *self, double x, double y, double *surface_x, double *surface_y);
+struct wlr_surface *zn_screen_get_surface_at(struct zn_screen *self, double x,
+    double y, double *surface_x, double *surface_y);
 
 struct zn_view *zn_screen_get_view_at(
     struct zn_screen *self, double x, double y, double *view_x, double *view_y);

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -11,6 +11,8 @@ struct zn_view;
 
 struct zn_view_impl {
   struct wlr_surface *(*get_wlr_surface)(struct zn_view *view);
+  struct wlr_surface *(*get_wlr_surface_at)(struct zn_view *view,
+      double view_sx, double view_sy, double *surface_x, double *surface_y);
   void (*get_geometry)(struct zn_view *view, struct wlr_box *box);
   void (*configure)(struct zn_view *view, double x, double y);  // nullable
   void (*for_each_popup_surface)(struct zn_view *view,

--- a/include/zen/wlr/box.h
+++ b/include/zen/wlr/box.h
@@ -2,7 +2,5 @@
 
 #include <wlr/util/box.h>
 
-bool zn_wlr_fbox_contains_point(const struct wlr_fbox* box, double x, double y);
-
 void zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,
     double* dest_x, double* dest_y);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -117,32 +117,8 @@ static struct wlr_surface*
 zn_cursor_get_pointing_surface(
     struct zn_cursor* self, double* surface_x, double* surface_y)
 {
-  struct zn_view* view;
-  double view_sx, view_sy;
-
-  // FIXME: take subsurfaces into account
-  view =
-      zn_screen_get_view_at(self->screen, self->x, self->y, &view_sx, &view_sy);
-
-  if (view == NULL) {
-    *surface_x = view_sx;
-    *surface_y = view_sy;
-    return NULL;
-  }
-
-  struct wlr_surface* surface = NULL;
-  if (view->type == ZN_VIEW_XDG_TOPLEVEL) {
-    struct zn_xdg_toplevel_view* xdg_toplevel_view =
-        zn_container_of(view, xdg_toplevel_view, base);
-    surface =
-        wlr_xdg_surface_surface_at(xdg_toplevel_view->wlr_xdg_toplevel->base,
-            view_sx, view_sy, surface_x, surface_y);
-  } else if (view->type == ZN_VIEW_XWAYLAND) {
-    surface = wlr_surface_surface_at(view->impl->get_wlr_surface(view), view_sx,
-        view_sy, surface_x, surface_y);
-  }
-
-  return surface;
+  return zn_screen_get_surface_at(
+      self->screen, self->x, self->y, surface_x, surface_y);
 }
 
 static void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -50,7 +50,7 @@ default_grab_button(
   struct zn_server* server = zn_server_get_singleton();
   struct wlr_seat* seat = server->input_manager->seat->wlr_seat;
   struct zn_cursor* cursor = grab->cursor;
-  struct zn_view* view;
+  struct zn_view* view = NULL;
 
   if (cursor->screen == NULL) {
     return;
@@ -60,8 +60,8 @@ default_grab_button(
       seat, event->time_msec, event->button, event->state);
 
   if (event->state == WLR_BUTTON_PRESSED) {
-    view =
-        zn_screen_get_view_at(cursor->screen, cursor->x, cursor->y, NULL, NULL);
+    zn_screen_get_surface_at(
+        cursor->screen, cursor->x, cursor->y, NULL, NULL, &view);
     zn_scene_set_focused_view(server->scene, view);
   }
 }
@@ -117,7 +117,7 @@ zn_cursor_get_pointing_surface(
     struct zn_cursor* self, double* surface_x, double* surface_y)
 {
   return zn_screen_get_surface_at(
-      self->screen, self->x, self->y, surface_x, surface_y);
+      self->screen, self->x, self->y, surface_x, surface_y, NULL);
 }
 
 static void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -12,7 +12,6 @@
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/view.h"
 #include "zen/server.h"
-#include "zen/xdg-toplevel-view.h"
 
 static struct wlr_surface* zn_cursor_get_pointing_surface(
     struct zn_cursor* self, double* surface_x, double* surface_y);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -13,9 +13,6 @@
 #include "zen/scene/view.h"
 #include "zen/server.h"
 
-static struct wlr_surface* zn_cursor_get_pointing_surface(
-    struct zn_cursor* self, double* surface_x, double* surface_y);
-
 static void
 default_grab_motion(
     struct zn_cursor_grab* grab, struct wlr_event_pointer_motion* event)
@@ -31,8 +28,8 @@ default_grab_motion(
     return;
   }
 
-  surface =
-      zn_cursor_get_pointing_surface(grab->cursor, &surface_x, &surface_y);
+  surface = zn_screen_get_surface_at(grab->cursor->screen, grab->cursor->x,
+      grab->cursor->y, &surface_x, &surface_y, NULL);
 
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
@@ -109,16 +106,6 @@ static const struct zn_cursor_grab_interface default_grab_interface = {
     .rebase = default_grab_rebase,
     .cancel = default_grab_cancel,
 };
-
-// get the surface that is just under the cursor
-// expect cursor::screen is non-NULL
-static struct wlr_surface*
-zn_cursor_get_pointing_surface(
-    struct zn_cursor* self, double* surface_x, double* surface_y)
-{
-  return zn_screen_get_surface_at(
-      self->screen, self->x, self->y, surface_x, surface_y, NULL);
-}
 
 static void
 zn_cursor_update_size(struct zn_cursor* self)
@@ -269,7 +256,8 @@ zn_cursor_end_grab(struct zn_cursor* self)
     return;
   }
 
-  surface = zn_cursor_get_pointing_surface(self, &surface_x, &surface_y);
+  surface = zn_screen_get_surface_at(
+      self->screen, self->x, self->y, &surface_x, &surface_y, NULL);
 
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -155,5 +155,6 @@ zn_cursor_grab_move_start(struct zn_cursor* cursor, struct zn_view* view)
 
   zn_cursor_set_xcursor(cursor, "grabbing");
   wlr_seat_pointer_clear_focus(seat);
+  if (view->impl->close_popups) view->impl->close_popups(view);
   zn_cursor_start_grab(cursor, &self->base);
 }

--- a/zen/output.c
+++ b/zen/output.c
@@ -84,17 +84,10 @@ damage_finish:
 }
 
 static void
-send_frame_done_callback(struct wlr_surface *surface, void *data)
-{
-  wlr_surface_send_frame_done(surface, data);
-}
-
-static void
 zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
 {
   struct zn_output *self =
       zn_container_of(listener, self, damage_frame_listener);
-  struct timespec now;
   UNUSED(data);
 
   if (self->wlr_output->enabled == false) return;
@@ -102,10 +95,7 @@ zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
   // TODO: add delay to call zn_output_repaint_timer_handler
 
   zn_output_repaint_timer_handler(self);
-
-  clock_gettime(CLOCK_MONOTONIC, &now);
-  zn_screen_for_each_visible_surface(
-      self->screen, send_frame_done_callback, &now);
+  zn_screen_send_frame_done_for_each_visible_surface(self->screen);
 }
 
 struct zn_output *

--- a/zen/output.c
+++ b/zen/output.c
@@ -84,10 +84,17 @@ damage_finish:
 }
 
 static void
+send_frame_done_callback(struct wlr_surface *surface, void *user_data)
+{
+  wlr_surface_send_frame_done(surface, user_data);
+}
+
+static void
 zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
 {
   struct zn_output *self =
       zn_container_of(listener, self, damage_frame_listener);
+  struct timespec now;
   UNUSED(data);
 
   if (self->wlr_output->enabled == false) return;
@@ -95,7 +102,10 @@ zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
   // TODO: add delay to call zn_output_repaint_timer_handler
 
   zn_output_repaint_timer_handler(self);
-  zn_screen_send_frame_done_for_each_visible_surface(self->screen);
+
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  zn_screen_for_each_visible_surface(
+      self->screen, send_frame_done_callback, &now);
 }
 
 struct zn_output *

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -6,7 +6,6 @@
 #include "zen/scene/screen-layout.h"
 #include "zen/scene/view.h"
 #include "zen/wlr/box.h"
-#include "zen/xdg-toplevel-view.h"
 
 struct surface_callback_data {
   zn_screen_for_each_visible_surface_callback_t callback;

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -51,46 +51,25 @@ zn_screen_for_each_visible_surface(struct zn_screen *self,
 
 struct wlr_surface *
 zn_screen_get_surface_at(struct zn_screen *self, double x, double y,
-    double *surface_x, double *surface_y)
+    double *surface_x, double *surface_y, struct zn_view **view)
 {
-  struct zn_view *view;
+  struct zn_view *view_iterator;
   struct zn_board *board = zn_screen_get_current_board(self);
   double view_sx, view_sy;
   struct wlr_surface *surface;
 
-  wl_list_for_each_reverse (view, &board->view_list, link) {
-    view_sx = x - view->x;
-    view_sy = y - view->y;
+  wl_list_for_each_reverse (view_iterator, &board->view_list, link) {
+    double sx, sy;
+    view_sx = x - view_iterator->x;
+    view_sy = y - view_iterator->y;
 
-    surface = view->impl->get_wlr_surface_at(
-        view, view_sx, view_sy, surface_x, surface_y);
-    if (surface != NULL) return surface;
-  }
-
-  return NULL;
-}
-
-struct zn_view *
-zn_screen_get_view_at(
-    struct zn_screen *self, double x, double y, double *view_x, double *view_y)
-{
-  struct zn_view *view;
-  struct zn_board *board = zn_screen_get_current_board(self);
-  double view_sx, view_sy;
-
-  wl_list_for_each_reverse (view, &board->view_list, link) {
-    view_sx = x - view->x;
-    view_sy = y - view->y;
-
-    if (view->impl->get_wlr_surface_at(view, view_sx, view_sy, NULL, NULL) !=
-        NULL) {
-      if (view_x != NULL) {
-        *view_x = view_sx;
-      }
-      if (view_y != NULL) {
-        *view_y = view_sy;
-      }
-      return view;
+    surface = view_iterator->impl->get_wlr_surface_at(
+        view_iterator, view_sx, view_sy, &sx, &sy);
+    if (surface != NULL) {
+      if (surface_x) *surface_x = sx;
+      if (surface_y) *surface_y = sy;
+      if (view) *view = view_iterator;
+      return surface;
     }
   }
 

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -37,7 +37,7 @@ zn_screen_for_each_visible_surface(struct zn_screen *self,
       .user_data = user_data,
   };
 
-  wl_list_for_each(view, &board->view_list, link) {
+  wl_list_for_each (view, &board->view_list, link) {
     callback(view->impl->get_wlr_surface(view), user_data);
 
     if (view->type == ZN_VIEW_XDG_TOPLEVEL) {
@@ -64,7 +64,7 @@ zn_screen_get_surface_at(struct zn_screen *self, double x, double y,
   double view_sx, view_sy;
   struct wlr_surface *surface;
 
-  wl_list_for_each_reverse(view, &board->view_list, link) {
+  wl_list_for_each_reverse (view, &board->view_list, link) {
     view_sx = x - view->x;
     view_sy = y - view->y;
 
@@ -84,7 +84,7 @@ zn_screen_get_view_at(
   struct zn_board *board = zn_screen_get_current_board(self);
   double view_sx, view_sy;
 
-  wl_list_for_each_reverse(view, &board->view_list, link) {
+  wl_list_for_each_reverse (view, &board->view_list, link) {
     view_sx = x - view->x;
     view_sy = y - view->y;
 

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -40,14 +40,9 @@ zn_screen_for_each_visible_surface(struct zn_screen *self,
   wl_list_for_each (view, &board->view_list, link) {
     callback(view->impl->get_wlr_surface(view), user_data);
 
-    if (view->type == ZN_VIEW_XDG_TOPLEVEL) {
-      struct zn_xdg_toplevel_view *xdg_toplevel_view =
-          zn_container_of(view, xdg_toplevel_view, base);
-
-      wlr_xdg_surface_for_each_popup_surface(
-          xdg_toplevel_view->wlr_xdg_toplevel->base,
-          zn_screen_for_each_visible_surface_callback, &data);
-    }
+    if (view->impl->for_each_popup_surface)
+      view->impl->for_each_popup_surface(
+          view, zn_screen_for_each_visible_surface_callback, &data);
   }
 
   if (cursor->screen == self && cursor->surface != NULL) {

--- a/zen/wlr/box.c
+++ b/zen/wlr/box.c
@@ -1,13 +1,5 @@
 #include "zen/wlr/box.h"
 
-// from wlroots::wlr_box_contains_point
-bool
-zn_wlr_fbox_contains_point(const struct wlr_fbox* box, double x, double y)
-{
-  return box->x <= x && x < box->x + box->width && box->y <= y &&
-         y < box->y + box->height;
-}
-
 // from wlroots::wlr_box_closest_point
 void
 zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -112,6 +112,16 @@ zn_xdg_toplevel_view_impl_get_wlr_surface(struct zn_view* view)
   return self->wlr_xdg_toplevel->base->surface;
 }
 
+static struct wlr_surface*
+zn_xdg_toplevel_view_impl_get_wlr_surface_at(struct zn_view* view,
+    double view_sx, double view_sy, double* surface_x, double* surface_y)
+{
+  struct zn_xdg_toplevel_view* self = zn_container_of(view, self, base);
+
+  return wlr_xdg_surface_surface_at(
+      self->wlr_xdg_toplevel->base, view_sx, view_sy, surface_x, surface_y);
+}
+
 static void
 zn_xdg_toplevel_view_impl_get_geometry(
     struct zn_view* view, struct wlr_box* box)
@@ -149,6 +159,7 @@ zn_xdg_toplevel_view_impl_close_popups(struct zn_view* view)
 
 static const struct zn_view_impl zn_xdg_toplevel_view_impl = {
     .get_wlr_surface = zn_xdg_toplevel_view_impl_get_wlr_surface,
+    .get_wlr_surface_at = zn_xdg_toplevel_view_impl_get_wlr_surface_at,
     .get_geometry = zn_xdg_toplevel_view_impl_get_geometry,
     .set_activated = zn_xdg_toplevel_view_impl_set_activated,
     .for_each_popup_surface = zn_xdg_toplevel_view_impl_for_each_popup_surface,

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -94,6 +94,16 @@ zn_xwayland_view_impl_get_wlr_surface(struct zn_view* view)
   return self->wlr_xwayland_surface->surface;
 }
 
+static struct wlr_surface*
+zn_xwayland_view_impl_get_wlr_surface_at(struct zn_view* view, double view_sx,
+    double view_sy, double* surface_x, double* surface_y)
+{
+  struct zn_xwayland_view* self = zn_container_of(view, self, base);
+
+  return wlr_surface_surface_at(self->wlr_xwayland_surface->surface, view_sx,
+      view_sy, surface_x, surface_y);
+}
+
 static void
 zn_xwayland_view_impl_get_geometry(struct zn_view* view, struct wlr_box* box)
 {
@@ -126,6 +136,7 @@ zn_xwayland_view_impl_restack(struct zn_view* view, enum xcb_stack_mode_t mode)
 
 static const struct zn_view_impl zn_xwayland_view_impl = {
     .get_wlr_surface = zn_xwayland_view_impl_get_wlr_surface,
+    .get_wlr_surface_at = zn_xwayland_view_impl_get_wlr_surface_at,
     .get_geometry = zn_xwayland_view_impl_get_geometry,
     .set_activated = zn_xwayland_view_impl_set_activated,
     .configure = zn_xwayland_view_impl_configure,


### PR DESCRIPTION
## Context

#116 ( before: #157 )

## Summary

- return popup's surface by new `zn_screen_get_surface_at` function

## How to check behavior

The following behaviors can be checked with the Wayland clients (e.g., `vlc` `weston-terminal` `weston-flower`)

- When hovering over a menu item in the wayland client's popup menu, the color of the item changes.
  - **In particular, it is possible to hover a popup outside the frame of the view.**

- When you click (button event) on each menu of the wayland client's popup, the input works accordingly (except unsupported functions such as minimize/maximize).
  - **In particular, it is possible to click a popup outside the frame of the view.**

- After hiding a popup, input is sent to the view where the popup was (input is not sent to the popup).

- "hiding popup" should occur when...
  - (right/left) click elsewhere in the view
  - close the view
  - start `move`
  - focus/restack another view

Belows are TODO.
- popups of popup. (popup tree)
- the verification of xwayland popups will be done in another PR. (#164 may be related)
