### PR TITLE
Create znr_gl_base_technique on applying commit

### DIFF
--- a/zna/scene/virtual-object/gl-base-technique.h
+++ b/zna/scene/virtual-object/gl-base-technique.h
@@ -3,10 +3,17 @@
 #include <zgnr/gl-base-technique.h>
 
 #include "system.h"
+#include "zen/renderer/gl-base-technique.h"
 
 struct zna_gl_base_technique {
   struct zgnr_gl_base_technique* zgnr_gl_base_technique;  // nonnull
   struct zna_system* system;                              // nonnull
+
+  /**
+   * null before the initial commit or when the current session does not exists,
+   * nonnull otherwise
+   */
+  struct znr_gl_base_technique* znr_gl_base_technique;
 
   struct wl_listener zgnr_gl_base_technique_destroy_listener;
   struct wl_listener session_destroyed_listener;
@@ -14,7 +21,8 @@ struct zna_gl_base_technique {
 
 /**
  * Precondition:
- *  Current session exists && the zgnr_gl_base_technique has been commited
+ *  Current session exists && the zgnr_gl_base_technique has been commited &&
+ * parent zna_rendering_unit has a valid znr_rendering_unit
  */
 void zna_gl_base_technique_apply_commit(
     struct zna_gl_base_technique* self, bool only_damaged);

--- a/zna/scene/virtual-object/gl-buffer.h
+++ b/zna/scene/virtual-object/gl-buffer.h
@@ -9,7 +9,10 @@ struct zna_gl_buffer {
   struct zgnr_gl_buffer *zgnr_gl_buffer;  // nonnull
   struct zna_system *system;              // nonnull
 
-  // null when current session does not exist, non-null otherwise
+  /**
+   * null before the initial commit or when the current session does not exists,
+   * nonnull otherwise
+   */
   struct znr_gl_buffer *znr_gl_buffer;
 
   struct wl_listener zgnr_gl_buffer_destroy_listener;


### PR DESCRIPTION
## Context

## Summary

- [x] Create `znr_gl_base_technique` in `zna_gl_base_technique_apply_commit`.

## How to check behavior

Start zen-box, GlBaseTechnique will be created in Quest.

## Note

When start zen-box, so much error log will be emitted. This will be fixed in another pull request in zen-remote.