### PR TITLE
create vertex array object

### DIFF
--- a/include/zen/renderer/gl-vertex-array.h
+++ b/include/zen/renderer/gl-vertex-array.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "zen/renderer/session.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct znr_gl_vertex_array;
+
+struct znr_gl_vertex_array* znr_gl_vertex_array_create(
+    struct znr_session* session);
+
+void znr_gl_vertex_array_destroy(struct znr_gl_vertex_array* self);
+
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = wlroots_req
-zen_remote_server_req = '0.1.0.12'
+zen_remote_server_req = '0.1.0.13'
 
 # dependencies
 

--- a/zgnroot/include/zgnr/gles-v32.h
+++ b/zgnroot/include/zgnr/gles-v32.h
@@ -11,7 +11,7 @@ struct zgnr_gles_v32 {
     struct wl_signal new_rendering_unit;     // (struct zgnr_rendering_unit*)
     struct wl_signal new_gl_base_technique;  // (struct zgnr_gl_base_technique*)
     struct wl_signal new_gl_buffer;          // (struct zgnr_gl_buffer*)
-    struct wl_signal new_gl_vertex_buffer;   // (struct zgnr_gl_vertex_buffer*)
+    struct wl_signal new_gl_vertex_array;    // (struct zgnr_gl_vertex_array*)
   } events;
 };
 

--- a/zgnroot/src/gles-v32.c
+++ b/zgnroot/src/gles-v32.c
@@ -97,7 +97,7 @@ zgnr_gles_v32_protocol_create_gl_vertex_array(
     return;
   }
 
-  wl_signal_emit(&self->base.events.new_gl_vertex_buffer, &vertex_array->base);
+  wl_signal_emit(&self->base.events.new_gl_vertex_array, &vertex_array->base);
 }
 
 static void
@@ -162,7 +162,7 @@ zgnr_gles_v32_create(struct wl_display* display)
   wl_signal_init(&self->base.events.new_rendering_unit);
   wl_signal_init(&self->base.events.new_gl_base_technique);
   wl_signal_init(&self->base.events.new_gl_buffer);
-  wl_signal_init(&self->base.events.new_gl_vertex_buffer);
+  wl_signal_init(&self->base.events.new_gl_vertex_array);
   self->display = display;
 
   self->global = wl_global_create(
@@ -191,7 +191,7 @@ zgnr_gles_v32_destroy(struct zgnr_gles_v32* parent)
   wl_list_remove(&self->base.events.new_gl_buffer.listener_list);
   wl_list_remove(&self->base.events.new_gl_base_technique.listener_list);
   wl_list_remove(&self->base.events.new_rendering_unit.listener_list);
-  wl_list_remove(&self->base.events.new_gl_vertex_buffer.listener_list);
+  wl_list_remove(&self->base.events.new_gl_vertex_array.listener_list);
 
   free(self);
 }

--- a/zna/meson.build
+++ b/zna/meson.build
@@ -5,6 +5,7 @@ _zen_appearance_srcs = [
   'scene/virtual-object.c',
   'scene/virtual-object/gl-base-technique.c',
   'scene/virtual-object/gl-buffer.c',
+  'scene/virtual-object/gl-vertex-array.c',
   'scene/virtual-object/rendering-unit.c',
 ]
 

--- a/zna/scene/virtual-object/gl-base-technique.c
+++ b/zna/scene/virtual-object/gl-base-technique.c
@@ -2,7 +2,7 @@
 
 #include <zen-common.h>
 
-#include "scene/virtual-object/gl-buffer.h"
+#include "scene/virtual-object/gl-vertex-array.h"
 
 static void zna_gl_base_technique_destroy(struct zna_gl_base_technique* self);
 
