### PR TITLE
send vertex attributes info

### DIFF
--- a/include/zen/renderer/gl-vertex-array.h
+++ b/include/zen/renderer/gl-vertex-array.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "zen/renderer/gl-buffer.h"
 #include "zen/renderer/session.h"
 
 #ifdef __cplusplus
@@ -7,6 +8,16 @@ extern "C" {
 #endif
 
 struct znr_gl_vertex_array;
+
+void znr_gl_vertex_array_enable_vertex_attrib_array(
+    struct znr_gl_vertex_array* self, uint32_t index);
+
+void znr_gl_vertex_array_disable_vertex_attrib_array(
+    struct znr_gl_vertex_array* self, uint32_t index);
+
+void znr_gl_vertex_array_vertex_attrib_pointer(struct znr_gl_vertex_array* self,
+    uint32_t index, int32_t size, uint32_t type, bool normalized,
+    int32_t stride, uint64_t offset, struct znr_gl_buffer* gl_buffer);
 
 struct znr_gl_vertex_array* znr_gl_vertex_array_create(
     struct znr_session* session);

--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = wlroots_req
-zen_remote_server_req = '0.1.0.13'
+zen_remote_server_req = '0.1.0.14'
 
 # dependencies
 

--- a/zgnroot/include/zgnr/gl-vertex-array.h
+++ b/zgnroot/include/zgnr/gl-vertex-array.h
@@ -14,7 +14,7 @@ struct zgnr_gl_vertex_array {
   } events;
 
   struct {
-    struct wl_array vertex_attribs;  // struct zgnr_gl_vertex_attrib
+    struct wl_list vertex_attrib_list;  // struct zgnr_gl_vertex_attrib::link
   } current;
 
   void* user_data;

--- a/zgnroot/include/zgnr/gl-vertex-attrib.h
+++ b/zgnroot/include/zgnr/gl-vertex-attrib.h
@@ -18,6 +18,10 @@ struct zgnr_gl_vertex_attrib {
   bool enable_changed;
   bool gl_buffer_changed;
   struct zn_weak_resource gl_buffer;  // (private)
+
+  // zgnr_gl_vertex_array::current.vertex_attrib_list or
+  // zgnr_gl_vertex_array_impl::pending.vertex_attrib_list (internal use)
+  struct wl_list link;
 };
 
 struct zgnr_gl_buffer* zgnr_gl_vertex_attrib_get_gl_buffer(

--- a/zgnroot/src/gl-vertex-array.h
+++ b/zgnroot/src/gl-vertex-array.h
@@ -6,7 +6,7 @@ struct zgnr_gl_vertex_array_impl {
   struct zgnr_gl_vertex_array base;
 
   struct {
-    struct wl_array vertex_attribs;  // struct zgnr_gl_vertex_attrib
+    struct wl_list vertex_attrib_list;  // struct zgnr_gl_vertex_attrib::link
   } pending;
 };
 

--- a/zgnroot/src/gl-vertex-attrib.c
+++ b/zgnroot/src/gl-vertex-attrib.c
@@ -1,4 +1,6 @@
-#include "zgnr/gl-vertex-attrib.h"
+#include "gl-vertex-attrib.h"
+
+#include <zen-common.h>
 
 #include "gl-buffer.h"
 
@@ -12,4 +14,50 @@ zgnr_gl_vertex_attrib_get_gl_buffer(struct zgnr_gl_vertex_attrib* attrib)
       zn_weak_resource_get_user_data(&attrib->gl_buffer);
 
   return gl_buffer ? &gl_buffer->base : NULL;
+}
+
+struct zgnr_gl_vertex_attrib*
+zgnr_gl_vertex_attrib_copy(struct zgnr_gl_vertex_attrib* src)
+{
+  struct zgnr_gl_vertex_attrib* dest = zgnr_gl_vertex_attrib_create(src->index);
+
+  memcpy(dest, src, sizeof *dest);
+
+  zn_weak_resource_init(&dest->gl_buffer);
+  zn_weak_resource_link(&dest->gl_buffer, src->gl_buffer.resource);
+
+  return dest;
+}
+
+struct zgnr_gl_vertex_attrib*
+zgnr_gl_vertex_attrib_create(uint32_t index)
+{
+  struct zgnr_gl_vertex_attrib* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->index = index;
+  self->enabled = false;
+  self->enable_changed = false;
+  self->gl_buffer_changed = false;
+  wl_list_init(&self->link);
+
+  zn_weak_resource_init(&self->gl_buffer);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zgnr_gl_vertex_attrib_destroy(struct zgnr_gl_vertex_attrib* self)
+{
+  wl_list_remove(&self->link);
+  zn_weak_resource_unlink(&self->gl_buffer);
+  free(self);
 }

--- a/zgnroot/src/gl-vertex-attrib.h
+++ b/zgnroot/src/gl-vertex-attrib.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "zgnr/gl-vertex-attrib.h"
+
+struct zgnr_gl_vertex_attrib* zgnr_gl_vertex_attrib_copy(
+    struct zgnr_gl_vertex_attrib* src);
+
+struct zgnr_gl_vertex_attrib* zgnr_gl_vertex_attrib_create(uint32_t index);
+
+void zgnr_gl_vertex_attrib_destroy(struct zgnr_gl_vertex_attrib* self);

--- a/zna/scene/virtual-object/gl-vertex-array.c
+++ b/zna/scene/virtual-object/gl-vertex-array.c
@@ -42,8 +42,8 @@ zna_gl_vertex_array_apply_commit(
     self->znr_gl_vertex_array = znr_gl_vertex_array_create(session);
   }
 
-  wl_array_for_each (
-      vertex_attrib, &self->zgnr_gl_vertex_array->current.vertex_attribs) {
+  wl_list_for_each (vertex_attrib,
+      &self->zgnr_gl_vertex_array->current.vertex_attrib_list, link) {
     struct zgnr_gl_buffer* zgnr_gl_buffer =
         zgnr_gl_vertex_attrib_get_gl_buffer(vertex_attrib);
     if (zgnr_gl_buffer == NULL) continue;
@@ -51,7 +51,22 @@ zna_gl_vertex_array_apply_commit(
     struct zna_gl_buffer* gl_buffer = zgnr_gl_buffer->user_data;
     zna_gl_buffer_apply_commit(gl_buffer, only_damage);
 
-    // TODO: apply attribs
+    if (vertex_attrib->enable_changed || !only_damage) {
+      if (vertex_attrib->enabled) {
+        znr_gl_vertex_array_enable_vertex_attrib_array(
+            self->znr_gl_vertex_array, vertex_attrib->index);
+      } else {
+        znr_gl_vertex_array_disable_vertex_attrib_array(
+            self->znr_gl_vertex_array, vertex_attrib->index);
+      }
+    }
+
+    if (vertex_attrib->gl_buffer_changed || !only_damage) {
+      znr_gl_vertex_array_vertex_attrib_pointer(self->znr_gl_vertex_array,
+          vertex_attrib->index, vertex_attrib->size, vertex_attrib->type,
+          vertex_attrib->normalized, vertex_attrib->stride,
+          vertex_attrib->offset, gl_buffer->znr_gl_buffer);
+    }
   }
 }
 

--- a/znr-remote/src/gl-vertex-array.cc
+++ b/znr-remote/src/gl-vertex-array.cc
@@ -2,7 +2,31 @@
 
 #include <zen-common.h>
 
+#include "gl-buffer.h"
 #include "session.h"
+
+void
+znr_gl_vertex_array_enable_vertex_attrib_array(
+    struct znr_gl_vertex_array* self, uint32_t index)
+{
+  self->proxy->GlEnableVertexAttribArray(index);
+}
+
+void
+znr_gl_vertex_array_disable_vertex_attrib_array(
+    struct znr_gl_vertex_array* self, uint32_t index)
+{
+  self->proxy->GlDisableVertexAttribArray(index);
+}
+
+void
+znr_gl_vertex_array_vertex_attrib_pointer(struct znr_gl_vertex_array* self,
+    uint32_t index, int32_t size, uint32_t type, bool normalized,
+    int32_t stride, uint64_t offset, struct znr_gl_buffer* gl_buffer)
+{
+  self->proxy->GlVertexAttribPointer(
+      index, size, type, normalized, stride, offset, gl_buffer->proxy->id());
+}
 
 struct znr_gl_vertex_array*
 znr_gl_vertex_array_create(struct znr_session* session_base)


### PR DESCRIPTION
## Context

Send vertex attributes to Quest using https://github.com/zigen-project/zen-remote/pull/37

## Summary

- [x] Send vertex attributes to Quest using https://github.com/zigen-project/zen-remote/pull/37
- [x] Fix bug usage of wl_array.

## How to check behavior

You can check that the vertex attributes info is sent to Quest by output the vertex attributes info in Quest.