### PR TITLE
Implement move/resize to x client by server-side decoration

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -38,6 +38,8 @@ void zn_cursor_start_grab(struct zn_cursor* self, struct zn_cursor_grab* grab);
 
 void zn_cursor_end_grab(struct zn_cursor* self);
 
+const char* zn_cursor_get_resize_xcursor_name(uint32_t edges);
+
 void zn_cursor_move_relative(struct zn_cursor* self, double dx, double dy);
 
 void zn_cursor_get_fbox(struct zn_cursor* self, struct wlr_fbox* fbox);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -38,7 +38,7 @@ void zn_cursor_start_grab(struct zn_cursor* self, struct zn_cursor_grab* grab);
 
 void zn_cursor_end_grab(struct zn_cursor* self);
 
-const char* zn_cursor_get_resize_xcursor_name(uint32_t edges);
+void zn_cursor_set_resizing_cursor(struct zn_cursor* self, uint32_t edges);
 
 void zn_cursor_move_relative(struct zn_cursor* self, double dx, double dy);
 

--- a/include/zen/input/cursor-grab-resize.h
+++ b/include/zen/input/cursor-grab-resize.h
@@ -8,7 +8,7 @@ struct zn_cursor_grab_resize {
   struct zn_cursor_grab base;
   struct zn_view* view;
 
-  double init_view_width, init_view_height;
+  double init_width, init_height;
   double init_cursor_x, init_cursor_y;
 
   struct wl_listener view_unmap_listener;

--- a/include/zen/scene/screen.h
+++ b/include/zen/scene/screen.h
@@ -6,6 +6,7 @@
 #include "zen/output.h"
 #include "zen/scene/board.h"
 #include "zen/scene/screen-layout.h"
+#include "zen/scene/view.h"
 
 typedef void (*zn_screen_for_each_visible_surface_callback_t)(
     struct wlr_surface *surface, void *user_data);
@@ -28,6 +29,13 @@ struct zn_screen {
 
 void zn_screen_for_each_visible_surface(struct zn_screen *self,
     zn_screen_for_each_visible_surface_callback_t callback, void *data);
+
+/**
+ * @param view can be NULL
+ * @retval bits sum of enum zn_view_area_type
+ */
+uint32_t zn_screen_get_view_area_type_at(
+    struct zn_screen *self, double x, double y, struct zn_view **view);
 
 /**
  * @param surface_x can be NULL

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -64,7 +64,7 @@ struct zn_view {
   } resize_status;
 
   struct {
-    struct wl_signal surface_resized;
+    struct wl_signal surface_resized;  // (struct wlr_surface)
     struct wl_signal unmap;
     struct wl_signal destroy;
   } events;

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -99,6 +99,12 @@ void zn_view_map_to_scene(struct zn_view *self, struct zn_scene *scene);
 
 void zn_view_unmap(struct zn_view *self);
 
+/**
+ * @retval bits sum of enum wlr_edges
+ * @param type bits sum of enum zn_view_area_type
+ */
+uint32_t zn_view_convert_area_type_to_wlr_edges(uint32_t type);
+
 void zn_view_init(struct zn_view *self, enum zn_view_type type,
     const struct zn_view_impl *impl);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -70,14 +70,6 @@ struct zn_view {
   } events;
 };
 
-/**
- * Add the damage of all surfaces associated with the view to the output where
- * the view is displayed.
- */
-void zn_view_damage(struct zn_view *self);
-
-void zn_view_damage_whole(struct zn_view *self);
-
 void zn_view_bring_to_front(struct zn_view *self);
 
 /**
@@ -86,6 +78,14 @@ void zn_view_bring_to_front(struct zn_view *self);
  */
 void zn_view_move(struct zn_view *self, struct zn_board *new_board,
     double board_x, double board_y);
+
+/**
+ * Add the damage of all surfaces associated with the view to the output where
+ * the view is displayed.
+ */
+void zn_view_damage(struct zn_view *self);
+
+void zn_view_damage_whole(struct zn_view *self);
 
 void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -64,7 +64,7 @@ struct zn_view {
   } resize_status;
 
   struct {
-    struct wl_signal surface_resized;  // (struct wlr_surface)
+    struct wl_signal surface_resized;
     struct wl_signal unmap;
     struct wl_signal destroy;
   } events;

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -55,6 +55,8 @@ struct zn_view {
 
   bool requested_client_decoration;
 
+  struct wl_listener surface_resized_listener;
+
   struct {
     bool resizing;
     uint32_t edges;
@@ -62,6 +64,7 @@ struct zn_view {
   } resize_status;
 
   struct {
+    struct wl_signal surface_resized;
     struct wl_signal unmap;
     struct wl_signal destroy;
   } events;
@@ -76,9 +79,6 @@ void zn_view_damage(struct zn_view *self);
 void zn_view_damage_whole(struct zn_view *self);
 
 void zn_view_bring_to_front(struct zn_view *self);
-
-void zn_view_update_pos_on_resizing(
-    struct zn_view *self, struct wlr_surface *surface);
 
 /**
  * @param board must not be NULL except when this view is unmapped with

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -67,15 +67,6 @@ struct zn_view {
   } events;
 };
 
-void zn_view_bring_to_front(struct zn_view *self);
-
-/**
- * @param board must not be NULL except when this view is unmapped with
- * `zn_view_unmap`
- */
-void zn_view_move(struct zn_view *self, struct zn_board *new_board,
-    double board_x, double board_y);
-
 /**
  * Add the damage of all surfaces associated with the view to the output where
  * the view id displayed.
@@ -83,6 +74,18 @@ void zn_view_move(struct zn_view *self, struct zn_board *new_board,
 void zn_view_damage(struct zn_view *self);
 
 void zn_view_damage_whole(struct zn_view *self);
+
+void zn_view_bring_to_front(struct zn_view *self);
+
+void zn_view_update_pos_on_resizing(
+    struct zn_view *self, struct wlr_surface *surface);
+
+/**
+ * @param board must not be NULL except when this view is unmapped with
+ * `zn_view_unmap`
+ */
+void zn_view_move(struct zn_view *self, struct zn_board *new_board,
+    double board_x, double board_y);
 
 void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -72,7 +72,7 @@ struct zn_view {
 
 /**
  * Add the damage of all surfaces associated with the view to the output where
- * the view id displayed.
+ * the view is displayed.
  */
 void zn_view_damage(struct zn_view *self);
 

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -7,7 +7,7 @@
 
 #include "zen/scene/scene.h"
 
-#define VIEW_DECORATION_BORDER 3
+#define VIEW_DECORATION_BORDER 8
 #define VIEW_DECORATION_TITLEBAR 27
 
 struct zn_view;

--- a/include/zen/scene/view.h
+++ b/include/zen/scene/view.h
@@ -32,6 +32,17 @@ enum zn_view_type {
   ZN_VIEW_XWAYLAND,
 };
 
+enum zn_view_area_type {
+  ZN_VIEW_AREA_TYPE_INVALID = 0,
+  ZN_VIEW_AREA_TYPE_SURFACE = 1 << 0,
+  ZN_VIEW_AREA_TYPE_TITLEBAR = 1 << 1,
+
+  ZN_VIEW_AREA_TYPE_BORDER_TOP = 1 << 2,
+  ZN_VIEW_AREA_TYPE_BORDER_BOTTOM = 1 << 3,
+  ZN_VIEW_AREA_TYPE_BORDER_LEFT = 1 << 4,
+  ZN_VIEW_AREA_TYPE_BORDER_RIGHT = 1 << 5,
+};
+
 struct zn_view {
   double x, y;
 

--- a/include/zen/wlr/box.h
+++ b/include/zen/wlr/box.h
@@ -2,5 +2,7 @@
 
 #include <wlr/util/box.h>
 
+bool zn_wlr_fbox_contains_point(const struct wlr_fbox* box, double x, double y);
+
 void zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,
     double* dest_x, double* dest_y);

--- a/include/zen/xwayland-view.h
+++ b/include/zen/xwayland-view.h
@@ -10,6 +10,9 @@ struct zn_xwayland_view {
   struct zn_view base;
   struct wlr_xwayland_surface *wlr_xwayland_surface;  // nonnull
 
+  /** last handled serial */
+  uint64_t current_resize_serial;
+
   struct zn_server *server;
 
   struct wl_listener map_listener;

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -72,9 +72,6 @@ default_grab_button(
     return;
   }
 
-  wlr_seat_pointer_send_button(
-      seat, event->time_msec, event->button, event->state);
-
   if (event->state == WLR_BUTTON_PRESSED) {
     const uint32_t type = zn_screen_get_view_area_type_at(
         grab->cursor->screen, grab->cursor->x, grab->cursor->y, &view);
@@ -82,12 +79,17 @@ default_grab_button(
 
     if (type == ZN_VIEW_AREA_TYPE_TITLEBAR) {
       zn_cursor_grab_move_start(cursor, view);
+      return;
     }
     if (type >= ZN_VIEW_AREA_TYPE_BORDER_TOP) {
       const uint32_t edges = zn_view_convert_area_type_to_wlr_edges(type);
       zn_cursor_grab_resize_start(cursor, view, edges);
+      return;
     }
   }
+
+  wlr_seat_pointer_send_button(
+      seat, event->time_msec, event->button, event->state);
 }
 
 static void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -50,31 +50,8 @@ default_grab_motion(
     return;
   }
 
-  char vertical = '\0', horizontal = '\0';
-  if (type & ZN_VIEW_AREA_TYPE_BORDER_LEFT) {
-    horizontal = 'w';
-  }
-  if (type & ZN_VIEW_AREA_TYPE_BORDER_RIGHT) {
-    horizontal = 'e';
-  }
-  if (type & ZN_VIEW_AREA_TYPE_BORDER_TOP) {
-    vertical = 'n';
-  }
-  if (type & ZN_VIEW_AREA_TYPE_BORDER_BOTTOM) {
-    vertical = 's';
-  }
-
-  // [ns][we]-resize
-  char cursor_name[10] = "xx-resize", *p = cursor_name + 2;
-  if (horizontal) {
-    --p;
-    *p = horizontal;
-  }
-  if (vertical) {
-    --p;
-    *p = vertical;
-  }
-  zn_cursor_set_xcursor(grab->cursor, p);
+  zn_cursor_set_xcursor(
+      grab->cursor, zn_cursor_get_resize_xcursor_name(type >> 2));
 }
 
 static void
@@ -308,6 +285,26 @@ zn_cursor_end_grab(struct zn_cursor* self)
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
   }
+}
+
+/**
+ * @param edges bits sum of enum wlr_edges
+ */
+const char*
+zn_cursor_get_resize_xcursor_name(uint32_t edges)
+{
+  const char* xcursor_name[] = {
+      [WLR_EDGE_TOP] = "top_side",
+      [WLR_EDGE_BOTTOM] = "bottom_side",
+      [WLR_EDGE_LEFT] = "left_side",
+      [WLR_EDGE_RIGHT] = "right_side",
+      [WLR_EDGE_TOP | WLR_EDGE_LEFT] = "top_left_corner",
+      [WLR_EDGE_TOP | WLR_EDGE_RIGHT] = "top_right_corner",
+      [WLR_EDGE_BOTTOM | WLR_EDGE_LEFT] = "bottom_left_corner",
+      [WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT] = "bottom_right_corner",
+  };
+
+  return xcursor_name[edges];
 }
 
 void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -50,8 +50,8 @@ default_grab_motion(
     return;
   }
 
-  zn_cursor_set_xcursor(
-      grab->cursor, zn_cursor_get_resize_xcursor_name(type >> 2));
+  const uint32_t edges = zn_view_convert_area_type_to_wlr_edges(type);
+  zn_cursor_set_xcursor(grab->cursor, zn_cursor_get_resize_xcursor_name(edges));
 }
 
 static void
@@ -79,9 +79,8 @@ default_grab_button(
       zn_cursor_grab_move_start(cursor, view);
     }
     if (type >= ZN_VIEW_AREA_TYPE_BORDER_TOP) {
-      // WLR_EDGE_TOP                 == 1 << 0
-      // ZN_VIEW_AREA_TYPE_BORDER_TOP == 1 << 2
-      zn_cursor_grab_resize_start(cursor, view, type >> 2);
+      const uint32_t edges = zn_view_convert_area_type_to_wlr_edges(type);
+      zn_cursor_grab_resize_start(cursor, view, edges);
     }
   }
 }

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -48,7 +48,7 @@ default_grab_motion(
     }
   }
 