@@ -31,19 +31,13 @@ void
 zna_gl_base_technique_apply_commit(
     struct zna_gl_base_technique* self, bool only_damaged)
 {
-  struct zgnr_gl_vertex_array* vertex_array;
+  // TODO: Create znr_gl_base_technique;
 
-  vertex_array = self->zgnr_gl_base_technique->current.vertex_array;
-  if (vertex_array) {
-    struct zgnr_gl_vertex_attrib* vertex_attrib;
-    wl_array_for_each (vertex_attrib, &vertex_array->current.vertex_attribs) {
-      struct zgnr_gl_buffer* zgnr_gl_buffer =
-          zgnr_gl_vertex_attrib_get_gl_buffer(vertex_attrib);
-      if (zgnr_gl_buffer == NULL) continue;
+  if (self->zgnr_gl_base_technique->current.vertex_array) {
+    struct zna_gl_vertex_array* vertex_array =
+        self->zgnr_gl_base_technique->current.vertex_array->user_data;
 
-      struct zna_gl_buffer* gl_buffer = zgnr_gl_buffer->user_data;
-      zna_gl_buffer_apply_commit(gl_buffer, only_damaged);
-    }
+    zna_gl_vertex_array_apply_commit(vertex_array, only_damaged);
   }
 
   // TODO: Apply draw arrays, etc.

--- a/zna/scene/virtual-object/gl-buffer.c
+++ b/zna/scene/virtual-object/gl-buffer.c
@@ -31,7 +31,6 @@ zna_gl_buffer_handle_zgnr_gl_buffer_destroy(
 void
 zna_gl_buffer_apply_commit(struct zna_gl_buffer *self, bool only_damaged)
 {
-  UNUSED(only_damaged);
   struct znr_session *session = self->system->current_session;
   if (self->znr_gl_buffer == NULL) {
     self->znr_gl_buffer = znr_gl_buffer_create(session, self->system->display);

--- a/zna/scene/virtual-object/gl-vertex-array.c
+++ b/zna/scene/virtual-object/gl-vertex-array.c
@@ -1,0 +1,99 @@
+#include "gl-vertex-array.h"
+
+#include <zen-common.h>
+
+#include "scene/virtual-object/gl-buffer.h"
+
+static void zna_gl_vertex_array_destroy(struct zna_gl_vertex_array* self);
+
+static void
+zna_gl_vertex_array_handle_session_destroy(
+    struct wl_listener* listener, void* data)
+{
+  struct zna_gl_vertex_array* self =
+      zn_container_of(listener, self, session_destroy_listener);
+  UNUSED(data);
+
+  if (self->znr_gl_vertex_array) {
+    znr_gl_vertex_array_destroy(self->znr_gl_vertex_array);
+    self->znr_gl_vertex_array = NULL;
+  }
+}
+
+static void
+zna_gl_vertex_array_handle_zgnr_gl_vertex_array_destroy(
+    struct wl_listener* listener, void* data)
+{
+  struct zna_gl_vertex_array* self =
+      zn_container_of(listener, self, zgnr_gl_vertex_array_destroy_listener);
+  UNUSED(data);
+
+  zna_gl_vertex_array_destroy(self);
+}
+
+void
+zna_gl_vertex_array_apply_commit(
+    struct zna_gl_vertex_array* self, bool only_damage)
+{
+  struct znr_session* session = self->system->current_session;
+  struct zgnr_gl_vertex_attrib* vertex_attrib;
+
+  if (self->znr_gl_vertex_array == NULL) {
+    self->znr_gl_vertex_array = znr_gl_vertex_array_create(session);
+  }
+
+  wl_array_for_each (
+      vertex_attrib, &self->zgnr_gl_vertex_array->current.vertex_attribs) {
+    struct zgnr_gl_buffer* zgnr_gl_buffer =
+        zgnr_gl_vertex_attrib_get_gl_buffer(vertex_attrib);
+    if (zgnr_gl_buffer == NULL) continue;
+
+    struct zna_gl_buffer* gl_buffer = zgnr_gl_buffer->user_data;
+    zna_gl_buffer_apply_commit(gl_buffer, only_damage);
+
+    // TODO: apply attribs
+  }
+}
+
+struct zna_gl_vertex_array*
+zna_gl_vertex_array_create(struct zgnr_gl_vertex_array* zgnr_gl_vertex_array,
+    struct zna_system* system)
+{
+  struct zna_gl_vertex_array* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->zgnr_gl_vertex_array = zgnr_gl_vertex_array;
+  zgnr_gl_vertex_array->user_data = self;
+  self->system = system;
+  self->znr_gl_vertex_array = NULL;
+
+  self->zgnr_gl_vertex_array_destroy_listener.notify =
+      zna_gl_vertex_array_handle_zgnr_gl_vertex_array_destroy;
+  wl_signal_add(&self->zgnr_gl_vertex_array->events.destroy,
+      &self->zgnr_gl_vertex_array_destroy_listener);
+
+  self->session_destroy_listener.notify =
+      zna_gl_vertex_array_handle_session_destroy;
+  wl_signal_add(&self->system->events.current_session_destroyed,
+      &self->session_destroy_listener);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+static void
+zna_gl_vertex_array_destroy(struct zna_gl_vertex_array* self)
+{
+  if (self->znr_gl_vertex_array)
+    znr_gl_vertex_array_destroy(self->znr_gl_vertex_array);
+  wl_list_remove(&self->session_destroy_listener.link);
+  wl_list_remove(&self->zgnr_gl_vertex_array_destroy_listener.link);
+  free(self);
+}

--- a/zna/scene/virtual-object/gl-vertex-array.h
+++ b/zna/scene/virtual-object/gl-vertex-array.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <zgnr/gl-vertex-array.h>
+
+#include "system.h"
+#include "zen/renderer/gl-vertex-array.h"
+
+struct zna_gl_vertex_array {
+  struct zgnr_gl_vertex_array* zgnr_gl_vertex_array;  // nonnull
+  struct zna_system* system;                          // nonnull
+
+  /**
+   * null before the initial commit or when the current session does not exists,
+   * nonnull otherwise
+   */
+  struct znr_gl_vertex_array* znr_gl_vertex_array;
+
+  struct wl_listener zgnr_gl_vertex_array_destroy_listener;
+  struct wl_listener session_destroy_listener;
+};
+
+/**
+ * Precondition:
+ *  Current session exists && the zgnr_gl_buffer has been committed
+ */
+void zna_gl_vertex_array_apply_commit(
+    struct zna_gl_vertex_array* self, bool only_damage);
+
+struct zna_gl_vertex_array* zna_gl_vertex_array_create(
+    struct zgnr_gl_vertex_array* zgnr_gl_vertex_array,
+    struct zna_system* system);

--- a/zna/system.c
+++ b/zna/system.c
@@ -6,6 +6,7 @@
 
 #include "scene/virtual-object/gl-base-technique.h"
 #include "scene/virtual-object/gl-buffer.h"
+#include "scene/virtual-object/gl-vertex-array.h"
 #include "scene/virtual-object/rendering-unit.h"
 
 void
@@ -73,6 +74,16 @@ zna_system_handle_new_gl_base_technique(
   (void)zna_gl_base_technique_create(gl_base_technique, self);
 }
 
+static void
+zna_system_handle_new_gl_vertex_array(struct wl_listener* listener, void* data)
+{
+  struct zna_system* self =
+      zn_container_of(listener, self, new_gl_vertex_array_listener);
+  struct zgnr_gl_vertex_array* gl_vertex_array = data;
+
+  (void)zna_gl_vertex_array_create(gl_vertex_array, self);
+}
+
 struct zna_system*
 zna_system_create(struct wl_display* display)
 {
@@ -110,6 +121,11 @@ zna_system_create(struct wl_display* display)
   wl_signal_add(&self->gles->events.new_gl_base_technique,
       &self->new_gl_base_technique_listener);
 
+  self->new_gl_vertex_array_listener.notify =
+      zna_system_handle_new_gl_vertex_array;
+  wl_signal_add(&self->gles->events.new_gl_vertex_array,
+      &self->new_gl_vertex_array_listener);
+
   self->current_session_disconnected_listener.notify =
       zna_system_handle_current_session_disconnected;
   wl_list_init(&self->current_session_disconnected_listener.link);
@@ -133,6 +149,7 @@ zna_system_destroy(struct zna_system* self)
   wl_list_remove(&self->new_rendering_unit_listener.link);
   wl_list_remove(&self->new_gl_buffer_listener.link);
   wl_list_remove(&self->new_gl_base_technique_listener.link);
+  wl_list_remove(&self->new_gl_vertex_array_listener.link);
   wl_list_remove(&self->current_session_disconnected_listener.link);
   zgnr_gles_v32_destroy(self->gles);
   free(self);

--- a/zna/system.h
+++ b/zna/system.h
@@ -21,5 +21,6 @@ struct zna_system {
   struct wl_listener new_rendering_unit_listener;
   struct wl_listener new_gl_buffer_listener;
   struct wl_listener new_gl_base_technique_listener;
+  struct wl_listener new_gl_vertex_array_listener;
   struct wl_listener current_session_disconnected_listener;
 };

--- a/znr-remote/meson.build
+++ b/znr-remote/meson.build
@@ -3,6 +3,7 @@ _znr_remote_inc = include_directories('include')
 _znr_remote_srcs = [
   'src/gl-base-technique.cc',
   'src/gl-buffer.cc',
+  'src/gl-vertex-array.cc',
   'src/loop.cc',
   'src/peer.cc',
   'src/remote.cc',

--- a/znr-remote/src/gl-vertex-array.cc
+++ b/znr-remote/src/gl-vertex-array.cc
@@ -1,0 +1,39 @@
+#include "gl-vertex-array.h"
+
+#include <zen-common.h>
+
+#include "session.h"
+
+struct znr_gl_vertex_array*
+znr_gl_vertex_array_create(struct znr_session* session_base)
+{
+  auto self = new znr_gl_vertex_array();
+  znr_session_impl* session;
+
+  if (self == nullptr) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  session = zn_container_of(session_base, session, base);
+
+  self->proxy = zen::remote::server::CreateGlVertexArray(session->proxy);
+  if (!self->proxy) {
+    zn_error("Failed to create remote gl vertex array");
+    goto err_delete;
+  }
+
+  return self;
+
+err_delete:
+  delete self;
+
+err:
+  return nullptr;
+}
+
+void
+znr_gl_vertex_array_destroy(struct znr_gl_vertex_array* self)
+{
+  delete self;
+}

--- a/znr-remote/src/gl-vertex-array.h
+++ b/znr-remote/src/gl-vertex-array.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <zen-remote/server/gl-vertex-array.h>
+
+#include "zen/renderer/gl-vertex-array.h"
+
+struct znr_gl_vertex_array {
+  std::unique_ptr<zen::remote::server::IGlVertexArray> proxy;
+};


### PR DESCRIPTION
## Context

Create vertex array object.
ref: https://github.com/zigen-project/zen-remote/pull/33

## Summary

- [x] Create `znr_gl_vertex_array` when client app create and commit vao.

## How to check behavior

see https://github.com/zigen-project/zen-remote/pull/33