### PR TITLE
change clang-format config of foreach macros

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,3 +8,4 @@ BraceWrapping:
   SplitEmptyRecord: false
 AlwaysBreakAfterReturnType: TopLevelDefinitions
 AlignAfterOpenBracket: DontAlign
+ForEachMacros: ['wl_list_for_each', 'wl_list_for_each_safe', 'wl_list_for_each_reverse']

--- a/.clang-format
+++ b/.clang-format
@@ -8,4 +8,13 @@ BraceWrapping:
   SplitEmptyRecord: false
 AlwaysBreakAfterReturnType: TopLevelDefinitions
 AlignAfterOpenBracket: DontAlign
-ForEachMacros: ['wl_list_for_each', 'wl_list_for_each_safe', 'wl_list_for_each_reverse']
+ForEachMacros: [
+  'wl_list_for_each',
+  'wl_list_for_each_safe',
+  'wl_list_for_each_reverse',
+  'wl_list_for_each_reverse_safe',
+  'wl_array_for_each',
+  'wl_client_for_each',
+  'wl_resource_for_each',
+  'wl_resource_for_each_safe'
+]

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -207,8 +207,7 @@ zn_cursor_handle_screen_destroy(struct wl_listener* listener, void* data)
   struct wlr_fbox box = {0};
   bool found = false;
 
