### PR TITLE
make buffer safe

### DIFF
--- a/include/zen/immersive/remote/mem-buffer.h
+++ b/include/zen/immersive/remote/mem-buffer.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <wayland-server-core.h>
+#include <znr/buffer.h>
+#include <znr/remote.h>
+
+struct zn_remote_mem_buffer {
+  void* data;
+  size_t size;
+  uint32_t ref;
+
+  struct znr_buffer* znr_buffer;
+  struct wl_listener znr_buffer_ref_listener;
+  uint32_t ref_internal;
+};
+
+/**
+ * Increment the reference count of buffer by one.
+ */
+void zn_remote_mem_buffer_ref(struct zn_remote_mem_buffer* self);
+
+/**
+ * Decrement the reference count of buffer by one.
+ */
+void zn_remote_mem_buffer_unref(struct zn_remote_mem_buffer* self);
+
+/**
+ * Create buffer in memory space.
+ *
+ * The buffer is refcounted. Then the reference count reaches 0, the buffer
+ * becomes invalid. When the buffer becomes unused, event inside `znr`
+ * (ref_internal == 0), the buffer is actually destroyed.
+ *
+ * The reference count is zero at the time of creation, so call
+ * `zn_remote_mem_buffer_ref` immediately for continuous use.
+ */
+struct zn_remote_mem_buffer* zn_remote_mem_buffer_create(
+    size_t size, struct znr_remote* remote);

--- a/include/zen/immersive/remote/object/ray.h
+++ b/include/zen/immersive/remote/object/ray.h
@@ -2,11 +2,11 @@
 
 #include <cglm/cglm.h>
 #include <wayland-server-core.h>
-#include <znr/buffer.h>
 #include <znr/gl-buffer.h>
 #include <znr/rendering-unit.h>
 #include <znr/virtual-object.h>
 
+#include "zen/immersive/remote/mem-buffer.h"
 #include "zen/scene/ray.h"
 
 struct zn_remote_scene;
@@ -18,8 +18,7 @@ struct zn_ray_remote_object {
   struct znr_virtual_object* virtual_object;
   struct znr_rendering_unit* rendering_unit;
   struct znr_gl_buffer* gl_buffer;
-  struct znr_buffer* vertex_buffer;
-  vec3 vertices[2];
+  struct zn_remote_mem_buffer* vertex_buffer;
 
   struct wl_listener ray_destroy_listener;
   struct wl_listener ray_motion_listener;

--- a/zen/immersive/remote/mem-buffer.c
+++ b/zen/immersive/remote/mem-buffer.c
@@ -1,0 +1,86 @@
+#include "zen/immersive/remote/mem-buffer.h"
+
+#include "zen-common.h"
+
+static void zn_remote_mem_buffer_destroy(struct zn_remote_mem_buffer* self);
+
+void
+zn_remote_mem_buffer_ref(struct zn_remote_mem_buffer* self)
+{
+  self->ref++;
+}
+
+void
+zn_remote_mem_buffer_unref(struct zn_remote_mem_buffer* self)
+{
+  self->ref--;
+
+  if (self->ref == 0 && self->ref_internal == 0) {
+    zn_remote_mem_buffer_destroy(self);
+  }
+}
+
+static void
+zn_remote_mem_buffer_handle_ref(struct wl_listener* listener, void* data)
+{
+  struct znr_buffer_ref_event* event = data;
+  struct zn_remote_mem_buffer* self =
+      zn_container_of(listener, self, znr_buffer_ref_listener);
+
+  self->ref_internal = event->count;
+
+  if (self->ref == 0 && self->ref_internal == 0) {
+    zn_remote_mem_buffer_destroy(self);
+  }
+}
+
+struct zn_remote_mem_buffer*
+zn_remote_mem_buffer_create(size_t size, struct znr_remote* remote)
+{
+  struct zn_remote_mem_buffer* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->data = zalloc(size);
+  if (self->data == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err_free;
+  }
+
+  self->size = size;
+  self->ref = 0;
+
+  self->znr_buffer = znr_buffer_create(self->data, remote);
+  if (self->znr_buffer == NULL) {
+    zn_error("Failed to create znr_buffer");
+    goto err_free_data;
+  }
+
+  self->znr_buffer_ref_listener.notify = zn_remote_mem_buffer_handle_ref;
+  wl_signal_add(&self->znr_buffer->events.ref, &self->znr_buffer_ref_listener);
+  self->ref_internal = 0;
+
+  return self;
+
+err_free_data:
+  free(self->data);
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+static void
+zn_remote_mem_buffer_destroy(struct zn_remote_mem_buffer* self)
+{
+  znr_buffer_destroy(self->znr_buffer);
+  wl_list_remove(&self->znr_buffer_ref_listener.link);
+  free(self->data);
+  free(self);
+}

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -25,6 +25,7 @@ _zen_desktop_srcs = [
   'immersive/remote/object/ray.c',
   'immersive/remote/renderer.c',
   'immersive/remote/scene.c',
+  'immersive/remote/mem-buffer.c',
 
   'input/cursor-grab-move.c',
   'input/cursor-grab-resize.c',

--- a/znr/include/znr/buffer.h
+++ b/znr/include/znr/buffer.h
@@ -7,9 +7,21 @@ extern "C" {
 
 #include "znr/remote.h"
 
+struct znr_buffer_ref_event {
+  uint32_t count;
+};
+
+/**
+ * The ref event notifies a changes in the number of objects using and
+ * referencing this buffer inside `znr`. The reference count is only increased
+ * when the buffer is used as an argument to other `znr` functions.
+ * When this reference count is 1 or greater, the buffer must not be deleted,
+ * the data pointer used when the buffer was created must always be available,
+ * and the contents of the data pointer must not be modified.
+ */
 struct znr_buffer {
   struct {
-    struct wl_signal release;  // (NULL)
+    struct wl_signal ref;  // (struct znr_buffer_ref_event *)
   } events;
 };
 

--- a/znr/src/buffer.h
+++ b/znr/src/buffer.h
@@ -11,6 +11,7 @@ struct znr_buffer_impl {
 
   struct znr_remote_impl* remote;
   void* data;
+  uint32_t ref;
 };
 
 std::unique_ptr<zen::remote::server::IBuffer> znr_buffer_impl_use(


### PR DESCRIPTION
## Context

As we make an asynchronous and parallel system, it's difficult to make a buffer safe.
Buffer must be available until it's actually consumed asynchronously or in another thread.
So we introduced refcounted buffer, which is alive until it's actually consumed and no longer used.

## Summary

- [x] Create such object which allocate buffer in memory space. (zn_remote_mem_buffer)
  - `zn_remote_shm_buffer` should be implemented in the future. (buffer allocated in shared memory)

## How to check behavior

No error happens.