-  if (type < ZN_VIEW_AREA_TYPE_BORDER_TOP) {
+  if (type == ZN_VIEW_AREA_TYPE_INVALID || type == ZN_VIEW_AREA_TYPE_TITLEBAR) {
     zn_cursor_set_xcursor(grab->cursor, "left_ptr");
     wlr_seat_pointer_clear_focus(seat);
     return;

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -51,7 +51,7 @@ default_grab_motion(
   }
 
   const uint32_t edges = zn_view_convert_area_type_to_wlr_edges(type);
-  zn_cursor_set_xcursor(grab->cursor, zn_cursor_get_resize_xcursor_name(edges));
+  zn_cursor_set_resizing_cursor(grab->cursor, edges);
 }
 
 static void
@@ -289,8 +289,8 @@ zn_cursor_end_grab(struct zn_cursor* self)
 /**
  * @param edges bits sum of enum wlr_edges
  */
-const char*
-zn_cursor_get_resize_xcursor_name(uint32_t edges)
+void
+zn_cursor_set_resizing_cursor(struct zn_cursor* self, uint32_t edges)
 {
   const char* xcursor_name[] = {
       [WLR_EDGE_TOP] = "top_side",
@@ -303,7 +303,7 @@ zn_cursor_get_resize_xcursor_name(uint32_t edges)
       [WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT] = "bottom_right_corner",
   };
 
-  return xcursor_name[edges];
+  zn_cursor_set_xcursor(self, xcursor_name[edges]);
 }
 
 void

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -48,9 +48,10 @@ default_grab_motion(
     }
   }
 