-  wl_list_for_each(screen, &screen_layout->screens, link)
-  {
+  wl_list_for_each (screen, &screen_layout->screens, link) {
     if (screen != self->screen) {
       found = true;
       break;

--- a/zen/display-system.c
+++ b/zen/display-system.c
@@ -65,8 +65,8 @@ zn_display_system_applied(
   if (self->type == type) return;
   self->type = type;
 
-  wl_resource_for_each(resource, &self->resources)
-      zen_display_system_send_applied(resource, type);
+  wl_resource_for_each (resource, &self->resources)
+    zen_display_system_send_applied(resource, type);
 }
 
 struct zn_display_system *
@@ -106,8 +106,8 @@ zn_display_system_destroy(struct zn_display_system *self)
 {
   struct wl_resource *resource, *tmp;
 
-  wl_resource_for_each_safe(resource, tmp, &self->resources)
-      wl_resource_destroy(resource);
+  wl_resource_for_each_safe (resource, tmp, &self->resources)
+    wl_resource_destroy(resource);
 
   wl_global_destroy(self->global);
   free(self);

--- a/zen/input/input-manager.c
+++ b/zen/input/input-manager.c
@@ -15,8 +15,7 @@ zn_input_manager_bindings_notify_key(struct zn_input_manager* self,
 {
   struct zn_binding *binding, *tmp;
 
-  wl_list_for_each_safe(binding, tmp, &self->key_binding_list, link)
-  {
+  wl_list_for_each_safe (binding, tmp, &self->key_binding_list, link) {
     if (zn_binding_notify_key(binding, time_msec, key, state, keyboard)) {
       return true;
     }
@@ -88,8 +87,7 @@ zn_input_manager_destroy(struct zn_input_manager* self)
 {
   struct zn_binding *binding, *tmp;
 
-  wl_list_for_each_safe(binding, tmp, &self->key_binding_list, link)
-  {
+  wl_list_for_each_safe (binding, tmp, &self->key_binding_list, link) {
     zn_binding_destroy(binding);
   }
 

--- a/zen/input/seat.c
+++ b/zen/input/seat.c
@@ -30,8 +30,7 @@ zn_seat_update_capabilities(struct zn_seat* self)
   uint32_t caps = 0;
 
   struct zn_input_device* input_device;
-  wl_list_for_each(input_device, &self->devices, link)
-  {
+  wl_list_for_each (input_device, &self->devices, link) {
     switch (input_device->wlr_input->type) {
       case WLR_INPUT_DEVICE_KEYBOARD:
         caps |= WL_SEAT_CAPABILITY_KEYBOARD;

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -111,8 +111,7 @@ static struct zn_board*
 zn_scene_ensure_dangling_board(struct zn_scene* self)
 {
   struct zn_board* board;
-  wl_list_for_each(board, &self->board_list, link)
-  {
+  wl_list_for_each (board, &self->board_list, link) {
     if (zn_board_is_dangling(board)) {
       return board;
     }
@@ -129,8 +128,7 @@ zn_scene_reassign_boards(struct zn_scene* self)
   struct zn_board* board;
 
   // assign a board to a screen without board
-  wl_list_for_each(screen, &self->screen_layout->screens, link)
-  {
+  wl_list_for_each (screen, &self->screen_layout->screens, link) {
     struct zn_board* board;
     if (!wl_list_empty(&screen->board_list)) {
       continue;
@@ -153,8 +151,7 @@ zn_scene_reassign_boards(struct zn_scene* self)
   }
 
   if (screen) {
-    wl_list_for_each(board, &self->board_list, link)
-    {
+    wl_list_for_each (board, &self->board_list, link) {
       if (zn_board_is_dangling(board)) {
         zn_board_assign_to_screen(board, screen);
       }
@@ -255,8 +252,7 @@ zn_scene_destroy(struct zn_scene* self)
 {
   struct zn_board *board, *tmp;
 
-  wl_list_for_each_safe(board, tmp, &self->board_list, link)
-  {
+  wl_list_for_each_safe (board, tmp, &self->board_list, link) {
     zn_board_destroy(board);
   }
 

--- a/zen/scene/screen-layout.c
+++ b/zen/scene/screen-layout.c
@@ -14,8 +14,7 @@ zn_screen_layout_rearrange(struct zn_screen_layout* self)
   struct zn_screen* screen;
   struct wlr_fbox box;
 
-  wl_list_for_each(screen, &self->screens, link)
-  {
+  wl_list_for_each (screen, &self->screens, link) {
     zn_screen_get_fbox(screen, &box);
     screen->x = x;
     screen->y = 0;
@@ -31,8 +30,7 @@ zn_screen_layout_get_closest_screen(struct zn_screen_layout* self, double x,
   struct zn_screen* closest_screen = NULL;
   struct zn_screen* screen;
 
-  wl_list_for_each(screen, &self->screens, link)
-  {
+  wl_list_for_each (screen, &self->screens, link) {
     double current_closest_x, current_closest_y, current_closest_distance;
     struct wlr_fbox box;
     zn_screen_get_fbox(screen, &box);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -16,8 +16,7 @@ zn_screen_for_each_visible_surface(struct zn_screen *self,
   struct zn_board *board = zn_screen_get_current_board(self);
   struct zn_view *view;
 
-  wl_list_for_each(view, &board->view_list, link)
-  {
+  wl_list_for_each (view, &board->view_list, link) {
     callback(view->impl->get_wlr_surface(view), data);
   }
 
@@ -34,8 +33,7 @@ zn_screen_get_view_at(
   struct zn_view *view;
   struct zn_board *board = zn_screen_get_current_board(self);
 
-  wl_list_for_each_reverse(view, &board->view_list, link)
-  {
+  wl_list_for_each_reverse (view, &board->view_list, link) {
     zn_view_get_window_fbox(view, &fbox);
 
     if (zn_wlr_fbox_contains_point(&fbox, x, y)) {
@@ -59,8 +57,7 @@ zn_screen_switch_to_next_board(struct zn_screen *self)
                           *current_board = zn_screen_get_current_board(self);
   bool found = false;
 
-  wl_list_for_each(board, &self->board_list, screen_link)
-  {
+  wl_list_for_each (board, &self->board_list, screen_link) {
     if (next_board == NULL) {
       next_board = board;
     }
@@ -90,8 +87,7 @@ zn_screen_switch_to_prev_board(struct zn_screen *self)
                           *current_board = zn_screen_get_current_board(self);
   bool found = false;
 
-  wl_list_for_each_reverse(board, &self->board_list, screen_link)
-  {
+  wl_list_for_each_reverse (board, &self->board_list, screen_link) {
     if (next_board == NULL) {
       next_board = board;
     }
@@ -140,8 +136,7 @@ static bool
 zn_screen_has_board(struct zn_screen *self, struct zn_board *target_board)
 {
   struct zn_board *board;
-  wl_list_for_each(board, &self->board_list, screen_link)
-  {
+  wl_list_for_each (board, &self->board_list, screen_link) {
     if (board == target_board) {
       return true;
     }

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -280,8 +280,8 @@ zn_screen_renderer_render(struct zn_screen *screen,
 
   zn_screen_renderer_render_background(
       output, renderer, server->scene->bg_texture, &screen_damage);
-  wl_list_for_each(view, &board->view_list, link)
-      zn_screen_renderer_render_view(screen, view, renderer, &screen_damage);
+  wl_list_for_each (view, &board->view_list, link)
+    zn_screen_renderer_render_view(screen, view, renderer, &screen_damage);
 
   zn_screen_renderer_render_cursor(screen, cursor, renderer, &screen_damage);
 

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -141,8 +141,8 @@ zn_xdg_toplevel_view_impl_close_popups(struct zn_view* view)
 {
   struct zn_xdg_toplevel_view* self = zn_container_of(view, self, base);
   struct wlr_xdg_popup *popup, *tmp;
-  wl_list_for_each_safe(popup, tmp, &self->wlr_xdg_toplevel->base->popups, link)
-  {
+  wl_list_for_each_safe (
+      popup, tmp, &self->wlr_xdg_toplevel->base->popups, link) {
     wlr_xdg_popup_destroy(popup->base);
   }
 }


### PR DESCRIPTION
## Context

for coding experience.

## Summary

Modified Clang-format settings to recognize some macros (`wl_list_for_each` etc) as foreach loops.

## How to check behavior
Just look at codes.