### PR TITLE
add znr_gl_base_technique

### DIFF
--- a/clients/gl-base-technique.cc
+++ b/clients/gl-base-technique.cc
@@ -25,6 +25,12 @@ GlBaseTechnique::Bind(GlVertexArray *vertex_array)
   zgn_gl_base_technique_bind_vertex_array(proxy_, vertex_array->proxy());
 }
 
+void
+GlBaseTechnique::DrawArrays(GLenum mode, GLint first, GLsizei count)
+{
+  zgn_gl_base_technique_draw_arrays(proxy_, mode, first, count);
+}
+
 GlBaseTechnique::GlBaseTechnique(Application *app) : app_(app) {}
 
 GlBaseTechnique::~GlBaseTechnique()

--- a/clients/gl-base-technique.h
+++ b/clients/gl-base-technique.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <GLES3/gl32.h>
 #include <zen-common.h>
 #include <zigen-gles-v32-client-protocol.h>
 
@@ -19,6 +20,8 @@ class GlBaseTechnique
   ~GlBaseTechnique();
 
   bool Init(RenderingUnit *unit);
+
+  void DrawArrays(GLenum mode, GLint first, GLsizei count);
 
   void Bind(GlVertexArray *vertex_array);
 

--- a/include/zen/renderer/gl-base-technique.h
+++ b/include/zen/renderer/gl-base-technique.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "zen/renderer/rendering-unit.h"
+#include "zen/renderer/session.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct znr_gl_base_technique;
+
+struct znr_gl_base_technique* znr_gl_base_technique_create(
+    struct znr_session* session, struct znr_rendering_unit* rendering_unit);
+
+void znr_gl_base_technique_destroy(struct znr_gl_base_technique* self);
+
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = wlroots_req
-zen_remote_server_req = '0.1.0.10'
+zen_remote_server_req = '0.1.0.11'
 
 # dependencies
 

--- a/znr-remote/meson.build
+++ b/znr-remote/meson.build
@@ -1,6 +1,7 @@
 _znr_remote_inc = include_directories('include')
 
 _znr_remote_srcs = [
+  'src/gl-base-technique.cc',
   'src/gl-buffer.cc',
   'src/loop.cc',
   'src/peer.cc',

--- a/znr-remote/src/gl-base-technique.cc
+++ b/znr-remote/src/gl-base-technique.cc
@@ -1,0 +1,42 @@
+#include "gl-base-technique.h"
+
+#include <zen-common.h>
+
+#include "rendering-unit.h"
+#include "session.h"
+
+struct znr_gl_base_technique*
+znr_gl_base_technique_create(
+    struct znr_session* session_base, struct znr_rendering_unit* rendering_unit)
+{
+  auto self = new znr_gl_base_technique();
+  znr_session_impl* session;
+
+  if (self == nullptr) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  session = zn_container_of(session_base, session, base);
+
+  self->proxy = zen::remote::server::CreateGlBaseTechnique(
+      session->proxy, rendering_unit->proxy->id());
+  if (!self->proxy) {
+    zn_error("Failed to create remote gl base technique");
+    goto err_delete;
+  }
+
+  return self;
+
+err_delete:
+  delete self;
+
+err:
+  return nullptr;
+}
+
+void
+znr_gl_base_technique_destroy(struct znr_gl_base_technique* self)
+{
+  delete self;
+}

--- a/znr-remote/src/gl-base-technique.h
+++ b/znr-remote/src/gl-base-technique.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <zen-remote/server/gl-base-technique.h>
+
+#include "zen/renderer/gl-base-technique.h"
+
+struct znr_gl_base_technique {
+  std::unique_ptr<zen::remote::server::IGlBaseTechnique> proxy;
+};


### PR DESCRIPTION
## Context

add gl base technique to zen renderer

## Summary

added: `znr_gl_base technique` to `znr-remote`, `DrawArrays` to client's `GlBaseTechnique`.

(But now it can't be used)

## How to check behavior

none?
