### PR TITLE
change meaning of view's position

### DIFF
--- a/include/zen/input/cursor-grab-resize.h
+++ b/include/zen/input/cursor-grab-resize.h
@@ -8,9 +8,7 @@ struct zn_cursor_grab_resize {
   struct zn_cursor_grab base;
   struct zn_view* view;
 
-  double init_view_x, init_view_y;
   double init_view_width, init_view_height;
-
   double init_cursor_x, init_cursor_y;
 
   struct wl_listener view_unmap_listener;

--- a/include/zen/scene/view-child.h
+++ b/include/zen/scene/view-child.h
@@ -8,7 +8,8 @@ struct zn_view_child;
 
 struct zn_view_child_impl {
   struct wlr_surface *(*get_wlr_surface)(struct zn_view_child *child);
-  void (*get_view_coords)(struct zn_view_child *child, int *sx, int *sy);
+  void (*get_toplevel_coords)(struct zn_view_child *child, double popup_sx,
+      double popup_sy, double *toplevel_sx, double *toplevel_sy);
 };
 
 /*

--- a/include/zen/scene/view-child.h
+++ b/include/zen/scene/view-child.h
@@ -8,8 +8,8 @@ struct zn_view_child;
 
 struct zn_view_child_impl {
   struct wlr_surface *(*get_wlr_surface)(struct zn_view_child *child);
-  void (*get_toplevel_coords)(struct zn_view_child *child, double popup_sx,
-      double popup_sy, double *toplevel_sx, double *toplevel_sy);
+  void (*get_toplevel_coords)(struct zn_view_child *child, double child_sx,
+      double child_sy, double *toplevel_sx, double *toplevel_sy);
 };
 
 /*

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -75,7 +75,7 @@ void zn_view_damage_whole(struct zn_view *self);
 
 void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
-void zn_view_get_window_fbox(struct zn_view *self, struct wlr_fbox *fbox);
+void zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 void zn_view_get_decoration_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -77,8 +77,6 @@ void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 void zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
-void zn_view_get_decoration_fbox(struct zn_view *self, struct wlr_fbox *fbox);
-
 bool zn_view_has_client_decoration(struct zn_view *self);
 
 bool zn_view_is_mapped(struct zn_view *self);

--- a/zen/input/cursor-grab-move.c
+++ b/zen/input/cursor-grab-move.c
@@ -106,7 +106,7 @@ zn_cursor_grab_move_create(struct zn_cursor* cursor, struct zn_view* view)
     return NULL;
   }
 
-  zn_view_get_surface_fbox(view, &view_box);
+  zn_view_get_view_fbox(view, &view_box);
   self->init_board = view->board;
   self->init_x = view_box.x;
   self->init_y = view_box.y;

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -115,7 +115,7 @@ zn_cursor_grab_resize_create(
   }
 
   struct wlr_fbox box;
-  zn_view_get_window_fbox(view, &box);
+  zn_view_get_view_fbox(view, &box);
 
   self->init_view_x = view->x;
   self->init_view_y = view->y;

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -117,8 +117,6 @@ zn_cursor_grab_resize_create(
   struct wlr_fbox box;
   zn_view_get_view_fbox(view, &box);
 
-  self->init_view_x = view->x;
-  self->init_view_y = view->y;
   self->init_view_width = box.width;
   self->init_view_height = box.height;
   self->init_cursor_x = cursor->x;

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -59,10 +59,12 @@ zn_screen_get_surface_at(struct zn_screen *self, double x, double y,
   struct wlr_surface *surface;
 
   wl_list_for_each_reverse (view_iterator, &board->view_list, link) {
-    double sx, sy;
-    view_sx = x - view_iterator->x;
-    view_sy = y - view_iterator->y;
+    struct wlr_fbox fbox;
+    zn_view_get_surface_fbox(view_iterator, &fbox);
+    view_sx = x - fbox.x;
+    view_sy = y - fbox.y;
 
+    double sx, sy;
     surface = view_iterator->impl->get_wlr_surface_at(
         view_iterator, view_sx, view_sy, &sx, &sy);
     if (surface != NULL) {

--- a/zen/scene/view-child.c
+++ b/zen/scene/view-child.c
@@ -29,12 +29,15 @@ zn_view_child_get_surface_fbox(
     struct zn_view_child *self, struct wlr_fbox *fbox)
 {
   struct wlr_surface *surface = self->impl->get_wlr_surface(self);
-  int sx, sy;
 
+  struct wlr_fbox view_fbox;
+  zn_view_get_surface_fbox(self->view, &view_fbox);
+
+  int sx, sy;
   self->impl->get_view_coords(self, &sx, &sy);
 
-  fbox->x = self->view->x + sx;
-  fbox->y = self->view->y + sy;
+  fbox->x = view_fbox.x + sx;
+  fbox->y = view_fbox.y + sy;
   fbox->width = surface->current.width;
   fbox->height = surface->current.height;
 }
@@ -71,10 +74,13 @@ zn_view_child_damage(struct zn_view_child *self)
 
   self->impl->get_view_coords(self, &sx, &sy);
 
+  struct wlr_fbox fbox;
+  zn_view_get_surface_fbox(self->view, &fbox);
+
   for (int i = 0; i < rect_count; ++i) {
     damage_box = (struct wlr_fbox){
-        .x = self->view->x + sx + rects[i].x1,
-        .y = self->view->y + sy + rects[i].y1,
+        .x = fbox.x + sx + rects[i].x1,
+        .y = fbox.y + sy + rects[i].y1,
         .width = rects[i].x2 - rects[i].x1,
         .height = rects[i].y2 - rects[i].y1,
     };

--- a/zen/scene/view-child.c
+++ b/zen/scene/view-child.c
@@ -33,8 +33,8 @@ zn_view_child_get_surface_fbox(
   struct wlr_fbox surface_fbox;
   zn_view_get_surface_fbox(self->view, &surface_fbox);
 
-  int sx, sy;
-  self->impl->get_view_coords(self, &sx, &sy);
+  double sx, sy;
+  self->impl->get_toplevel_coords(self, 0, 0, &sx, &sy);
 
   fbox->x = surface_fbox.x + sx;
   fbox->y = surface_fbox.y + sy;
@@ -62,7 +62,6 @@ zn_view_child_damage(struct zn_view_child *self)
   pixman_region32_t damage;
   pixman_box32_t *rects;
   int rect_count;
-  int sx, sy;
 
   if (!zn_view_child_is_mapped(self) || self->view->board->screen == NULL)
     return;
@@ -72,7 +71,8 @@ zn_view_child_damage(struct zn_view_child *self)
   wlr_surface_get_effective_damage(surface, &damage);
   rects = pixman_region32_rectangles(&damage, &rect_count);
 
-  self->impl->get_view_coords(self, &sx, &sy);
+  double sx, sy;
+  self->impl->get_toplevel_coords(self, 0, 0, &sx, &sy);
 
   struct wlr_fbox fbox;
   zn_view_get_surface_fbox(self->view, &fbox);

--- a/zen/scene/view-child.c
+++ b/zen/scene/view-child.c
@@ -30,14 +30,14 @@ zn_view_child_get_surface_fbox(
 {
   struct wlr_surface *surface = self->impl->get_wlr_surface(self);
 
-  struct wlr_fbox view_fbox;
-  zn_view_get_surface_fbox(self->view, &view_fbox);
+  struct wlr_fbox surface_fbox;
+  zn_view_get_surface_fbox(self->view, &surface_fbox);
 
   int sx, sy;
   self->impl->get_view_coords(self, &sx, &sy);
 
-  fbox->x = view_fbox.x + sx;
-  fbox->y = view_fbox.y + sy;
+  fbox->x = surface_fbox.x + sx;
+  fbox->y = surface_fbox.y + sy;
   fbox->width = surface->current.width;
   fbox->height = surface->current.height;
 }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -98,6 +98,7 @@ zn_view_damage_whole(struct zn_view *self)
 {
   struct wlr_fbox fbox;
 
+  // TODO: handle moving subsurface
   if (zn_view_has_client_decoration(self)) {
     zn_view_get_surface_fbox(self, &fbox);
   } else {

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -126,7 +126,7 @@ zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 }
 
 void
-zn_view_get_window_fbox(struct zn_view *self, struct wlr_fbox *fbox)
+zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 {
   struct wlr_box view_geometry;
   self->impl->get_geometry(self, &view_geometry);
@@ -186,7 +186,7 @@ zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene)
 
   // TODO: handle board destruction
 
-  zn_view_get_window_fbox(self, &fbox);
+  zn_view_get_view_fbox(self, &fbox);
   zn_view_move(self, board, (board->width - fbox.width) / 2,
       (board->height - fbox.height) / 2);
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -101,7 +101,7 @@ zn_view_damage_whole(struct zn_view *self)
   if (zn_view_has_client_decoration(self)) {
     zn_view_get_surface_fbox(self, &fbox);
   } else {
-    zn_view_get_decoration_fbox(self, &fbox);
+    zn_view_get_view_fbox(self, &fbox);
   }
 
   zn_view_add_damage_fbox(self, &fbox);
@@ -140,16 +140,6 @@ zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox)
     fbox->width += VIEW_DECORATION_BORDER * 2;
     fbox->height += VIEW_DECORATION_BORDER * 2 + VIEW_DECORATION_TITLEBAR;
   }
-}
-
-void
-zn_view_get_decoration_fbox(struct zn_view *self, struct wlr_fbox *fbox)
-{
-  zn_view_get_surface_fbox(self, fbox);
-  fbox->x -= VIEW_DECORATION_BORDER;
-  fbox->y -= VIEW_DECORATION_BORDER + VIEW_DECORATION_TITLEBAR;
-  fbox->width += VIEW_DECORATION_BORDER * 2;
-  fbox->height += VIEW_DECORATION_BORDER * 2 + VIEW_DECORATION_TITLEBAR;
 }
 
 bool

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -176,7 +176,7 @@ zn_screen_renderer_render_view_popups(struct zn_screen *screen,
 }
 
 static void
-zn_screen_renderer_render_decoration(struct zn_screen *screen,
+zn_screen_renderer_render_server_decoration(struct zn_screen *screen,
     struct zn_view *view, struct wlr_renderer *renderer,
     pixman_region32_t *screen_damage)
 {
@@ -202,15 +202,15 @@ zn_screen_renderer_render_decoration(struct zn_screen *screen,
   {
     pixman_region32_t region;
     struct wlr_fbox surface_fbox;
-    struct wlr_box transformed_window_box;
+    struct wlr_box transformed_surface_box;
 
     zn_view_get_surface_fbox(view, &surface_fbox);
     zn_output_box_effective_to_transformed_coords(
-        output, &surface_fbox, &transformed_window_box);
+        output, &surface_fbox, &transformed_surface_box);
 
-    pixman_region32_init_rect(&region, transformed_window_box.x,
-        transformed_window_box.y, transformed_window_box.width,
-        transformed_window_box.height);
+    pixman_region32_init_rect(&region, transformed_surface_box.x,
+        transformed_surface_box.y, transformed_surface_box.width,
+        transformed_surface_box.height);
     pixman_region32_subtract(&render_damage, &render_damage, &region);
 
     pixman_region32_fini(&region);
@@ -255,7 +255,8 @@ zn_screen_renderer_render_view(struct zn_screen *screen, struct zn_view *view,
   };
 
   if (!zn_view_has_client_decoration(view)) {
-    zn_screen_renderer_render_decoration(screen, view, renderer, screen_damage);
+    zn_screen_renderer_render_server_decoration(
+        screen, view, renderer, screen_damage);
   }
 
   wlr_surface_for_each_surface(

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -193,7 +193,7 @@ zn_screen_renderer_render_decoration(struct zn_screen *screen,
   int rect_count;
   struct wlr_fbox fbox;
 
-  zn_view_get_window_fbox(view, &fbox);
+  zn_view_get_view_fbox(view, &fbox);
 
   zn_output_box_effective_to_transformed_coords(
       output, &fbox, &transformed_box);

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -100,8 +100,11 @@ zn_screen_renderer_get_surface_fbox(struct wlr_surface *surface,
     struct zn_view *view, int surface_x, int surface_y,
     struct wlr_fbox *surface_box)
 {
-  surface_box->x = view->x + surface_x;
-  surface_box->y = view->y + surface_y;
+  struct wlr_fbox fbox;
+  zn_view_get_surface_fbox(view, &fbox);
+
+  surface_box->x = fbox.x + surface_x;
+  surface_box->y = fbox.y + surface_y;
   surface_box->width = surface->current.width;
   surface_box->height = surface->current.height;
 }
@@ -190,7 +193,7 @@ zn_screen_renderer_render_decoration(struct zn_screen *screen,
   int rect_count;
   struct wlr_fbox fbox;
 
-  zn_view_get_decoration_fbox(view, &fbox);
+  zn_view_get_window_fbox(view, &fbox);
 
   zn_output_box_effective_to_transformed_coords(
       output, &fbox, &transformed_box);
@@ -203,12 +206,12 @@ zn_screen_renderer_render_decoration(struct zn_screen *screen,
 
   {
     pixman_region32_t region;
-    struct wlr_fbox window_fbox;
+    struct wlr_fbox surface_fbox;
     struct wlr_box transformed_window_box;
 
-    zn_view_get_window_fbox(view, &window_fbox);
+    zn_view_get_surface_fbox(view, &surface_fbox);
     zn_output_box_effective_to_transformed_coords(
-        output, &window_fbox, &transformed_window_box);
+        output, &surface_fbox, &transformed_window_box);
 
     pixman_region32_init_rect(&region, transformed_window_box.x,
         transformed_window_box.y, transformed_window_box.width,

--- a/zen/screen-renderer.c
+++ b/zen/screen-renderer.c
@@ -96,28 +96,23 @@ zn_screen_renderer_render_background(struct zn_output *output,
 }
 
 static void
-zn_screen_renderer_get_surface_fbox(struct wlr_surface *surface,
-    struct zn_view *view, int surface_x, int surface_y,
-    struct wlr_fbox *surface_box)
-{
-  struct wlr_fbox fbox;
-  zn_view_get_surface_fbox(view, &fbox);
-
-  surface_box->x = fbox.x + surface_x;
-  surface_box->y = fbox.y + surface_y;
-  surface_box->width = surface->current.width;
-  surface_box->height = surface->current.height;
-}
-
-static void
 zn_screen_renderer_for_each_surface_iterator(
     struct wlr_surface *surface, int surface_x, int surface_y, void *user_data)
 {
   struct surface_iterator_data *data = user_data;
   struct wlr_fbox surface_box;
 
-  zn_screen_renderer_get_surface_fbox(
-      surface, data->view, surface_x, surface_y, &surface_box);
+  {
+    struct wlr_fbox fbox;
+    zn_view_get_surface_fbox(data->view, &fbox);
+
+    surface_box = (struct wlr_fbox){
+        .x = fbox.x + surface_x,
+        .y = fbox.y + surface_y,
+        .width = surface->current.width,
+        .height = surface->current.height,
+    };
+  }
 
   data->iterator(
       data->screen, surface, data->renderer, &surface_box, data->screen_damage);

--- a/zen/xdg-popup.c
+++ b/zen/xdg-popup.c
@@ -58,7 +58,7 @@ zn_xdg_popup_view_child_impl_get_wlr_surface(struct zn_view_child* child)
 
 static void
 zn_xdg_popup_view_child_impl_get_toplevel_coords(struct zn_view_child* child,
-    double popup_sx, double popup_sy, double* toplevel_sx, double* toplevel_sy)
+    double child_sx, double child_sy, double* toplevel_sx, double* toplevel_sy)
 {
   struct zn_xdg_popup* self = zn_container_of(child, self, base);
   struct wlr_xdg_surface* surface = self->wlr_xdg_popup->base;
@@ -68,8 +68,8 @@ zn_xdg_popup_view_child_impl_get_toplevel_coords(struct zn_view_child* child,
       surface->popup->geometry.x - surface->current.geometry.x,
       surface->popup->geometry.y - surface->current.geometry.y, &sx, &sy);
 
-  *toplevel_sx = sx + popup_sx;
-  *toplevel_sy = sy + popup_sy;
+  *toplevel_sx = sx + child_sx;
+  *toplevel_sy = sy + child_sy;
 }
 
 static void

--- a/zen/xdg-popup.c
+++ b/zen/xdg-popup.c
@@ -57,15 +57,19 @@ zn_xdg_popup_view_child_impl_get_wlr_surface(struct zn_view_child* child)
 }
 
 static void
-zn_xdg_popup_view_child_impl_get_view_coords(
-    struct zn_view_child* child, int* sx, int* sy)
+zn_xdg_popup_view_child_impl_get_toplevel_coords(struct zn_view_child* child,
+    double popup_sx, double popup_sy, double* toplevel_sx, double* toplevel_sy)
 {
   struct zn_xdg_popup* self = zn_container_of(child, self, base);
   struct wlr_xdg_surface* surface = self->wlr_xdg_popup->base;
 
+  int sx, sy;
   wlr_xdg_popup_get_toplevel_coords(surface->popup,
       surface->popup->geometry.x - surface->current.geometry.x,
-      surface->popup->geometry.y - surface->current.geometry.y, sx, sy);
+      surface->popup->geometry.y - surface->current.geometry.y, &sx, &sy);
+
+  *toplevel_sx = sx + popup_sx;
+  *toplevel_sy = sy + popup_sy;
 }
 
 static void
@@ -81,7 +85,7 @@ zn_xdg_popup_handle_wlr_xdg_surface_destroy(
 
 static const struct zn_view_child_impl zn_xdg_popup_view_child_impl = {
     .get_wlr_surface = zn_xdg_popup_view_child_impl_get_wlr_surface,
-    .get_view_coords = zn_xdg_popup_view_child_impl_get_view_coords,
+    .get_toplevel_coords = zn_xdg_popup_view_child_impl_get_toplevel_coords,
 };
 
 struct zn_xdg_popup*


### PR DESCRIPTION
## Context

See #147

## Summary

Change meaning of view::x, y. It pointing to surface's pos before, but now `geometry` position.

## How to check behavior

Move the view to some position, check that there is no difference between specified pos and appeared pos.

[suggest] insert following line to `view.c:191` (at: `zn_view_map_to_scene`)

```c
zn_view_move(self, NULL, 0, 0);
```
