### PR TITLE
switch display system

### DIFF
--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -55,6 +55,9 @@ struct zn_server {
 
 struct zn_server *zn_server_get_singleton(void);
 
+void zn_server_change_display_system(
+    struct zn_server *self, enum zen_display_system_type display_system);
+
 /** returns exit code */
 int zn_server_run(struct zn_server *self);
 

--- a/meson.build
+++ b/meson.build
@@ -146,8 +146,8 @@ subdir('protocols')
 subdir('common')
 subdir('zgnroot')
 subdir('znr-remote')
-subdir('zna')
 subdir('zen')
+subdir('zna')
 if get_option('clients')
   subdir('clients')
 endif
@@ -165,3 +165,13 @@ install_data(
 if get_option('tests')
   subdir('tests')
 endif
+
+executable(
+  'zen-desktop',
+  'zen/main.c',
+  install: true,
+  dependencies: [
+    zen_dep,
+    zen_appearance_dep,
+  ],
+)

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -1,4 +1,4 @@
-_zen_desktop_srcs = [
+_zen_srcs = [
   'binding.c',
   'config.c',
   'cursor.c',
@@ -30,14 +30,16 @@ _zen_desktop_srcs = [
   'scene/virtual-object.c',
 
   'wlr/box.c',
+]
 
+_zen_srcs_pub = [
   protocols['xdg-shell']['private-code'],
   protocols['xdg-shell']['server-header'],
   protocols['zen-desktop']['private-code'],
   protocols['zen-desktop']['server-header'],
 ]
 
-_zen_desktop_deps = [
+_zen_deps = [
   cairo_dep,
   cglm_dep,
   m_dep,
@@ -47,17 +49,23 @@ _zen_desktop_deps = [
   wlroots_dep,
   wlr_glew_renderer_dep,
   xkbcommon_dep,
-  zen_appearance_dep,
   zen_common_dep,
-  znr_remote_dep,
   zgnr_dep,
+  znr_remote_dep,
 ]
 
-executable(
-  'zen-desktop',
-  _zen_desktop_srcs,
-  install: true,
+_zen_lib = static_library(
+  'zen-lib',
+  _zen_srcs + _zen_srcs_pub,
+  install: false,
   c_args: ['-include', 'config.h'],
-  dependencies: _zen_desktop_deps,
+  dependencies: _zen_deps,
   include_directories: zen_inc,
+)
+
+zen_dep = declare_dependency(
+  link_with: _zen_lib,
+  dependencies: _zen_deps,
+  include_directories: zen_inc,
+  sources: _zen_srcs_pub,
 )

--- a/zen/server.c
+++ b/zen/server.c
@@ -116,6 +116,13 @@ zn_server_get_singleton(void)
   return server_singleton;
 }
 
+void
+zn_server_change_display_system(
+    struct zn_server *self, enum zen_display_system_type display_system)
+{
+  self->display_system = display_system;
+}
+
 int
 zn_server_run(struct zn_server *self)
 {

--- a/zna/meson.build
+++ b/zna/meson.build
@@ -12,9 +12,7 @@ _zen_appearance_srcs = [
 ]
 
 _zen_appearance_deps = [
-  wayland_server_dep,
-  zen_common_dep,
-  zgnr_dep,
+  zen_dep,
 ]
 
 _zen_appearance_lib = static_library(

--- a/zna/system.c
+++ b/zna/system.c
@@ -11,10 +11,14 @@
 #include "scene/virtual-object/gl-shader.h"
 #include "scene/virtual-object/gl-vertex-array.h"
 #include "scene/virtual-object/rendering-unit.h"
+#include "zen/server.h"
+
 void
 zna_system_set_current_session(
     struct zna_system* self, struct znr_session* session)
 {
+  struct zn_server* server = zn_server_get_singleton();
+
   if (self->current_session) {
     wl_list_remove(&self->current_session_disconnected_listener.link);
     wl_list_init(&self->current_session_disconnected_listener.link);
@@ -32,6 +36,10 @@ zna_system_set_current_session(
 
     zn_debug("The current session is newly created");
     wl_signal_emit(&self->events.current_session_created, NULL);
+
+    zn_server_change_display_system(server, ZEN_DISPLAY_SYSTEM_TYPE_IMMERSIVE);
+  } else {
+    zn_server_change_display_system(server, ZEN_DISPLAY_SYSTEM_TYPE_SCREEN);
   }
 }
 


### PR DESCRIPTION
## Context

Switch display system when renderer session starts

## Summary

- [x] Refactor build system
- [x] Switch display system when renderer session starts 

## How to check behavior

When Quest is connected, screen display poses.

## Note

`./build/zen/zen-desktop` moves to `./build/zen-desktop`