+  wlr_seat_pointer_clear_focus(seat);
+
   if (type == ZN_VIEW_AREA_TYPE_INVALID || type == ZN_VIEW_AREA_TYPE_TITLEBAR) {
     zn_cursor_set_xcursor(grab->cursor, "left_ptr");
-    wlr_seat_pointer_clear_focus(seat);
     return;
   }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -29,6 +29,10 @@ default_grab_motion(
     return;
   }
 
+  if (!grab->cursor->surface) {
+    zn_cursor_set_xcursor(grab->cursor, "left_ptr");
+  }
+
   const uint32_t type = zn_screen_get_view_area_type_at(
       grab->cursor->screen, grab->cursor->x, grab->cursor->y, NULL);
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -91,12 +91,10 @@ default_grab_button(
       seat, event->time_msec, event->button, event->state);
 
   if (event->state == WLR_BUTTON_PRESSED) {
-    zn_screen_get_surface_at(
-        cursor->screen, cursor->x, cursor->y, NULL, NULL, &view);
-    zn_scene_set_focused_view(server->scene, view);
-
     const uint32_t type = zn_screen_get_view_area_type_at(
         grab->cursor->screen, grab->cursor->x, grab->cursor->y, &view);
+    zn_scene_set_focused_view(server->scene, view);
+
     if (type == ZN_VIEW_AREA_TYPE_TITLEBAR) {
       zn_cursor_grab_move_start(cursor, view);
     }

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -17,8 +17,8 @@ resize_grab_motion(
     return;
   }
 
-  double width = self->init_view_width;
-  double height = self->init_view_height;
+  double width = self->init_width;
+  double height = self->init_height;
   const double diff_width = grab->cursor->x - self->init_cursor_x;
   const double diff_height = grab->cursor->y - self->init_cursor_y;
 
@@ -86,7 +86,7 @@ resize_grab_cancel(struct zn_cursor_grab* grab)
   struct zn_cursor_grab_resize* self = zn_container_of(grab, self, base);
   self->view->resize_status.resizing = true;
   self->view->resize_status.last_serial = self->view->impl->set_size(
-      self->view, self->init_view_width, self->init_view_height);
+      self->view, self->init_width, self->init_height);
   zn_cursor_grab_resize_end(self);
 }
 
