### PR TITLE
draw ray but without motion

### DIFF
--- a/include/zen/appearance/scene/ray.h
+++ b/include/zen/appearance/scene/ray.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "zen/appearance/system.h"
+#include "zen/scene/ray.h"
+
+struct zna_ray;
+
+struct zna_ray* zna_ray_create(struct zn_ray* ray, struct zna_system* system);
+
+void zna_ray_destroy(struct zna_ray* self);

--- a/include/zen/scene/ray.h
+++ b/include/zen/scene/ray.h
@@ -3,6 +3,8 @@
 #include <cglm/cglm.h>
 #include <wayland-server-core.h>
 
+struct zna_ray;
+
 struct zn_ray {
   vec3 origin;
 
@@ -17,6 +19,8 @@ struct zn_ray {
     struct wl_signal destroy;  // (NULL)
     struct wl_signal motion;   // (NULL)
   } events;
+
+  struct zna_ray* appearance;  // nonnull, owning
 };
 
 void zn_ray_move(struct zn_ray* self, float polar, float azimuthal);

--- a/zen/scene/virtual-object.c
+++ b/zen/scene/virtual-object.c
@@ -58,8 +58,8 @@ err:
 static void
 zn_virtual_object_destroy(struct zn_virtual_object* self)
 {
+  zna_virtual_object_destroy(self->appearance);
   wl_list_remove(&self->link);
   wl_list_remove(&self->zgnr_virtual_object_destroy_listener.link);
-  zna_virtual_object_destroy(self->appearance);
   free(self);
 }

--- a/zgnroot/include/zgnr/mem-storage.h
+++ b/zgnroot/include/zgnr/mem-storage.h
@@ -10,6 +10,11 @@ struct zgnr_mem_storage {
   ssize_t size;
 };
 
+/**
+ * @param src if null, memory is allocated but nothing is copied
+ */
+struct zgnr_mem_storage* zgnr_mem_storage_create(void* src, size_t size);
+
 struct zgnr_mem_storage* zgnr_mem_storage_ref(struct zgnr_mem_storage* self);
 
 void zgnr_mem_storage_unref(struct zgnr_mem_storage* self);

--- a/zgnroot/src/gl-base-technique.c
+++ b/zgnroot/src/gl-base-technique.c
@@ -124,14 +124,13 @@ zgnr_gl_base_technique_protocol_uniform_vector(struct wl_client *client,
 static void
 zgnr_gl_base_technique_protocol_uniform_matrix(struct wl_client *client,
     struct wl_resource *resource, uint32_t location, const char *name,
-    uint32_t type, uint32_t col, uint32_t row, uint32_t count,
-    uint32_t transpose, struct wl_array *value)
+    uint32_t col, uint32_t row, uint32_t count, uint32_t transpose,
+    struct wl_array *value)
 {
   UNUSED(client);
   UNUSED(resource);
   UNUSED(location);
   UNUSED(name);
-  UNUSED(type);
   UNUSED(col);
   UNUSED(row);
   UNUSED(count);

--- a/zgnroot/src/mem-storage.c
+++ b/zgnroot/src/mem-storage.c
@@ -40,7 +40,7 @@ zgnr_mem_storage_create(void* src, size_t size)
     goto err_free;
   }
 
-  memcpy(self->base.data, src, size);
+  if (src) memcpy(self->base.data, src, size);
 
   return &self->base;
 

--- a/zgnroot/src/mem-storage.h
+++ b/zgnroot/src/mem-storage.h
@@ -5,5 +5,3 @@ struct zgnr_mem_storage_impl {
 
   int ref_count;
 };
-
-struct zgnr_mem_storage* zgnr_mem_storage_create(void* src, size_t size);

