### PR TITLE
introduce remote display system

### DIFF
--- a/include/zen/immersive/display-system.h
+++ b/include/zen/immersive/display-system.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "zen/immersive/renderer.h"
+
+struct zn_immersive_display_system {
+  struct {
+    struct wl_signal activate;
+    struct wl_signal deactivated;
+  } events;
+};
+
+struct zn_immersive_display_system* zn_immersive_display_system_create(
+    struct wl_display* display, struct zn_immersive_renderer* renderer);
+
+void zn_immersive_display_system_destroy(
+    struct zn_immersive_display_system* self);

--- a/include/zen/immersive/remote/display-system.h
+++ b/include/zen/immersive/remote/display-system.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <wayland-server-core.h>
+#include <zen-desktop-protocol.h>
+
+#include "zen/immersive/display-system.h"
+#include "zen/immersive/remote/renderer.h"
+
+struct zn_remote_display_system {
+  struct zn_immersive_display_system base;
+
+  struct wl_global* global;
+  struct wl_list resources;
+
+  enum zen_display_system_type type;
+
+  struct zn_remote_immersive_renderer* renderer;  // non null
+};

--- a/include/zen/immersive/remote/object/board.h
+++ b/include/zen/immersive/remote/object/board.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "zen/immersive/remote/scene.h"
+#include "zen/scene/board.h"
+
+struct zn_board_remote_object {
+  struct zn_board* board;  // non null;
+
+  struct wl_list link;  // zn_remote_immersive_render::scene::board_object_list
+
+  struct wl_listener board_destroy_listener;
+};
+
+struct zn_board_remote_object* zn_board_remote_object_create(
+    struct zn_board* board, struct zn_remote_scene* remote_scene);
+
+void zn_board_remote_object_destroy(struct zn_board_remote_object* self);

--- a/include/zen/immersive/remote/renderer.h
+++ b/include/zen/immersive/remote/renderer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "zen/immersive/remote/scene.h"
+#include "zen/immersive/renderer.h"
+#include "zen/scene/scene.h"
+
+struct zn_remote_immersive_renderer {
+  struct zn_immersive_renderer base;
+
+  struct zn_remote_scene* remote_scene;
+};
+
+void zn_remote_immersive_renderer_activate(
+    struct zn_remote_immersive_renderer* self);
+
+void zn_remote_immersive_renderer_deactivate(
+    struct zn_remote_immersive_renderer* self);

--- a/include/zen/immersive/remote/scene.h
+++ b/include/zen/immersive/remote/scene.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "zen/scene/scene.h"
+
+struct zn_remote_scene {
+  struct zn_scene* scene;  // non null
+
+  struct wl_list board_object_list;  // zn_board_remote_object::link
+
+  struct wl_listener new_board_listener;
+};
+
+void zn_remote_scene_start_sync(struct zn_remote_scene* self);
+
+void zn_remote_scene_stop_sync(struct zn_remote_scene* self);
+
+struct zn_remote_scene* zn_remote_scene_create(struct zn_scene* scene);
+
+void zn_remote_scene_destroy(struct zn_remote_scene* self);

--- a/include/zen/immersive/renderer.h
+++ b/include/zen/immersive/renderer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "zen/scene/scene.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct zn_immersive_renderer {};
+#pragma GCC diagnostic pop
+
+struct zn_immersive_renderer* zn_immersive_renderer_create(
+    struct zn_scene* scene);
+
+void zn_immersive_renderer_destroy(struct zn_immersive_renderer* self);

