### PR TITLE
implement creation of zgnr_gl_base_technique

### DIFF
--- a/clients/box.cc
+++ b/clients/box.cc
@@ -1,6 +1,7 @@
 #include <wayland-client.h>
 
 #include "application.h"
+#include "gl-base-technique.h"
 #include "rendering-unit.h"
 #include "virtual-object.h"
 
@@ -19,6 +20,9 @@ main(void)
 
   auto unit = CreateRenderingUnit(&app, vo.get());
   if (!unit) return EXIT_FAILURE;
+
+  auto technique = CreateGlBaseTechnique(&app, unit.get());
+  if (!technique) return EXIT_FAILURE;
 
   return app.Run();
 }

--- a/clients/gl-base-technique.cc
+++ b/clients/gl-base-technique.cc
@@ -1,0 +1,42 @@
+#include "gl-base-technique.h"
+
+#include "application.h"
+#include "rendering-unit.h"
+
+namespace zen::client {
+
+bool
+GlBaseTechnique::Init(RenderingUnit *unit)
+{
+  proxy_ =
+      zgn_gles_v32_create_gl_base_technique(app_->gles_v32(), unit->proxy());
+  if (proxy_ == nullptr) {
+    LOG_ERROR("Failed to create gl base technique object proxy");
+    return false;
+  }
+
+  return true;
+}
+
+GlBaseTechnique::GlBaseTechnique(Application *app) : app_(app) {}
+
+GlBaseTechnique::~GlBaseTechnique()
+{
+  if (proxy_) {
+    zgn_gl_base_technique_destroy(proxy_);
+  }
+}
+
+std::unique_ptr<GlBaseTechnique>
+CreateGlBaseTechnique(Application *app, RenderingUnit *unit)
+{
+  auto technique = std::make_unique<GlBaseTechnique>(app);
+
+  if (!technique->Init(unit)) {
+    return std::unique_ptr<GlBaseTechnique>();
+  }
+
+  return technique;
+}
+
+}  // namespace zen::client

--- a/clients/gl-base-technique.h
+++ b/clients/gl-base-technique.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <zigen-gles-v32-client-protocol.h>
+
+#include <memory>
+
+#include "common.h"
+
+namespace zen::client {
+
+class Application;
+class RenderingUnit;
+
+class GlBaseTechnique
+{
+ public:
+  DISABLE_MOVE_AND_COPY(GlBaseTechnique);
+  GlBaseTechnique(Application *app);
+  ~GlBaseTechnique();
+
+  bool Init(RenderingUnit *unit);
+
+ private:
+  Application *app_;
+  zgn_gl_base_technique *proxy_ = nullptr;  // nonnull after initialization
+};
+
+std::unique_ptr<GlBaseTechnique> CreateGlBaseTechnique(
+    Application *app, RenderingUnit *unit);
+
+}  // namespace zen::client

--- a/clients/meson.build
+++ b/clients/meson.build
@@ -1,6 +1,7 @@
 _zen_box_client_srcs = [
   'application.cc',
   'box.cc',
+  'gl-base-technique.cc',
   'loop.cc',
   'rendering-unit.cc',
   'virtual-object.cc',

--- a/clients/rendering-unit.h
+++ b/clients/rendering-unit.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <zigen-client-protocol.h>
 #include <zigen-gles-v32-client-protocol.h>
 
 #include <memory>
@@ -21,10 +20,18 @@ class RenderingUnit
 
   bool Init(VirtualObject* virtual_object);
 
+  inline zgn_rendering_unit* proxy();
+
  private:
   Application* app_;
   zgn_rendering_unit* proxy_ = nullptr;  // nonnull after initialization
 };
+
+inline zgn_rendering_unit*
+RenderingUnit::proxy()
+{
+  return proxy_;
+}
 
 std::unique_ptr<RenderingUnit> CreateRenderingUnit(
     Application* app, VirtualObject* virtual_object);

