### PR TITLE
implement zna_gl-base-technique

### DIFF
--- a/zna/meson.build
+++ b/zna/meson.build
@@ -3,6 +3,7 @@ _zen_appearance_inc = include_directories('.')
 _zen_appearance_srcs = [
   'system.c',
   'scene/virtual-object.c',
+  'scene/virtual-object/gl-base-technique.c',
   'scene/virtual-object/gl-buffer.c',
   'scene/virtual-object/rendering-unit.c',
 ]

--- a/zna/scene/virtual-object/gl-base-technique.c
+++ b/zna/scene/virtual-object/gl-base-technique.c
@@ -1,0 +1,79 @@
+#include "gl-base-technique.h"
+
+#include <zen-common.h>
+
+static void zna_gl_base_technique_destroy(struct zna_gl_base_technique* self);
+
+static void
+zna_gl_base_technique_handle_zgnr_gl_base_technique_destroy(
+    struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zna_gl_base_technique* self =
+      zn_container_of(listener, self, zgnr_gl_base_technique_destroy_listener);
+
+  zna_gl_base_technique_destroy(self);
+}
+
+static void
+zna_gl_base_technique_handle_session_destroyed(
+    struct wl_listener* listener, void* data)
+{
+  struct zna_gl_base_technique* self =
+      zn_container_of(listener, self, session_destroyed_listener);
+  UNUSED(self);
+  UNUSED(data);
+}
+
+void
+zna_gl_base_technique_apply_commit(
+    struct zna_gl_base_technique* self, bool only_damaged)
+{
+  UNUSED(self);
+  UNUSED(only_damaged);
+}
+
+struct zna_gl_base_technique*
+zna_gl_base_technique_create(
+    struct zgnr_gl_base_technique* zgnr_gl_base_technique,
+    struct zna_system* system)
+{
+  struct zna_gl_base_technique* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->zgnr_gl_base_technique = zgnr_gl_base_technique;
+  zgnr_gl_base_technique->user_data = self;
+  self->system = system;
+
+  self->zgnr_gl_base_technique_destroy_listener.notify =
+      zna_gl_base_technique_handle_zgnr_gl_base_technique_destroy;
+  wl_signal_add(&self->zgnr_gl_base_technique->events.destroy,
+      &self->zgnr_gl_base_technique_destroy_listener);
+
+  self->session_destroyed_listener.notify =
+      zna_gl_base_technique_handle_session_destroyed;
+  wl_signal_add(&self->system->renderer->events.current_session_destroyed,
+      &self->session_destroyed_listener);
+
+  zn_debug("gl-base-technique is created");
+
+  return self;
+
+err:
+  return NULL;
+}
+
+static void
+zna_gl_base_technique_destroy(struct zna_gl_base_technique* self)
+{
+  zn_debug("gl-base-technique is destroyed");
+
+  wl_list_remove(&self->zgnr_gl_base_technique_destroy_listener.link);
+  wl_list_remove(&self->session_destroyed_listener.link);
+  free(self);
+}