--- a/include/zen/scene/board.h
+++ b/include/zen/scene/board.h
@@ -13,8 +13,6 @@ struct zn_board_screen_assigned_event {
 struct zn_board {
   double width, height;
 
-  struct zn_scene *scene;
-
   // List of mapped zn_view in z-order, from bottom to top
   struct wl_list view_list;  // zn_view::link
 
@@ -38,6 +36,6 @@ bool zn_board_is_dangling(struct zn_board *self);
 
 void zn_board_assign_to_screen(struct zn_board *self, struct zn_screen *screen);
 
-struct zn_board *zn_board_create(struct zn_scene *scene);
+struct zn_board *zn_board_create(void);
 
 void zn_board_destroy(struct zn_board *self);

--- a/include/zen/scene/scene.h
+++ b/include/zen/scene/scene.h
@@ -16,6 +16,10 @@ struct zn_scene {
   struct wl_listener unmap_focused_view_listener;
 
   struct wlr_texture* bg_texture;  // nullable
+
+  struct {
+    struct wl_signal new_board;  // (struct zn_board*)
+  } signals;
 };
 
 void zn_scene_set_focused_view(struct zn_scene* self, struct zn_view* view);

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -8,9 +8,11 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/xwayland.h>
+#include <zen-desktop-protocol.h>
 
 #include "zen/config.h"
 #include "zen/decoration-manager.h"
+#include "zen/immersive/display-system.h"
 #include "zen/input/input-manager.h"
 #include "zen/scene/scene.h"
 
@@ -29,11 +31,17 @@ struct zn_server {
 
   struct zn_config *config;
   struct zn_input_manager *input_manager;
+  struct zn_immersive_renderer *immersive_renderer;
+  struct zn_immersive_display_system *immersive_display_system;
 
   struct zn_scene *scene;
 
+  enum zen_display_system_type display_system;
+
   char *socket;
 
+  struct wl_listener immersive_activate_listener;
+  struct wl_listener immersive_deactivated_listener;
   struct wl_listener new_input_listener;
   struct wl_listener new_output_listener;
   struct wl_listener xdg_shell_new_surface_listener;

--- a/zen/immersive/remote/display-system.c
+++ b/zen/immersive/remote/display-system.c
@@ -1,0 +1,121 @@
+#include "zen/immersive/remote/display-system.h"
+
+#include <wayland-server-core.h>
+
+#include "zen-common.h"
+
+static void
+zn_remote_display_system_handle_destroy(struct wl_resource* resource)
+{
+  wl_list_remove(&resource->link);
+}
+
+static void
+zn_remote_display_system_send_applied(struct zn_remote_display_system* self)
+{
+  struct wl_resource* resource;
+
+  wl_resource_for_each (resource, &self->resources) {
+    zen_display_system_send_applied(resource, self->type);
+  }
+}
+
+static void
+zn_remote_display_system_protocol_switch_type(
+    struct wl_client* client, struct wl_resource* resource, uint32_t type)
+{
+  struct zn_remote_display_system* self = wl_resource_get_user_data(resource);
+  UNUSED(client);
+
+  if (self->type == type) return;
+  self->type = type;
+
+  if (type == ZEN_DISPLAY_SYSTEM_TYPE_IMMERSIVE) {
+    wl_signal_emit(&self->base.events.activate, NULL);
+    zn_remote_immersive_renderer_activate(self->renderer);
+  } else {
+    zn_remote_immersive_renderer_deactivate(self->renderer);
+    wl_signal_emit(&self->base.events.deactivated, NULL);
+  }
+
+  zn_remote_display_system_send_applied(self);
+}
+
+static void
+zn_remote_display_system_protocol_release(
+    struct wl_client* client, struct wl_resource* resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+
+static const struct zen_display_system_interface zn_display_system_interface = {
+    .switch_type = zn_remote_display_system_protocol_switch_type,
+    .release = zn_remote_display_system_protocol_release,
+};
+
+static void
+zn_remote_display_system_bind(
+    struct wl_client* client, void* data, uint32_t version, uint32_t id)
+{
+  struct zn_remote_display_system* self = data;
+  struct wl_resource* resource;
+
+  resource =
+      wl_resource_create(client, &zen_display_system_interface, version, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    zn_error("Failed to create a wl_resource");
+    return;
+  }
+
+  wl_resource_set_implementation(resource, &zn_display_system_interface, self,
+      zn_remote_display_system_handle_destroy);
+
+  wl_list_insert(&self->resources, &resource->link);
+
+  zen_display_system_send_applied(resource, self->type);
+}
+
+struct zn_immersive_display_system*
+zn_immersive_display_system_create(
+    struct wl_display* display, struct zn_immersive_renderer* renderer)
+{
+  struct zn_remote_display_system* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->global = wl_global_create(display, &zen_display_system_interface, 1,
+      self, zn_remote_display_system_bind);
+
+  self->type = ZEN_DISPLAY_SYSTEM_TYPE_SCREEN;
+  wl_list_init(&self->resources);
+
+  self->renderer = zn_container_of(renderer, self->renderer, base);
+
+  wl_signal_init(&self->base.events.activate);
+  wl_signal_init(&self->base.events.deactivated);
+
+  return &self->base;
+
+err:
+  return NULL;
+}
+
+void
+zn_immersive_display_system_destroy(struct zn_immersive_display_system* parent)
+{
+  struct zn_remote_display_system* self = zn_container_of(parent, self, base);
+
+  wl_global_destroy(self->global);
+  wl_list_remove(&self->resources);
+
+  wl_list_remove(&self->base.events.activate.listener_list);
+  wl_list_remove(&self->base.events.deactivated.listener_list);
+
+  free(self);
+}

--- a/zen/immersive/remote/object/board.c
+++ b/zen/immersive/remote/object/board.c
@@ -1,0 +1,47 @@
+#include "zen/immersive/remote/object/board.h"
+
+#include "zen-common.h"
+
+static void
+zn_board_remote_object_handle_board_destroy(
+    struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zn_board_remote_object* self =
+      zn_container_of(listener, self, board_destroy_listener);
+
+  zn_board_remote_object_destroy(self);
+}
+
+struct zn_board_remote_object*
+zn_board_remote_object_create(
+    struct zn_board* board, struct zn_remote_scene* remote_scene)
+{
+  struct zn_board_remote_object* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->board = board;
+  self->board_destroy_listener.notify =
+      zn_board_remote_object_handle_board_destroy;
+  wl_signal_add(&board->events.destroy, &self->board_destroy_listener);
+
+  wl_list_insert(&remote_scene->board_object_list, &self->link);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_board_remote_object_destroy(struct zn_board_remote_object* self)
+{
+  wl_list_remove(&self->link);
+  wl_list_remove(&self->board_destroy_listener.link);
+  free(self);
+}

--- a/zen/immersive/remote/renderer.c
+++ b/zen/immersive/remote/renderer.c
@@ -1,0 +1,53 @@
+#include "zen/immersive/remote/renderer.h"
+
+#include "zen-common.h"
+#include "zen/immersive/remote/object/board.h"
+
+void
+zn_remote_immersive_renderer_activate(struct zn_remote_immersive_renderer* self)
+{
+  zn_remote_scene_start_sync(self->remote_scene);
+}
+
+void
+zn_remote_immersive_renderer_deactivate(
+    struct zn_remote_immersive_renderer* self)
+{
+  zn_remote_scene_stop_sync(self->remote_scene);
+}
+
+struct zn_immersive_renderer*
+zn_immersive_renderer_create(struct zn_scene* scene)
+{
+  struct zn_remote_immersive_renderer* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->remote_scene = zn_remote_scene_create(scene);
+  if (self->remote_scene == NULL) {
+    zn_error("Failed to create a remote scene");
+    goto err_free;
+  }
+
+  return &self->base;
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+void
+zn_immersive_renderer_destroy(struct zn_immersive_renderer* parent)
+{
+  struct zn_remote_immersive_renderer* self =
+      zn_container_of(parent, self, base);
+
+  zn_remote_scene_destroy(self->remote_scene);
+  free(self);
+}

--- a/zen/immersive/remote/scene.c
+++ b/zen/immersive/remote/scene.c
@@ -1,0 +1,86 @@
+#include "zen/immersive/remote/scene.h"
+
+#include "zen-common.h"
+#include "zen/immersive/remote/object/board.h"
+
+static void
+zn_remote_scene_handle_new_board(struct wl_listener* listener, void* data)
+{
+  struct zn_remote_scene* self =
+      zn_container_of(listener, self, new_board_listener);
+
+  struct zn_board* board = data;
+
+  zn_board_remote_object_create(board, self);
+}
+
+static void
+zn_remote_scene_clean(struct zn_remote_scene* self)
+{
+  struct zn_board_remote_object *board_object, *tmp;
+
+  wl_list_for_each_safe (board_object, tmp, &self->board_object_list, link) {
+    zn_board_remote_object_destroy(board_object);
+  }
+}
+
+static void
+zn_remote_scene_clean_build(struct zn_remote_scene* self)
+{
+  struct zn_board* board;
+
+  zn_remote_scene_clean(self);
+
+  wl_list_for_each (board, &self->scene->board_list, link) {
+    zn_board_remote_object_create(board, self);
+  }
+}
+
+void
+zn_remote_scene_start_sync(struct zn_remote_scene* self)
+{
+  zn_remote_scene_clean_build(self);
+
+  wl_signal_add(&self->scene->signals.new_board, &self->new_board_listener);
+}
+
+void
+zn_remote_scene_stop_sync(struct zn_remote_scene* self)
+{
+  wl_list_remove(&self->new_board_listener.link);
+  wl_list_init(&self->new_board_listener.link);
+
+  zn_remote_scene_clean(self);
+}
+
+struct zn_remote_scene*
+zn_remote_scene_create(struct zn_scene* scene)
+{
+  struct zn_remote_scene* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->scene = scene;
+
+  wl_list_init(&self->board_object_list);
+
+  self->new_board_listener.notify = zn_remote_scene_handle_new_board;
+  wl_list_init(&self->new_board_listener.link);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_remote_scene_destroy(struct zn_remote_scene* self)
+{
+  wl_list_remove(&self->board_object_list);
+  wl_list_remove(&self->new_board_listener.link);
+  free(self);
+}

--- a/zen/input/pointer.c
+++ b/zen/input/pointer.c
@@ -17,7 +17,11 @@ zn_pointer_handle_motion(struct wl_listener* listener, void* data)
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
   struct wlr_event_pointer_motion* event = data;
 
-  cursor->grab->interface->motion(cursor->grab, event);
+  if (server->display_system == ZEN_DISPLAY_SYSTEM_TYPE_SCREEN) {
+    cursor->grab->interface->motion(cursor->grab, event);
+  } else {
+    // TODO: ray
+  }
 }
 
 static void
@@ -28,7 +32,11 @@ zn_pointer_handle_button(struct wl_listener* listener, void* data)
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
   struct wlr_event_pointer_button* event = data;
 
-  cursor->grab->interface->button(cursor->grab, event);
+  if (server->display_system == ZEN_DISPLAY_SYSTEM_TYPE_SCREEN) {
+    cursor->grab->interface->button(cursor->grab, event);
+  } else {
+    // TODO: ray
+  }
 }
 
 static void
@@ -39,7 +47,11 @@ zn_pointer_handle_axis(struct wl_listener* listener, void* data)
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
   struct wlr_event_pointer_axis* event = data;
 
-  cursor->grab->interface->axis(cursor->grab, event);
+  if (server->display_system == ZEN_DISPLAY_SYSTEM_TYPE_SCREEN) {
+    cursor->grab->interface->axis(cursor->grab, event);
+  } else {
+    // TODO: ray
+  }
 }
 
 static void
@@ -50,7 +62,11 @@ zn_pointer_handle_frame(struct wl_listener* listener, void* data)
   struct zn_server* server = zn_server_get_singleton();
   struct zn_cursor* cursor = server->input_manager->seat->cursor;
 
-  cursor->grab->interface->frame(cursor->grab);
+  if (server->display_system == ZEN_DISPLAY_SYSTEM_TYPE_SCREEN) {
+    cursor->grab->interface->frame(cursor->grab);
+  } else {
+    // TODO: ray
+  }
 }
 
 struct zn_pointer*

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -20,6 +20,11 @@ _zen_desktop_srcs = [
   'xdg-toplevel-view.c',
   'xwayland-view.c',
 
+  'immersive/remote/display-system.c',
+  'immersive/remote/object/board.c',
+  'immersive/remote/renderer.c',
+  'immersive/remote/scene.c',
+
   'input/cursor-grab-move.c',
   'input/cursor-grab-resize.c',
   'input/input-device.c',

--- a/zen/output.c
+++ b/zen/output.c
@@ -94,10 +94,16 @@ zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
 {
   struct zn_output *self =
       zn_container_of(listener, self, damage_frame_listener);
+  struct zn_server *server = zn_server_get_singleton();
   struct timespec now;
   UNUSED(data);
 
   if (self->wlr_output->enabled == false) return;
+
+  if (server->display_system == ZEN_DISPLAY_SYSTEM_TYPE_IMMERSIVE) {
+    // TODO: Display an indication that an immersive display system is in use.
+    return;
+  }
 
   // TODO: add delay to call zn_output_repaint_timer_handler
 

--- a/zen/scene/board.c
+++ b/zen/scene/board.c
@@ -61,7 +61,7 @@ zn_board_assign_to_screen(struct zn_board *self, struct zn_screen *screen)
 }
 
 struct zn_board *
-zn_board_create(struct zn_scene *scene)
+zn_board_create(void)
 {
   struct zn_board *self;
 
@@ -74,11 +74,7 @@ zn_board_create(struct zn_scene *scene)
   self->width = 1920;
   self->height = 1080;
 
-  self->scene = scene;
-
   wl_list_init(&self->view_list);
-
-  wl_list_insert(scene->board_list.prev, &self->link);
 
   wl_list_init(&self->screen_link);
   self->screen = NULL;

--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -51,6 +51,24 @@ zn_scene_move_board_binding_handler(
   }
 }
 
+static struct zn_board*
+zn_scene_new_board(struct zn_scene* self)
+{
+  struct zn_board* board;
+
+  board = zn_board_create();
+  if (board == NULL) {
+    zn_error("Failed to create a new board");
+    return NULL;
+  }
+
+  wl_list_insert(self->board_list.prev, &board->link);
+
+  wl_signal_emit(&self->signals.new_board, board);
+
+  return board;
+}
+
 static void
 zn_scene_new_board_binding_handler(uint32_t time_msec, uint32_t key, void* data)
 {
@@ -62,9 +80,8 @@ zn_scene_new_board_binding_handler(uint32_t time_msec, uint32_t key, void* data)
 
   if (screen == NULL) return;
 
-  board = zn_board_create(self);
+  board = zn_scene_new_board(self);
   if (board == NULL) {
-    zn_error("Failed to creaet a new board");
     return;
   }
 
@@ -127,7 +144,7 @@ zn_scene_ensure_dangling_board(struct zn_scene* self)
     }
   }
 
-  return zn_board_create(self);
+  return zn_scene_new_board(self);
 }
 
 /** Keep this idempotent. */
@@ -235,20 +252,25 @@ zn_scene_create(struct zn_config* config)
 
   wl_list_init(&self->board_list);
 
-  board = zn_board_create(self);
-  if (board == NULL) {
-    zn_error("Failed to create a initial board");
-    goto err_screen_layout;
-  }
-
   zn_scene_setup_background(self, config->bg_image_file);
 
   self->unmap_focused_view_listener.notify = zn_scene_handle_unmap_focused_view;
   wl_list_init(&self->unmap_focused_view_listener.link);
 
+  wl_signal_init(&self->signals.new_board);
+
+  board = zn_scene_new_board(self);
+  if (board == NULL) {
+    goto err_bg_texture;
+  }
+
   return self;
 
-err_screen_layout:
+err_bg_texture:
+  if (self->bg_texture != NULL) {
+    wlr_texture_destroy(self->bg_texture);
+  }
+
   zn_screen_layout_destroy(self->screen_layout);
 
 err_free:
@@ -277,6 +299,7 @@ zn_scene_destroy(struct zn_scene* self)
 
   zn_screen_layout_destroy(self->screen_layout);
 
+  wl_list_remove(&self->signals.new_board.listener_list);
   wl_list_remove(&self->unmap_focused_view_listener.link);
 
   free(self);


### PR DESCRIPTION
## Context

Introduce remote immersive display system

## Summary

- [x] implement display system switch
  - switch display system using `cui-client`
  - stop updating screen display system when using immersive display system
  - stop cursor event when using immersive display system
- [x] introduce building `remote-scene`
  - `remote-scene` consists of `remote-object`s
  - `zn_board_remote_object` is the first `remote-object`
  - `remote-scene` is basically mirror of `zn_scene`. `zn_scene` represents pure logic, and `remote-scene` constructs the information necessary for drawing, such as meshes, from the properties of `zn_scene`.

Any known unfinished work is left as TODO comments.

## How to check behavior

1. Build and run
2. Start `cui-client` and type "immersive". After that, the screen will not be updated and cursor will be unavailable.
3. During "immersive" display mode, the count of `zn_board` and `zn_board_remote_object` will be synchronized.

You can check the behavior by adding debugging code shown below.

```c
static void
zn_remote_scene_handle_new_board(struct wl_listener* listener, void* data)
{
  struct zn_remote_scene* self =
      zn_container_of(listener, self, new_board_listener);

  struct zn_board* board = data;

  zn_board_remote_object_create(board, self);

  zn_info("%d boards", wl_list_length(&self->board_object_list)); // HERE
}
```

```c
static void
zn_remote_scene_clean_build(struct zn_remote_scene* self)
{
  struct zn_board* board;

  zn_remote_scene_clean(self);

  wl_list_for_each (board, &self->scene->board_list, link) {
    zn_board_remote_object_create(board, self);
  }
  zn_info("%d boards", wl_list_length(&self->board_object_list)); // HERE
}
```