--- a/zgnroot/include/zgnr/gl-base-technique.h
+++ b/zgnroot/include/zgnr/gl-base-technique.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <wayland-server-core.h>
-#include <zgnr/virtual-object.h>
+#include <zgnr/rendering-unit.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct zgnr_rendering_unit {
-  struct zgnr_virtual_object *virtual_object;  // nonnull
+struct zgnr_gl_base_technique {
+  struct zgnr_rendering_unit *unit;  // nonnull
 
   struct {
     struct wl_signal destroy;  // (NULL)

--- a/zgnroot/include/zgnr/gles-v32.h
+++ b/zgnroot/include/zgnr/gles-v32.h
@@ -8,7 +8,8 @@ extern "C" {
 
 struct zgnr_gles_v32 {
   struct {
-    struct wl_signal new_rendering_unit;  // (struct zgnr_rendering_unit*)
+    struct wl_signal new_rendering_unit;     // (struct zgnr_rendering_unit*)
+    struct wl_signal new_gl_base_technique;  // (struct zgnr_gl_base_technique*)
   } events;
 };
 

--- a/zgnroot/meson.build
+++ b/zgnroot/meson.build
@@ -4,6 +4,7 @@ _zgnr_srcs = [
   'src/backend.c',
   'src/compositor.c',
   'src/gles-v32.c',
+  'src/gl-base-technique.c',
   'src/rendering-unit.c',
   'src/virtual-object.c',
 

--- a/zgnroot/src/gl-base-technique.c
+++ b/zgnroot/src/gl-base-technique.c
@@ -1,0 +1,196 @@
+#include "gl-base-technique.h"
+
+#include <zen-common.h>
+#include <zigen-gles-v32-protocol.h>
+
+static void zgnr_gl_base_technique_destroy(
+    struct zgnr_gl_base_technique_impl *self);
+static void zgnr_gl_base_technique_inert(
+    struct zgnr_gl_base_technique_impl *self);
+
+static void
+zgnr_gl_base_technique_handle_destroy(struct wl_resource *resource)
+{
+  struct zgnr_gl_base_technique_impl *self =
+      wl_resource_get_user_data(resource);
+
+  zgnr_gl_base_technique_destroy(self);
+}
+
+static void
+zgnr_gl_base_technique_protocol_destroy(
+    struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+
+static void
+zgnr_gl_base_technique_protocol_bind_program(struct wl_client *client,
+    struct wl_resource *resource, struct wl_resource *program)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(program);
+}
+
+static void
+zgnr_gl_base_technique_protocol_bind_vertex_array(struct wl_client *client,
+    struct wl_resource *resource, struct wl_resource *vertex_array)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(vertex_array);
+}
+
+static void
+zgnr_gl_base_technique_protocol_bind_texture(struct wl_client *client,
+    struct wl_resource *resource, uint32_t location,
+    struct wl_resource *texture)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(location);
+  UNUSED(texture);
+}
+
+static void
+zgnr_gl_base_technique_protocol_uniform_vector(struct wl_client *client,
+    struct wl_resource *resource, uint32_t location, const char *name,
+    uint32_t type, uint32_t size, uint32_t count, struct wl_array *value)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(location);
+  UNUSED(name);
+  UNUSED(type);
+  UNUSED(size);
+  UNUSED(count);
+  UNUSED(value);
+}
+
+static void
+zgnr_gl_base_technique_protocol_uniform_matrix(struct wl_client *client,
+    struct wl_resource *resource, uint32_t location, const char *name,
+    uint32_t type, uint32_t col, uint32_t row, uint32_t count,
+    uint32_t transpose, struct wl_array *value)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(location);
+  UNUSED(name);
+  UNUSED(type);
+  UNUSED(col);
+  UNUSED(row);
+  UNUSED(count);
+  UNUSED(transpose);
+  UNUSED(value);
+}
+
+static void
+zgnr_gl_base_technique_protocol_draw_arrays(struct wl_client *client,
+    struct wl_resource *resource, uint32_t mode, int32_t first, uint32_t count)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(mode);
+  UNUSED(first);
+  UNUSED(count);
+}
+
+static void
+zgnr_gl_base_technique_protocol_draw_elements(struct wl_client *client,
+    struct wl_resource *resource, uint32_t mode, uint32_t count, uint32_t type,
+    struct wl_array *offset, struct wl_resource *element_array_buffer)
+{
+  UNUSED(client);
+  UNUSED(resource);
+  UNUSED(mode);
+  UNUSED(count);
+  UNUSED(type);
+  UNUSED(offset);
+  UNUSED(element_array_buffer);
+}
+
+/** Be careful, resource can be inert. */
+static const struct zgn_gl_base_technique_interface interface = {
+    .destroy = zgnr_gl_base_technique_protocol_destroy,
+    .bind_program = zgnr_gl_base_technique_protocol_bind_program,
+    .bind_vertex_array = zgnr_gl_base_technique_protocol_bind_vertex_array,
+    .bind_texture = zgnr_gl_base_technique_protocol_bind_texture,
+    .uniform_vector = zgnr_gl_base_technique_protocol_uniform_vector,
+    .uniform_matrix = zgnr_gl_base_technique_protocol_uniform_matrix,
+    .draw_arrays = zgnr_gl_base_technique_protocol_draw_arrays,
+    .draw_elements = zgnr_gl_base_technique_protocol_draw_elements,
+};
+
+static void
+zgnr_gl_base_technique_handle_rendering_unit_destroy(
+    struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+
+  struct zgnr_gl_base_technique_impl *self =
+      zn_container_of(listener, self, rendering_unit_destroy_listener);
+
+  zgnr_gl_base_technique_inert(self);
+}
+
+static void
+zgnr_gl_base_technique_inert(struct zgnr_gl_base_technique_impl *self)
+{
+  struct wl_resource *resource = self->resource;
+  zgnr_gl_base_technique_destroy(self);
+  wl_resource_set_user_data(resource, NULL);
+  wl_resource_set_destructor(resource, NULL);
+}
+
+struct zgnr_gl_base_technique_impl *
+zgnr_gl_base_technique_create(struct wl_client *client, uint32_t id,
+    struct zgnr_rendering_unit_impl *unit)
+{
+  struct zgnr_gl_base_technique_impl *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->resource =
+      wl_resource_create(client, &zgn_gl_base_technique_interface, 1, id);
+  if (self->resource == NULL) {
+    zn_error("Failed to create a wl_resource");
+    goto err_free;
+  }
+
+  wl_resource_set_implementation(
+      self->resource, &interface, self, zgnr_gl_base_technique_handle_destroy);
+
+  self->base.unit = &unit->base;
+
+  wl_signal_init(&self->base.events.destroy);
+
+  self->rendering_unit_destroy_listener.notify =
+      zgnr_gl_base_technique_handle_rendering_unit_destroy;
+  wl_signal_add(
+      &unit->base.events.destroy, &self->rendering_unit_destroy_listener);
+
+  return self;
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+static void
+zgnr_gl_base_technique_destroy(struct zgnr_gl_base_technique_impl *self)
+{
+  wl_signal_emit(&self->base.events.destroy, NULL);
+
+  wl_list_remove(&self->rendering_unit_destroy_listener.link);
+  wl_list_remove(&self->base.events.destroy.listener_list);
+  free(self);
+}

--- a/zgnroot/src/gl-base-technique.h
+++ b/zgnroot/src/gl-base-technique.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "rendering-unit.h"
+#include "zgnr/gl-base-technique.h"
+
+/**
+ * When the associated rendering unit is destroyed, this object is destroyed and
+ * the wl_resource becomes inert (resource::data == NULL).
+ */
+struct zgnr_gl_base_technique_impl {
+  struct zgnr_gl_base_technique base;
+
+  struct wl_resource *resource;
+  struct wl_listener rendering_unit_destroy_listener;
+};
+
+struct zgnr_gl_base_technique_impl *zgnr_gl_base_technique_create(
+    struct wl_client *client, uint32_t id,
+    struct zgnr_rendering_unit_impl *unit);

--- a/zgnroot/src/rendering-unit.h
+++ b/zgnroot/src/rendering-unit.h
@@ -2,9 +2,8 @@
 
 #include <wayland-server-core.h>
 
+#include "virtual-object.h"
 #include "zgnr/rendering-unit.h"
-
-struct zgnr_virtual_object_impl;
 
 /**
  * When the associated virtual object is destroyed, this object is destroyed and


### PR DESCRIPTION
## Context

Enable clients to create gl_base_technique.
Object is just created in zgnroot. Sending the object to the renderer is not the scope of this pull request.

## Summary

- [x] Create zgnr_gl_base_technique
- [x] handle create_gl_base_technique 

