### PR TITLE
Support RGB png for custom bg images

### DIFF
--- a/zen/scene/scene.c
+++ b/zen/scene/scene.c
@@ -198,7 +198,7 @@ zn_scene_setup_background(struct zn_scene* self, const char* background_png)
     goto err;
   }
   cairo_format_t format = cairo_image_surface_get_format(surface);
-  if (format != CAIRO_FORMAT_ARGB32) {
+  if (format != CAIRO_FORMAT_ARGB32 && format != CAIRO_FORMAT_RGB24) {
     zn_error("Image format not supported");
     goto err;
   }


### PR DESCRIPTION
## Context
 #159 

## Summary
It turned out that when you get underlying data from cairo rgb image [cairo converts the data into argb format](https://github.com/freedesktop/cairo/blob/923715f2e9acec31f6af406f39e14c36f9f7365c/src/cairo-png.c#L614) with `alpha = 0xff`. Using this, we can directly use RGB png image as the background image. 
## How to check behavior
Follow https://github.com/zigen-project/zen/pull/160#issue-1377382258 with a PNG image with RGB format.