### PR TITLE
use git submodules for remote display system

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: main
+          submodules: true
 
       - name: Build & Test
         run: meson build && ninja -C build test

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 # Other
 build/
 
-subprojects/*
-!subprojects/*.wrap

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "subprojects/zen-remote-display-system"]
+	path = subprojects/zen-remote-display-system
+	url = https://github.com/zigen-project/zen-remote-display-system.git

--- a/meson.build
+++ b/meson.build
@@ -75,10 +75,10 @@ remote_display_system_option.add_cmake_defines({
 })
 remote_display_system_option.append_compile_args(
   'cpp', 
-  '-fmacro-prefix-map=@0@subprojects/remote-display-system/='.format(relative_source_dir)
+  '-fmacro-prefix-map=@0@subprojects/zen-remote-display-system/='.format(relative_source_dir)
 )
 remote_display_system_proj = cmake.subproject(
-  'remote-display-system',
+  'zen-remote-display-system',
   options: remote_display_system_option,
 )
 

--- a/subprojects/remote-display-system.wrap
+++ b/subprojects/remote-display-system.wrap
@@ -1,5 +1,0 @@
-[wrap-git]
-
-url = https://github.com/zigen-project/zen-remote-display-system.git
-revision = main
-depth = 1


### PR DESCRIPTION
## Context

We used meson's wrap file to fetch [zen-remote-display-system](https://github.com/zigen-project/zen-remote-display-system). But it was hard to develop [zen-remote-display-system](https://github.com/zigen-project/zen-remote-display-system) and this repository at the same time. Using git submodules seems better in this situation.

## Summary

- [x] use git submodules for [zen-remote-display-system](https://github.com/zigen-project/zen-remote-display-system)

## How to check behavior

Check that nothing about behavior have changed