--- a/zna/base-unit.c
+++ b/zna/base-unit.c
@@ -1,0 +1,128 @@
+#include "base-unit.h"
+
+#include <GLES3/gl32.h>
+#include <zen-common.h>
+
+void
+zna_base_unit_setup_renderer_objects(struct zna_base_unit* self,
+    struct znr_session* session, struct znr_virtual_object* virtual_object)
+{
+  struct znr_gl_shader *vertex_shader, *fragment_shader;
+
+  if (self->has_renderer_objects) return;
+
+  self->rendering_unit = znr_rendering_unit_create(session, virtual_object);
+  self->technique = znr_gl_base_technique_create(session, self->rendering_unit);
+  self->vertex_buffer = znr_gl_buffer_create(session, self->system->display);
+  self->vertex_array = znr_gl_vertex_array_create(session);
+  self->program = znr_gl_program_create(session);
+
+  // program
+  vertex_shader = zna_shader_inventory_get(
+      self->system->shader_inventory, self->vertex_shader);
+  fragment_shader = zna_shader_inventory_get(
+      self->system->shader_inventory, self->fragment_shader);
+
+  znr_gl_program_attach_shader(self->program, vertex_shader);
+  znr_gl_program_attach_shader(self->program, fragment_shader);
+  znr_gl_program_link(self->program);
+
+  // vertex buffer
+  znr_gl_buffer_data(self->vertex_buffer, GL_ARRAY_BUFFER,
+      self->vertex_buffer_storage, GL_STATIC_DRAW);
+
+  // vertex array
+  struct zna_base_unit_vertex_attribute* vertex_attribute;
+  wl_array_for_each (vertex_attribute, &self->vertex_attributes) {
+    znr_gl_vertex_array_enable_vertex_attrib_array(
+        self->vertex_array, vertex_attribute->index);
+    znr_gl_vertex_array_vertex_attrib_pointer(self->vertex_array,
+        vertex_attribute->index, vertex_attribute->size, vertex_attribute->type,
+        vertex_attribute->normalized, vertex_attribute->stride,
+        vertex_attribute->offset, self->vertex_buffer);
+  }
+
+  // base technique
+  znr_gl_base_technique_bind_vertex_array(self->technique, self->vertex_array);
+  znr_gl_base_technique_bind_program(self->technique, self->program);
+
+  switch (self->draw_method) {
+    case ZGNR_GL_BASE_TECHNIQUE_DRAW_METHOD_ARRAYS:
+      znr_gl_base_technique_draw_arrays(self->technique,
+          self->draw_args.arrays.mode, self->draw_args.arrays.first,
+          self->draw_args.arrays.count);
+      break;
+
+    case ZGNR_GL_BASE_TECHNIQUE_DRAW_METHOD_NONE:  // fall through
+    default:
+      break;
+  }
+
+  self->has_renderer_objects = true;
+}
+
+void
+zna_base_unit_teardown_renderer_objects(struct zna_base_unit* self)
+{
+  if (!self->has_renderer_objects) return;
+
+  znr_rendering_unit_destroy(self->rendering_unit);
+  self->rendering_unit = NULL;
+  znr_gl_base_technique_destroy(self->technique);
+  self->technique = NULL;
+  znr_gl_buffer_destroy(self->vertex_buffer);
+  self->vertex_buffer = NULL;
+  znr_gl_vertex_array_destroy(self->vertex_array);
+  self->vertex_array = NULL;
+  znr_gl_program_destroy(self->program);
+  self->program = NULL;
+
+  self->has_renderer_objects = false;
+}
+
+struct zna_base_unit*
+zna_base_unit_create(struct zna_system* system,
+    enum zna_shader_name vertex_shader, enum zna_shader_name fragment_shader,
+    struct zgnr_mem_storage* vertex_buffer, struct wl_array* vertex_attributes,
+    enum zgnr_gl_base_technique_draw_method draw_method,
+    union zgnr_gl_base_technique_draw_args draw_args)
+{
+  struct zna_base_unit* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->system = system;
+  self->has_renderer_objects = false;
+  self->vertex_shader = vertex_shader;
+  self->fragment_shader = fragment_shader;
+  self->vertex_buffer_storage = vertex_buffer;
+  zgnr_mem_storage_ref(vertex_buffer);
+  wl_array_init(&self->vertex_attributes);
+  wl_array_copy(&self->vertex_attributes, vertex_attributes);
+  self->draw_method = draw_method;
+  self->draw_args = draw_args;
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zna_base_unit_destroy(struct zna_base_unit* self)
+{
+  if (self->rendering_unit) znr_rendering_unit_destroy(self->rendering_unit);
+  if (self->technique) znr_gl_base_technique_destroy(self->technique);
+  if (self->vertex_buffer) znr_gl_buffer_destroy(self->vertex_buffer);
+  if (self->vertex_array) znr_gl_vertex_array_destroy(self->vertex_array);
+  if (self->program) znr_gl_program_destroy(self->program);
+
+  zgnr_mem_storage_unref(self->vertex_buffer_storage);
+  wl_array_release(&self->vertex_attributes);
+
+  free(self);
+}

--- a/zna/base-unit.h
+++ b/zna/base-unit.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <wayland-server-core.h>
+#include <zgnr/gl-base-technique.h>
+#include <zgnr/mem-storage.h>
+
+#include "shader-inventory.h"
+#include "system.h"
+#include "zen/renderer/gl-base-technique.h"
+#include "zen/renderer/gl-buffer.h"
+#include "zen/renderer/gl-program.h"
+#include "zen/renderer/gl-shader.h"
+#include "zen/renderer/gl-vertex-array.h"
+#include "zen/renderer/rendering-unit.h"
+#include "zen/renderer/virtual-object.h"
+
+struct zna_base_unit_vertex_attribute {
+  uint32_t index;
+  int32_t size;
+  uint32_t type;
+  bool normalized;
+  int32_t stride;
+  uint32_t offset;
+};
+
+struct zna_base_unit {
+  struct zna_system* system;
+
+  bool has_renderer_objects;
+  struct znr_rendering_unit* rendering_unit;
+  struct znr_gl_base_technique* technique;
+  struct znr_gl_buffer* vertex_buffer;
+  struct znr_gl_vertex_array* vertex_array;
+  struct znr_gl_program* program;
+
+  enum zna_shader_name vertex_shader;
+  enum zna_shader_name fragment_shader;
+
+  struct zgnr_mem_storage* vertex_buffer_storage;  // nullable
+
+  struct wl_array vertex_attributes;  // struct zna_base_unit_vertex_attribute
+
+  enum zgnr_gl_base_technique_draw_method draw_method;
+  union zgnr_gl_base_technique_draw_args draw_args;
+};
+
+void zna_base_unit_setup_renderer_objects(struct zna_base_unit* self,
+    struct znr_session* session, struct znr_virtual_object* virtual_object);
+
+void zna_base_unit_teardown_renderer_objects(struct zna_base_unit* self);
+
+struct zna_base_unit* zna_base_unit_create(struct zna_system* system,
+    enum zna_shader_name vertex_shader, enum zna_shader_name fragment_shader,
+    struct zgnr_mem_storage* vertex_buffer, struct wl_array* vertex_attributes,
+    enum zgnr_gl_base_technique_draw_method draw_method,
+    union zgnr_gl_base_technique_draw_args draw_args);
+
+void zna_base_unit_destroy(struct zna_base_unit* self);

--- a/zna/meson.build
+++ b/zna/meson.build
@@ -1,7 +1,13 @@
+subdir('shaders')
+
 _zen_appearance_inc = include_directories('.')
 
 _zen_appearance_srcs = [
+  'base-unit.c',
+  'shader-inventory.c',
   'system.c',
+  
+  'scene/ray.c',
   'scene/virtual-object.c',
   'scene/virtual-object/gl-base-technique.c',
   'scene/virtual-object/gl-buffer.c',
@@ -9,7 +15,7 @@ _zen_appearance_srcs = [
   'scene/virtual-object/gl-shader.c',
   'scene/virtual-object/gl-vertex-array.c',
   'scene/virtual-object/rendering-unit.c',
-]
+] + shaders
 
 _zen_appearance_deps = [
   zen_dep,

--- a/zna/scene/ray.c
+++ b/zna/scene/ray.c
@@ -1,0 +1,130 @@
+#include "ray.h"
+
+#include <GLES3/gl32.h>
+#include <zen-common.h>
+
+#include "system.h"
+
+/**
+ * @param session must not be null
+ */
+static void
+zna_ray_setup_renderer_objects(
+    struct zna_ray* self, struct znr_session* session)
+{
+  self->virtual_object = znr_virtual_object_create(session);
+
+  zna_base_unit_setup_renderer_objects(
+      self->baes_unit, session, self->virtual_object);
+
+  znr_virtual_object_commit(self->virtual_object);
+}
+
+static void
+zna_ray_teardown_renderer_objects(struct zna_ray* self)
+{
+  zna_base_unit_teardown_renderer_objects(self->baes_unit);
+
+  if (self->virtual_object) {
+    znr_virtual_object_destroy(self->virtual_object);
+    self->virtual_object = NULL;
+  }
+}
+
+static void
+zna_ray_handle_session_created(struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+
+  struct zna_ray* self =
+      zn_container_of(listener, self, session_created_listener);
+  struct znr_session* session = self->system->current_session;
+
+  zna_ray_setup_renderer_objects(self, session);
+}
+
+static void
+zna_ray_handle_session_destroyed(struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+
+  struct zna_ray* self =
+      zn_container_of(listener, self, session_destroyed_listener);
+
+  zna_ray_teardown_renderer_objects(self);
+}
+
+struct zna_ray*
+zna_ray_create(struct zn_ray* ray, struct zna_system* system)
+{
+  struct zna_ray* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->session_created_listener.notify = zna_ray_handle_session_created;
+  wl_signal_add(
+      &system->events.current_session_created, &self->session_created_listener);
+
+  self->session_destroyed_listener.notify = zna_ray_handle_session_destroyed;
+  wl_signal_add(&system->events.current_session_destroyed,
+      &self->session_destroyed_listener);
+
+  self->zn_ray = ray;
+  self->system = system;
+  self->virtual_object = NULL;
+
+  {  // setup base unit
+    vec3 vertices[] = {{0, 0, 0}, {0, 1, -1}};
+    struct zgnr_mem_storage* vertex_buffer =
+        zgnr_mem_storage_create(vertices[0], sizeof(vertices));
+
+    struct wl_array vertex_attributes;
+    wl_array_init(&vertex_attributes);
+
+    struct zna_base_unit_vertex_attribute* vertex_attribute =
+        wl_array_add(&vertex_attributes, sizeof *vertex_attribute);
+    vertex_attribute->index = 0;
+    vertex_attribute->size = 3;
+    vertex_attribute->type = GL_FLOAT;
+    vertex_attribute->normalized = GL_FALSE;
+    vertex_attribute->stride = 0;
+    vertex_attribute->offset = 0;
+
+    union zgnr_gl_base_technique_draw_args draw_args;
+    draw_args.arrays.mode = GL_LINES;
+    draw_args.arrays.first = 0;
+    draw_args.arrays.count = sizeof(vertices) / sizeof(vec3);
+
+    self->baes_unit = zna_base_unit_create(system, ZNA_SHADER_DEFAULT_VERTEX,
+        ZNA_SHADER_COLOR_FRAGMENT, vertex_buffer, &vertex_attributes,
+        ZGNR_GL_BASE_TECHNIQUE_DRAW_METHOD_ARRAYS, draw_args);
+
+    wl_array_release(&vertex_attributes);
+
+    zgnr_mem_storage_unref(vertex_buffer);
+  }
+
+  struct znr_session* session = self->system->current_session;
+  if (session) {
+    zna_ray_setup_renderer_objects(self, session);
+  }
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zna_ray_destroy(struct zna_ray* self)
+{
+  if (self->virtual_object) znr_virtual_object_destroy(self->virtual_object);
+  zna_base_unit_destroy(self->baes_unit);
+  wl_list_remove(&self->session_created_listener.link);
+  wl_list_remove(&self->session_destroyed_listener.link);
+  free(self);
+}

--- a/zna/scene/ray.h
+++ b/zna/scene/ray.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "base-unit.h"
+#include "zen/appearance/scene/ray.h"
+#include "zen/renderer/virtual-object.h"
+
+struct zna_ray {
+  struct zn_ray* zn_ray;      // nonnull
+  struct zna_system* system;  // nonnull
+
+  // null when the current session does not exist, not null otherwise
+  struct znr_virtual_object* virtual_object;
+
+  struct zna_base_unit* baes_unit;  // nonnull
+
+  struct wl_listener session_created_listener;
+  struct wl_listener session_destroyed_listener;
+};

--- a/zna/shader-inventory.c
+++ b/zna/shader-inventory.c
@@ -1,0 +1,105 @@
+#include "shader-inventory.h"
+
+#include <GLES3/gl32.h>
+#include <zen-common.h>
+
+#include "color.frag.h"
+#include "default.vert.h"
+#include "system.h"
+
+struct zna_shader_inventory {
+  struct znr_gl_shader* shaders[ZNA_SHADER_COUNT];
+  struct zna_system* system;
+
+  struct wl_listener session_destroyed_listener;
+};
+
+static void
+zna_shader_inventory_handle_session_destroyed(
+    struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct zna_shader_inventory* self =
+      zn_container_of(listener, self, session_destroyed_listener);
+
+  for (int i = 0; i < ZNA_SHADER_COUNT; i++) {
+    if (self->shaders[i]) {
+      znr_gl_shader_destroy(self->shaders[i]);
+      self->shaders[i] = NULL;
+    }
+  }
+}
+
+struct znr_gl_shader*
+zna_shader_inventory_get(
+    struct zna_shader_inventory* self, enum zna_shader_name name)
+{
+  struct znr_session* session = self->system->current_session;
+  const char* shader_source;
+  uint32_t type;
+  size_t length;
+
+  if (!session || name >= ZNA_SHADER_COUNT) return NULL;
+
+  if (self->shaders[name]) {
+    return self->shaders[name];
+  }
+
+  switch (name) {
+    case ZNA_SHADER_DEFAULT_VERTEX:
+      shader_source = default_vert_source;
+      length = sizeof(default_vert_source);
+      type = GL_VERTEX_SHADER;
+      break;
+
+    case ZNA_SHADER_COLOR_FRAGMENT:
+      shader_source = color_frag_source;
+      length = sizeof(color_frag_source);
+      type = GL_FRAGMENT_SHADER;
+      break;
+
+    default:
+      zn_assert(false, "Unknown shader name");
+      return NULL;
+  }
+
+  self->shaders[name] =
+      znr_gl_shader_create(session, shader_source, length, type);
+
+  return self->shaders[name];
+}
+
+struct zna_shader_inventory*
+zna_shader_inventory_create(struct zna_system* system)
+{
+  struct zna_shader_inventory* self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    goto err;
+  }
+
+  self->system = system;
+
+  self->session_destroyed_listener.notify =
+      zna_shader_inventory_handle_session_destroyed;
+  wl_signal_add(&system->events.current_session_destroyed,
+      &self->session_destroyed_listener);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zna_shader_inventory_destroy(struct zna_shader_inventory* self)
+{
+  for (int i = 0; i < ZNA_SHADER_COUNT; i++) {
+    if (self->shaders[i]) {
+      znr_gl_shader_destroy(self->shaders[i]);
+    }
+  }
+  wl_list_remove(&self->session_destroyed_listener.link);
+  free(self);
+}

--- a/zna/shader-inventory.h
+++ b/zna/shader-inventory.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "system.h"
+#include "zen/renderer/gl-shader.h"
+
+enum zna_shader_name {
+  ZNA_SHADER_DEFAULT_VERTEX = 0,
+  ZNA_SHADER_COLOR_FRAGMENT,
+  ZNA_SHADER_COUNT,
+};
+
+struct zna_shader_inventory;
+
+/**
+ * @return struct znr_gl_shader* : nullable
+ */
+struct znr_gl_shader* zna_shader_inventory_get(
+    struct zna_shader_inventory* self, enum zna_shader_name name);
+
+struct zna_shader_inventory* zna_shader_inventory_create(
+    struct zna_system* system);
+
+void zna_shader_inventory_destroy(struct zna_shader_inventory* self);

--- a/zna/shaders/color.frag
+++ b/zna/shaders/color.frag
@@ -1,0 +1,10 @@
+#version 320 es
+precision mediump float;
+
+out vec4 outputColor;
+
+void
+main()
+{
+  outputColor = vec4(1.0, 0.0, 0.0, 1.0);
+}

--- a/zna/shaders/default.vert
+++ b/zna/shaders/default.vert
@@ -1,0 +1,10 @@
+#version 320 es
+
+uniform mat4 mvp;
+layout(location = 0) in vec4 position;
+
+void
+main()
+{
+  gl_Position = mvp * position;
+}

--- a/zna/shaders/meson.build
+++ b/zna/shaders/meson.build
@@ -1,0 +1,18 @@
+_shader_sources = [
+  'color.frag',
+  'default.vert',
+]
+
+shaders = []
+
+foreach shader : _shader_sources
+  var_name = shader.underscorify() + '_source'
+  file_name = '@0@.h'.format(shader)
+
+  shaders += custom_target(
+    file_name,
+    command: [textify, var_name, '@INPUT@', '@OUTPUT@'],
+    input: shader,
+    output: file_name,
+  )
+endforeach

--- a/zna/system.c
+++ b/zna/system.c
@@ -11,6 +11,7 @@
 #include "scene/virtual-object/gl-shader.h"
 #include "scene/virtual-object/gl-vertex-array.h"
 #include "scene/virtual-object/rendering-unit.h"
+#include "shader-inventory.h"
 #include "zen/server.h"
 
 void
@@ -170,6 +171,8 @@ zna_system_create(struct wl_display* display)
       zna_system_handle_current_session_disconnected;
   wl_list_init(&self->current_session_disconnected_listener.link);
 
+  self->shader_inventory = zna_shader_inventory_create(self);
+
   return self;
 
 err_free:
@@ -183,6 +186,8 @@ void
 zna_system_destroy(struct zna_system* self)
 {
   if (self->current_session) znr_session_destroy(self->current_session);
+
+  zna_shader_inventory_destroy(self->shader_inventory);
 
   wl_list_remove(&self->events.current_session_created.listener_list);
   wl_list_remove(&self->events.current_session_destroyed.listener_list);

--- a/zna/system.h
+++ b/zna/system.h
@@ -4,11 +4,14 @@
 
 #include "zen/appearance/system.h"
 
+struct zna_shader_inventory;
+
 struct zna_system {
   struct wl_display *display;
   struct zgnr_gles_v32 *gles;  // nonnull, owning
 
-  struct znr_session *current_session;  // nullable, owning
+  struct zna_shader_inventory *shader_inventory;  // nonnull, owning
+  struct znr_session *current_session;            // nullable, owning
 
   struct {
     // When the current session switches to a new one, current_session_destroyed


### PR DESCRIPTION
## Context

So far we have been considering the case where the client application does the rendering. However, in this pull request, we will start treating "ray" as something that zen draws.

## Summary

- [x] Draw lines when ray is active. Motion of ray is not the scope of this pull request.

## How to check behavior

Start immersive display system

You will see a ray when a pointing device is connected. It will disappear when the pointing device is disconnected.