### PR TITLE
[refactor] destroying process

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -49,4 +49,6 @@ void zn_cursor_set_xcursor(struct zn_cursor* self, const char* name);
 
 struct zn_cursor* zn_cursor_create(void);
 
+void zn_cursor_destroy_resources(struct zn_cursor* self);
+
 void zn_cursor_destroy(struct zn_cursor* self);

--- a/include/zen/scene/scene.h
+++ b/include/zen/scene/scene.h
@@ -27,4 +27,6 @@ void zn_scene_setup_bindings(struct zn_scene* self);
 
 struct zn_scene* zn_scene_create(void);
 
+void zn_scene_destroy_resources(struct zn_scene* self);
+
 void zn_scene_destroy(struct zn_scene* self);

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -53,4 +53,6 @@ void zn_server_terminate(struct zn_server *self, int exit_code);
 
 struct zn_server *zn_server_create(struct wl_display *display);
 
+void zn_server_destroy_resources(struct zn_server *self);
+
 void zn_server_destroy(struct zn_server *self);

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -450,15 +450,20 @@ err:
 }
 
 void
+zn_cursor_destroy_resources(struct zn_cursor* self)
+{
+  if (self->xcursor_texture) {
+    wlr_texture_destroy(self->xcursor_texture);
+  }
+}
+
+void
 zn_cursor_destroy(struct zn_cursor* self)
 {
   wl_list_remove(&self->new_screen_listener.link);
   wl_list_remove(&self->screen_destroy_listener.link);
   wl_list_remove(&self->surface_commit_listener.link);
   wl_list_remove(&self->surface_destroy_listener.link);
-  if (self->xcursor_texture) {
-    wlr_texture_destroy(self->xcursor_texture);
-  }
   wlr_xcursor_manager_destroy(self->xcursor_manager);
   free(self);
 }

--- a/zen/main.c
+++ b/zen/main.c
@@ -192,6 +192,7 @@ main(int argc, char *argv[])
   }
 
   exit_status = zn_server_run(server);
+  zn_server_destroy_resources(server);
 
 err_server:
   zn_server_destroy(server);

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -243,6 +243,7 @@ zn_scene_create(void)
   zn_scene_setup_background(self, DEFAULT_WALLPAPER);
 
   self->unmap_focused_view_listener.notify = zn_scene_handle_unmap_focused_view;
+  wl_list_init(&self->unmap_focused_view_listener.link);
 
   return self;
 

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -257,6 +257,14 @@ err:
 }
 
 void
+zn_scene_destroy_resources(struct zn_scene* self)
+{
+  if (self->bg_texture != NULL) {
+    wlr_texture_destroy(self->bg_texture);
+  }
+}
+
+void
 zn_scene_destroy(struct zn_scene* self)
 {
   struct zn_board *board, *tmp;
@@ -264,8 +272,6 @@ zn_scene_destroy(struct zn_scene* self)
   wl_list_for_each_safe (board, tmp, &self->board_list, link) {
     zn_board_destroy(board);
   }
-
-  if (self->bg_texture != NULL) wlr_texture_destroy(self->bg_texture);
 
   zn_screen_layout_destroy(self->screen_layout);
 

--- a/zen/server.c
+++ b/zen/server.c
@@ -334,6 +334,16 @@ err:
 }
 
 void
+zn_server_destroy_resources(struct zn_server *self)
+{
+  wlr_backend_destroy(self->backend);
+  wl_display_destroy_clients(self->display);
+
+  zn_cursor_destroy_resources(self->input_manager->seat->cursor);
+  zn_scene_destroy_resources(self->scene);
+}
+
+void
 zn_server_destroy(struct zn_server *self)
 {
   wlr_xwayland_destroy(self->xwayland);
@@ -341,7 +351,6 @@ zn_server_destroy(struct zn_server *self)
   zn_display_system_destroy(self->display_system);
   zn_immersive_backend_destroy(self->immersive_backend);
   free(self->socket);
-  wlr_backend_destroy(self->backend);
   wlr_allocator_destroy(self->allocator);
   wlr_renderer_destroy(self->renderer);
   zn_scene_destroy(self->scene);


### PR DESCRIPTION
## Context

See #167. And now, Segmentation Fault occurs when destroying texture.

## Summary

destroy resources (e.g. client, backend, texture) before destroying server.

## How to check behavior

start zen and exit, check no error occured. Leave comments if you expect to destroy something before exiting.