--- a/zna/scene/virtual-object/gl-base-technique.c
+++ b/zna/scene/virtual-object/gl-base-technique.c
@@ -60,8 +60,6 @@ zna_gl_base_technique_create(
   wl_signal_add(&self->system->renderer->events.current_session_destroyed,
       &self->session_destroyed_listener);
 
-  zn_debug("gl-base-technique is created");
-
   return self;
 
 err:
@@ -71,8 +69,6 @@ err:
 static void
 zna_gl_base_technique_destroy(struct zna_gl_base_technique* self)
 {
-  zn_debug("gl-base-technique is destroyed");
-
   wl_list_remove(&self->zgnr_gl_base_technique_destroy_listener.link);
   wl_list_remove(&self->session_destroyed_listener.link);
   free(self);

--- a/zna/scene/virtual-object/gl-base-technique.h
+++ b/zna/scene/virtual-object/gl-base-technique.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <zgnr/gl-base-technique.h>
+
+#include "system.h"
+
+struct zna_gl_base_technique {
+  struct zgnr_gl_base_technique* zgnr_gl_base_technique;
+  struct zna_system* system;
+
+  struct wl_listener zgnr_gl_base_technique_destroy_listener;
+  struct wl_listener session_destroyed_listener;
+};
+
+/**
+ * Precondition:
+ *  Current session exists && the zgnr_gl_base_technique has been commited
+ */
+void zna_gl_base_technique_apply_commit(
+    struct zna_gl_base_technique* self, bool only_damaged);
+
+struct zna_gl_base_technique* zna_gl_base_technique_create(
+    struct zgnr_gl_base_technique* zgnr_gl_base_technique,
+    struct zna_system* system);

--- a/zna/scene/virtual-object/gl-base-technique.h
+++ b/zna/scene/virtual-object/gl-base-technique.h
@@ -5,8 +5,8 @@
 #include "system.h"
 
 struct zna_gl_base_technique {
-  struct zgnr_gl_base_technique* zgnr_gl_base_technique;
-  struct zna_system* system;
+  struct zgnr_gl_base_technique* zgnr_gl_base_technique;  // nonnull
+  struct zna_system* system;                              // nonnull
 
   struct wl_listener zgnr_gl_base_technique_destroy_listener;
   struct wl_listener session_destroyed_listener;

--- a/zna/scene/virtual-object/rendering-unit.c
+++ b/zna/scene/virtual-object/rendering-unit.c
@@ -4,6 +4,7 @@
 #include <zgnr/virtual-object.h>
 
 #include "scene/virtual-object.h"
+#include "scene/virtual-object/gl-base-technique.h"
 #include "zen/scene/virtual-object.h"
 
 static void zna_rendering_unit_destroy(struct zna_rendering_unit* self);
@@ -30,10 +31,6 @@ zna_rendering_unit_handle_session_destroyed(
   }
 }
 
-/**
- * Precondition:
- *  Current session exists && the zgnr_rendering_unit has been committed
- */
 void
 zna_rendering_unit_apply_commit(
     struct zna_rendering_unit* self, bool only_damaged)
@@ -47,7 +44,11 @@ zna_rendering_unit_apply_commit(
         znr_rendering_unit_create(session, virtual_object->znr_virtual_object);
   }
 
-  UNUSED(only_damaged);
+  if (self->zgnr_rendering_unit->current.technique) {
+    struct zna_gl_base_technique* gl_base_technique =
+        self->zgnr_rendering_unit->current.technique->user_data;
+    zna_gl_base_technique_apply_commit(gl_base_technique, only_damaged);
+  }
 }
 
 static void

--- a/zna/scene/virtual-object/rendering-unit.h
+++ b/zna/scene/virtual-object/rendering-unit.h
@@ -19,7 +19,10 @@ struct zna_rendering_unit {
   struct wl_listener session_destroyed_listener;
 };
 
-/** Check that the current session exists before calling this */
+/**
+ * Precondition:
+ *  Current session exists && the zgnr_rendering_unit has been committed
+ */
 void zna_rendering_unit_apply_commit(
     struct zna_rendering_unit* self, bool only_damaged);
 

--- a/zna/system.c
+++ b/zna/system.c
@@ -4,6 +4,7 @@
 #include <zgnr/gl-buffer.h>
 #include <zgnr/rendering-unit.h>
 
+#include "scene/virtual-object/gl-base-technique.h"
 #include "scene/virtual-object/gl-buffer.h"
 #include "scene/virtual-object/rendering-unit.h"
 #include "zen/renderer/system.h"
@@ -26,6 +27,17 @@ zna_system_handle_new_gl_buffer(struct wl_listener* listener, void* data)
   struct zgnr_gl_buffer* gl_buffer = data;
 
   (void)zna_gl_buffer_create(gl_buffer, self);
+}
+
+static void
+zna_system_handle_new_gl_base_technique(
+    struct wl_listener* listener, void* data)
+{
+  struct zna_system* self =
+      zn_container_of(listener, self, new_gl_base_technique_listener);
+  struct zgnr_gl_base_technique* gl_base_technique = data;
+
+  (void)zna_gl_base_technique_create(gl_base_technique, self);
 }
 
 struct zna_system*
@@ -57,6 +69,11 @@ zna_system_create(struct wl_display* display, struct znr_system* renderer)
   wl_signal_add(
       &self->gles->events.new_gl_buffer, &self->new_gl_buffer_listener);
 
+  self->new_gl_base_technique_listener.notify =
+      zna_system_handle_new_gl_base_technique;
+  wl_signal_add(&self->gles->events.new_gl_base_technique,
+      &self->new_gl_base_technique_listener);
+
   return self;
 
 err_free:
@@ -71,6 +88,7 @@ zna_system_destroy(struct zna_system* self)
 {
   wl_list_remove(&self->new_rendering_unit_listener.link);
   wl_list_remove(&self->new_gl_buffer_listener.link);
+  wl_list_remove(&self->new_gl_base_technique_listener.link);
   zgnr_gles_v32_destroy(self->gles);
   free(self);
 }

--- a/zna/system.h
+++ b/zna/system.h
@@ -11,4 +11,5 @@ struct zna_system {
 
   struct wl_listener new_rendering_unit_listener;
   struct wl_listener new_gl_buffer_listener;
+  struct wl_listener new_gl_base_technique_listener;
 };


### PR DESCRIPTION
# 602c8c4

## Context

Enable clients to create `zna_gl_base_technique`

## Summary

Listen `zna_system::new_gl_base_technique` signal, create `zna_gl_base_technique`.

## How to check behavior

1. start zen / zen-oculus-display-system
2. launch `zen-box`; you can see the log `gl-base-technique is created`
3. terminate `zen-box`; the log `gl-base-technique is destroyed`