@@ -124,15 +124,14 @@ zn_cursor_grab_resize_create(
   struct wlr_fbox box;
   zn_view_get_view_fbox(view, &box);
 
-  self->init_view_width = box.width;
-  self->init_view_height = box.height;
+  self->init_width = box.width;
+  self->init_height = box.height;
   self->init_cursor_x = cursor->x;
   self->init_cursor_y = cursor->y;
 
   if (!zn_view_has_client_decoration(view)) {
-    self->init_view_width -= VIEW_DECORATION_BORDER * 2;
-    self->init_view_height -=
-        VIEW_DECORATION_BORDER * 2 + VIEW_DECORATION_TITLEBAR;
+    self->init_width -= VIEW_DECORATION_BORDER * 2;
+    self->init_height -= VIEW_DECORATION_BORDER * 2 + VIEW_DECORATION_TITLEBAR;
   }
 
   self->view = view;

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -162,6 +162,7 @@ zn_cursor_grab_resize_start(
     return;
   }
 
+  zn_debug(">> edge: %d", edges);
   const char* xcursor_name[] = {
       [WLR_EDGE_TOP] = "n-resize",
       [WLR_EDGE_BOTTOM] = "s-resize",

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -175,18 +175,7 @@ zn_cursor_grab_resize_start(
     return;
   }
 
-  const char* xcursor_name[] = {
-      [WLR_EDGE_TOP] = "n-resize",
-      [WLR_EDGE_BOTTOM] = "s-resize",
-      [WLR_EDGE_LEFT] = "w-resize",
-      [WLR_EDGE_RIGHT] = "e-resize",
-      [WLR_EDGE_TOP | WLR_EDGE_LEFT] = "nw-resize",
-      [WLR_EDGE_TOP | WLR_EDGE_RIGHT] = "ne-resize",
-      [WLR_EDGE_BOTTOM | WLR_EDGE_LEFT] = "sw-resize",
-      [WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT] = "se-resize",
-  };
-
   wlr_seat_pointer_clear_focus(seat);
-  zn_cursor_set_xcursor(cursor, xcursor_name[edges]);
+  zn_cursor_set_xcursor(cursor, zn_cursor_get_resize_xcursor_name(edges));
   zn_cursor_start_grab(cursor, &self->base);
 }

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -176,6 +176,6 @@ zn_cursor_grab_resize_start(
   }
 
   wlr_seat_pointer_clear_focus(seat);
-  zn_cursor_set_xcursor(cursor, zn_cursor_get_resize_xcursor_name(edges));
+  zn_cursor_set_resizing_cursor(cursor, edges);
   zn_cursor_start_grab(cursor, &self->base);
 }

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -122,6 +122,12 @@ zn_cursor_grab_resize_create(
   self->init_cursor_x = cursor->x;
   self->init_cursor_y = cursor->y;
 
+  if (!zn_view_has_client_decoration(view)) {
+    self->init_view_width -= VIEW_DECORATION_BORDER * 2;
+    self->init_view_height -=
+        VIEW_DECORATION_BORDER * 2 + VIEW_DECORATION_TITLEBAR;
+  }
+
   self->view = view;
   self->base.interface = &resize_grab_interface;
   self->base.cursor = cursor;

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -168,7 +168,6 @@ zn_cursor_grab_resize_start(
     return;
   }
 
-  zn_debug(">> edge: %d", edges);
   const char* xcursor_name[] = {
       [WLR_EDGE_TOP] = "n-resize",
       [WLR_EDGE_BOTTOM] = "s-resize",

--- a/zen/input/cursor-grab-resize.c
+++ b/zen/input/cursor-grab-resize.c
@@ -35,6 +35,13 @@ resize_grab_motion(
     height += diff_height;
   }
 
+  if (width <= 0) {
+    width = 1;
+  }
+  if (height <= 0) {
+    height = 1;
+  }
+
   self->view->resize_status.resizing = true;
   self->view->resize_status.last_serial =
       self->view->impl->set_size(self->view, width, height);

--- a/zen/scene/screen.c
+++ b/zen/scene/screen.c
@@ -85,16 +85,17 @@ zn_screen_get_view_area_type_at(
     }
 
     uint32_t edges = 0;
-    uint32_t iter[4] = {
+    uint32_t borders[4] = {
         ZN_VIEW_AREA_TYPE_BORDER_TOP,
         ZN_VIEW_AREA_TYPE_BORDER_BOTTOM,
         ZN_VIEW_AREA_TYPE_BORDER_LEFT,
         ZN_VIEW_AREA_TYPE_BORDER_RIGHT,
     };
 
-    for (int i = 0; i < 4; ++i) {
-      /** w == view width, h == view height
-       *  B == VIEW_DECORATION_BORDER
+    for (unsigned long int i = 0; i < ARRAY_LENGTH(borders); ++i) {
+      /**
+       * w == view width, h == view height
+       * B == VIEW_DECORATION_BORDER
        *  box.? |  x  |  y  | w | h
        * =======+=====+=====+===+===
        *    Top |  0  |  0  | w | B
@@ -103,22 +104,26 @@ zn_screen_get_view_area_type_at(
        *  Right | w-B |  0  | B | h
        */
       fbox = (struct wlr_fbox){
-          .x = view_iterator->x + ((iter[i] == ZN_VIEW_AREA_TYPE_BORDER_RIGHT)
-                                          ? view_width - VIEW_DECORATION_BORDER
-                                          : 0),
-          .y = view_iterator->y + ((iter[i] == ZN_VIEW_AREA_TYPE_BORDER_BOTTOM)
-                                          ? view_height - VIEW_DECORATION_BORDER
-                                          : 0),
-          .width = (iter[i] <= ZN_VIEW_AREA_TYPE_BORDER_BOTTOM)
-                       ? view_width
-                       : VIEW_DECORATION_BORDER,
-          .height = (iter[i] <= ZN_VIEW_AREA_TYPE_BORDER_BOTTOM)
+          .x = view_iterator->x +  //
+               ((borders[i] == ZN_VIEW_AREA_TYPE_BORDER_RIGHT)
+                       ? view_width - VIEW_DECORATION_BORDER
+                       : 0),
+          .y = view_iterator->y +  //
+               ((borders[i] == ZN_VIEW_AREA_TYPE_BORDER_BOTTOM)
+                       ? view_height - VIEW_DECORATION_BORDER
+                       : 0),
+          .width = (borders[i] & (ZN_VIEW_AREA_TYPE_BORDER_LEFT |
+                                     ZN_VIEW_AREA_TYPE_BORDER_RIGHT))
+                       ? VIEW_DECORATION_BORDER
+                       : view_width,
+          .height = (borders[i] & (ZN_VIEW_AREA_TYPE_BORDER_TOP |
+                                      ZN_VIEW_AREA_TYPE_BORDER_BOTTOM))
                         ? VIEW_DECORATION_BORDER
                         : view_height,
       };
 
       if (zn_wlr_fbox_contains_point(&fbox, x, y)) {
-        edges |= iter[i];
+        edges |= borders[i];
       }
     }
 

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -1,5 +1,6 @@
 #include "zen/scene/view.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <wlr/types/wlr_output_damage.h>
 
@@ -8,46 +9,6 @@
 #include "zen/scene/board.h"
 #include "zen/xdg-toplevel-view.h"
 #include "zen/xwayland-view.h"
-
-void
-zn_view_bring_to_front(struct zn_view *self)
-{
-  wl_list_remove(&self->link);
-  wl_list_insert(self->board->view_list.prev, &self->link);
-
-  if (self->impl->restack) {
-    self->impl->restack(self, XCB_STACK_MODE_ABOVE);
-  }
-
-  zn_view_damage_whole(self);
-}
-
-void
-zn_view_move(struct zn_view *self, struct zn_board *new_board, double board_x,
-    double board_y)
-{
-  zn_view_damage_whole(self);
-
-  if (new_board != self->board) {
-    if (self->board) {
-      wl_list_remove(&self->link);
-      wl_list_init(&self->link);
-    }
-    if (new_board) {
-      wl_list_insert(new_board->view_list.prev, &self->link);
-    }
-    self->board = new_board;
-  }
-
-  self->x = board_x;
-  self->y = board_y;
-
-  if (self->impl->set_position) {
-    self->impl->set_position(self, board_x, board_y);
-  }
-
-  zn_view_damage_whole(self);
-}
 
 static void
 zn_view_add_damage_fbox(struct zn_view *self, struct wlr_fbox *effective_box)
@@ -106,6 +67,66 @@ zn_view_damage_whole(struct zn_view *self)
   }
 
   zn_view_add_damage_fbox(self, &fbox);
+}
+
+void
+zn_view_bring_to_front(struct zn_view *self)
+{
+  wl_list_remove(&self->link);
+  wl_list_insert(self->board->view_list.prev, &self->link);
+
+  if (self->impl->restack) {
+    self->impl->restack(self, XCB_STACK_MODE_ABOVE);
+  }
+
+  zn_view_damage_whole(self);
+}
+
+void
+zn_view_update_pos_on_resizing(
+    struct zn_view *self, struct wlr_surface *surface)
+{
+  assert(self->resize_status.resizing);
+
+  if (!(self->resize_status.edges & (WLR_EDGE_LEFT | WLR_EDGE_TOP))) {
+    return;
+  }
+
+  int dx = 0, dy = 0;
+  if (self->resize_status.edges & WLR_EDGE_LEFT) {
+    dx = surface->previous.width - surface->current.width;
+  }
+  if (self->resize_status.edges & WLR_EDGE_TOP) {
+    dy = surface->previous.height - surface->current.height;
+  }
+  zn_view_move(self, self->board, self->x + dx, self->y + dy);
+}
+
+void
+zn_view_move(struct zn_view *self, struct zn_board *new_board, double board_x,
+    double board_y)
+{
+  zn_view_damage_whole(self);
+
+  if (new_board != self->board) {
+    if (self->board) {
+      wl_list_remove(&self->link);
+      wl_list_init(&self->link);
+    }
+    if (new_board) {
+      wl_list_insert(new_board->view_list.prev, &self->link);
+    }
+    self->board = new_board;
+  }
+
+  self->x = board_x;
+  self->y = board_y;
+
+  if (self->impl->set_position) {
+    self->impl->set_position(self, board_x, board_y);
+  }
+
+  zn_view_damage_whole(self);
 }
 
 void

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -16,10 +16,12 @@ static void zn_view_add_damage_fbox(
 static void
 zn_view_handle_surface_resized(struct wl_listener *listener, void *data)
 {
+  UNUSED(data);
   struct zn_view *self =
       zn_container_of(listener, self, surface_resized_listener);
-  struct wlr_surface *surface = data;
+  struct wlr_surface *surface = self->impl->get_wlr_surface(self);
   assert(self->resize_status.resizing);
+
   {
     struct wlr_fbox damage_box = {
         .x = self->x,

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -88,6 +88,17 @@ zn_view_update_pos_on_resizing(
 {
   assert(self->resize_status.resizing);
 
+  {
+    struct wlr_fbox damage_box = {
+        .x = self->x,
+        .y = self->y,
+        .width = 1 + surface->previous.width + VIEW_DECORATION_BORDER * 2,
+        .height = 1 + surface->previous.height + VIEW_DECORATION_BORDER * 2 +
+                  VIEW_DECORATION_TITLEBAR,
+    };
+    zn_view_add_damage_fbox(self, &damage_box);
+  }
+
   if (!(self->resize_status.edges & (WLR_EDGE_LEFT | WLR_EDGE_TOP))) {
     return;
   }

--- a/zen/scene/view.c
+++ b/zen/scene/view.c
@@ -232,6 +232,25 @@ zn_view_unmap(struct zn_view *self)
   zn_view_move(self, NULL, 0, 0);
 }
 
+uint32_t
+zn_view_convert_area_type_to_wlr_edges(uint32_t type)
+{
+  uint32_t edges = 0;
+  if (type & ZN_VIEW_AREA_TYPE_BORDER_TOP) {
+    edges |= WLR_EDGE_TOP;
+  }
+  if (type & ZN_VIEW_AREA_TYPE_BORDER_BOTTOM) {
+    edges |= WLR_EDGE_BOTTOM;
+  }
+  if (type & ZN_VIEW_AREA_TYPE_BORDER_LEFT) {
+    edges |= WLR_EDGE_LEFT;
+  }
+  if (type & ZN_VIEW_AREA_TYPE_BORDER_RIGHT) {
+    edges |= WLR_EDGE_RIGHT;
+  }
+  return edges;
+}
+
 void
 zn_view_init(struct zn_view *self, enum zn_view_type type,
     const struct zn_view_impl *impl)

--- a/zen/wlr/box.c
+++ b/zen/wlr/box.c
@@ -1,5 +1,13 @@
 #include "zen/wlr/box.h"
 
+// from wlroots::wlr_box_contains_point
+bool
+zn_wlr_fbox_contains_point(const struct wlr_fbox* box, double x, double y)
+{
+  return box->x <= x && x < box->x + box->width && box->y <= y &&
+         y < box->y + box->height;
+}
+
 // from wlroots::wlr_box_closest_point
 void
 zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -23,7 +23,7 @@ zn_xdg_toplevel_view_handle_wlr_surface_commit(
     return;
   }
 
-  zn_view_update_pos_on_resizing(&self->base, data);
+  wl_signal_emit(&self->base.events.surface_resized, data);
 
   if (self->wlr_xdg_toplevel->base->current.configure_serial ==
       self->base.resize_status.last_serial) {

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -14,6 +14,7 @@ static void
 zn_xdg_toplevel_view_handle_wlr_surface_commit(
     struct wl_listener* listener, void* data)
 {
+  UNUSED(data);
   struct zn_xdg_toplevel_view* self =
       zn_container_of(listener, self, wlr_surface_commit_listener);
 
@@ -23,7 +24,7 @@ zn_xdg_toplevel_view_handle_wlr_surface_commit(
     return;
   }
 
-  wl_signal_emit(&self->base.events.surface_resized, data);
+  wl_signal_emit(&self->base.events.surface_resized, NULL);
 
   if (self->wlr_xdg_toplevel->base->current.configure_serial ==
       self->base.resize_status.last_serial) {

--- a/zen/xdg-toplevel-view.c
+++ b/zen/xdg-toplevel-view.c
@@ -23,20 +23,7 @@ zn_xdg_toplevel_view_handle_wlr_surface_commit(
     return;
   }
 
-  if (!(self->base.resize_status.edges & (WLR_EDGE_LEFT | WLR_EDGE_TOP))) {
-    return;
-  }
-
-  struct wlr_surface* surface = data;
-  int dx = 0, dy = 0;
-  if (self->base.resize_status.edges & WLR_EDGE_LEFT) {
-    dx = surface->previous.width - surface->current.width;
-  }
-  if (self->base.resize_status.edges & WLR_EDGE_TOP) {
-    dy = surface->previous.height - surface->current.height;
-  }
-  zn_view_move(
-      &self->base, self->base.board, self->base.x + dx, self->base.y + dy);
+  zn_view_update_pos_on_resizing(&self->base, data);
 
   if (self->wlr_xdg_toplevel->base->current.configure_serial ==
       self->base.resize_status.last_serial) {

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -18,7 +18,13 @@ zn_xwayland_view_handle_wlr_surface_commit(
 
   zn_view_damage(&self->base);
 
-  // FIXME: when resizing, adjust the position of the view
+  if (!self->base.resize_status.resizing) {
+    return;
+  }
+
+  zn_view_update_pos_on_resizing(&self->base, data);
+
+  self->base.resize_status.resizing = false;
 }
 
 static void

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -165,12 +165,11 @@ zn_xwayland_view_impl_set_size(
 {
   struct zn_xwayland_view* self = zn_container_of(view, self, base);
 
-  ++view->resize_status.last_serial;
   wlr_xwayland_surface_configure(self->wlr_xwayland_surface,
       self->wlr_xwayland_surface->x, self->wlr_xwayland_surface->y, width,
       height);
 
-  return 0;
+  return view->resize_status.last_serial + 1;
 }
 
 static void

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -14,7 +14,6 @@ zn_xwayland_view_handle_wlr_surface_commit(
 {
   struct zn_xwayland_view* self =
       zn_container_of(listener, self, wlr_surface_commit_listener);
-  UNUSED(data);
 
   zn_view_damage(&self->base);
 
@@ -22,7 +21,7 @@ zn_xwayland_view_handle_wlr_surface_commit(
     return;
   }
 
-  zn_view_update_pos_on_resizing(&self->base, data);
+  wl_signal_emit(&self->base.events.surface_resized, data);
 
   self->base.resize_status.resizing = false;
 }

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -12,6 +12,7 @@ static void
 zn_xwayland_view_handle_wlr_surface_commit(
     struct wl_listener* listener, void* data)
 {
+  UNUSED(data);
   struct zn_xwayland_view* self =
       zn_container_of(listener, self, wlr_surface_commit_listener);
 
@@ -21,7 +22,7 @@ zn_xwayland_view_handle_wlr_surface_commit(
     return;
   }
 
-  wl_signal_emit(&self->base.events.surface_resized, data);
+  wl_signal_emit(&self->base.events.surface_resized, NULL);
 
   ++self->current_resize_serial;
   if (self->current_resize_serial == self->base.resize_status.last_serial) {

--- a/zen/xwayland-view.c
+++ b/zen/xwayland-view.c
@@ -23,7 +23,10 @@ zn_xwayland_view_handle_wlr_surface_commit(
 
   wl_signal_emit(&self->base.events.surface_resized, data);
 
-  self->base.resize_status.resizing = false;
+  ++self->current_resize_serial;
+  if (self->current_resize_serial == self->base.resize_status.last_serial) {
+    self->base.resize_status.resizing = false;
+  }
 }
 
 static void
@@ -161,6 +164,7 @@ zn_xwayland_view_impl_set_size(
 {
   struct zn_xwayland_view* self = zn_container_of(view, self, base);
 
+  ++view->resize_status.last_serial;
   wlr_xwayland_surface_configure(self->wlr_xwayland_surface,
       self->wlr_xwayland_surface->x, self->wlr_xwayland_surface->y, width,
       height);


### PR DESCRIPTION
## Context

At #172 , server-side decoration is rendered, but it isn't able to interact (move/resize).

## Summary

Add `zn_screen_get_view_area_type_at`, and implement interaction to server-side decoration.

## How to check behavior

1. start zen with some x client
2. drag border of the server-side decoration (colored dark blue; #0e1e4d)

You can interact like other software or DE.
