### PR TITLE
make zna own current session

### DIFF
--- a/zna/system.c
+++ b/zna/system.c
@@ -126,6 +126,8 @@ err:
 void
 zna_system_destroy(struct zna_system* self)
 {
+  if (self->current_session) znr_session_destroy(self->current_session);
+
   wl_list_remove(&self->events.current_session_created.listener_list);
   wl_list_remove(&self->events.current_session_destroyed.listener_list);
   wl_list_remove(&self->new_rendering_unit_listener.link);

--- a/zna/system.h
+++ b/zna/system.h
@@ -8,7 +8,7 @@ struct zna_system {
   struct wl_display *display;
   struct zgnr_gles_v32 *gles;  // nonnull, owning
 
-  struct znr_session *current_session;  // nullable, reference
+  struct znr_session *current_session;  // nullable, owning
 
   struct {
     // When the current session switches to a new one, current_session_destroyed


### PR DESCRIPTION
## Context

zna should have an ownership of the current session, but it's not.

## Summary

- [x] fix the ownership of the current session.


