### PR TITLE
animation with uniform variable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           sudo apt-get install \
             libwayland-dev libwlroots-dev libpixman-1-dev libxml2-dev \
             libopenvr-dev libxkbcommon-dev libglu1-mesa-dev libglew-dev weston \
-            meson
+            libglm-dev meson
 
       - uses: actions/setup-python@v1
         with:

--- a/clients/box.cc
+++ b/clients/box.cc
@@ -4,6 +4,7 @@
 #include <zigen-protocol.h>
 
 #include <cstring>
+#include <glm/vec4.hpp>
 #include <iostream>
 #include <vector>
 
@@ -33,9 +34,20 @@ class Box final : public VirtualObject
   Box() = delete;
   Box(Application* app) : VirtualObject(app), app_(app) {}
 
+  void SetUniformVariables()
+  {
+    glm::vec4 translation = {0, 1.2, -1, 0};
+
+    translation.x = sin(animation_seed_ * 2 * M_PI);
+
+    technique_->Uniform(0, "translate", translation);
+  }
+
   void Frame(uint32_t time) override
   {
-    std::cerr << "frame! " << time << std::endl;
+    animation_seed_ = (float)(time % 2000) / 2000.0f;
+
+    SetUniformVariables();
     NextFrame();
     Commit();
   }
@@ -50,21 +62,21 @@ class Box final : public VirtualObject
     technique_ = CreateGlBaseTechnique(app_, unit_.get());
     if (!technique_) return false;
 
-    float cx = 0, cy = 1.2, cz = -1, size = 0.25;
+    float size = 0.25;
     // clang-format off
     vertices_ = {
-      {cx - size, cy - size, cz + size}, {cx + size, cy - size, cz + size},
-      {cx + size, cy - size, cz + size}, {cx + size, cy - size, cz - size},
-      {cx + size, cy - size, cz - size}, {cx - size, cy - size, cz - size},
-      {cx - size, cy - size, cz - size}, {cx - size, cy - size, cz + size},
-      {cx - size, cy + size, cz + size}, {cx + size, cy + size, cz + size},
-      {cx + size, cy + size, cz + size}, {cx + size, cy + size, cz - size},
-      {cx + size, cy + size, cz - size}, {cx - size, cy + size, cz - size},
-      {cx - size, cy + size, cz - size}, {cx - size, cy + size, cz + size},
-      {cx - size, cy - size, cz + size}, {cx - size, cy + size, cz + size},
-      {cx + size, cy - size, cz + size}, {cx + size, cy + size, cz + size},
-      {cx + size, cy - size, cz - size}, {cx + size, cy + size, cz - size},
-      {cx - size, cy - size, cz - size}, {cx - size, cy + size, cz - size},
+      {-size, -size, +size}, {+size, -size, +size},
+      {+size, -size, +size}, {+size, -size, -size},
+      {+size, -size, -size}, {-size, -size, -size},
+      {-size, -size, -size}, {-size, -size, +size},
+      {-size, +size, +size}, {+size, +size, +size},
+      {+size, +size, +size}, {+size, +size, -size},
+      {+size, +size, -size}, {-size, +size, -size},
+      {-size, +size, -size}, {-size, +size, +size},
+      {-size, -size, +size}, {-size, +size, +size},
+      {+size, -size, +size}, {+size, +size, +size},
+      {+size, -size, -size}, {+size, +size, -size},
+      {-size, -size, -size}, {-size, +size, -size},
     };
     // clang-format on
 
@@ -134,6 +146,8 @@ class Box final : public VirtualObject
   std::unique_ptr<GlShader> vertex_shader_;
   std::unique_ptr<GlShader> fragment_shader_;
   std::unique_ptr<GlProgram> program_;
+
+  float animation_seed_;  // 0 to 1
 };
 
 int

--- a/clients/default.vert
+++ b/clients/default.vert
@@ -1,10 +1,11 @@
 #version 320 es
 
 uniform mat4 mvp;
+uniform vec4 translate;
 layout(location = 0) in vec4 position;
 
 void
 main()
 {
-  gl_Position = mvp * position;
+  gl_Position = mvp * (translate + position);
 }

--- a/clients/gl-base-technique.cc
+++ b/clients/gl-base-technique.cc
@@ -1,5 +1,7 @@
 #include "gl-base-technique.h"
 
+#include <cstring>
+
 #include "application.h"
 #include "gl-program.h"
 #include "gl-vertex-array.h"
@@ -36,6 +38,26 @@ void
 GlBaseTechnique::DrawArrays(GLenum mode, GLint first, GLsizei count)
 {
   zgn_gl_base_technique_draw_arrays(proxy_, mode, first, count);
+}
+
+void
+GlBaseTechnique::UniformVector(uint32_t location, std::string name,
+    enum zgn_gl_base_technique_uniform_variable_type type, uint32_t size,
+    uint32_t count, void *value)
+{
+  wl_array array;
+  wl_array_init(&array);
+
+  {
+    size_t value_size = 4 * size * count;
+    void *data = wl_array_add(&array, value_size);
+    std::memcpy(data, value, value_size);
+  }
+
+  zgn_gl_base_technique_uniform_vector(
+      proxy_, location, name.c_str(), type, size, count, &array);
+
+  wl_array_release(&array);
 }
 
 GlBaseTechnique::GlBaseTechnique(Application *app) : app_(app) {}

--- a/clients/gl-base-technique.h
+++ b/clients/gl-base-technique.h
@@ -4,7 +4,14 @@
 #include <zen-common.h>
 #include <zigen-gles-v32-client-protocol.h>
 
+#include <glm/detail/type_vec1.hpp>
+#include <glm/detail/type_vec2.hpp>
+#include <glm/detail/type_vec3.hpp>
+#include <glm/detail/type_vec4.hpp>
 #include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 namespace zen::client {
 
@@ -22,6 +29,30 @@ class GlBaseTechnique
 
   bool Init(RenderingUnit *unit);
 
+  template <glm::length_t length, typename T>
+  void Uniform(uint32_t location, std::string name, glm::vec<length, T> value)
+  {
+    static_assert(std::is_same<T, float>::value ||
+                      std::is_same<T, int32_t>::value ||
+                      std::is_same<T, uint32_t>::value,
+        "Vector type must be one of [float, int32_t, uint32_t]");
+    static_assert(
+        0 < length && length <= 4, "Vector length must be between 1 to 4");
+
+    zgn_gl_base_technique_uniform_variable_type type;
+    if (std::is_same<T, float>::value) {
+      type = ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_FLOAT;
+    } else if (std::is_same<T, int32_t>::value) {
+      type = ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_INT;
+    } else if (std::is_same<T, uint32_t>::value) {
+      type = ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_UINT;
+    } else {
+      assert(false && "unknown vector type");
+    }
+
+    UniformVector(location, std::move(name), type, length, 1, &value);
+  }
+
   void DrawArrays(GLenum mode, GLint first, GLsizei count);
 
   void Bind(GlProgram *program);
@@ -29,6 +60,10 @@ class GlBaseTechnique
   void Bind(GlVertexArray *vertex_array);
 
  private:
+  void UniformVector(uint32_t location, std::string name,
+      enum zgn_gl_base_technique_uniform_variable_type type, uint32_t size,
+      uint32_t count, void *value);
+
   Application *app_;
   zgn_gl_base_technique *proxy_ = nullptr;  // nonnull after initialization
 };

--- a/clients/meson.build
+++ b/clients/meson.build
@@ -38,6 +38,7 @@ _zen_box_client_srcs = [
 _zen_box_client_deps = [
   wayland_client_dep,
   zen_common_dep,
+  glm_dep,
 ]
 
 executable(

--- a/include/zen/renderer/gl-base-technique.h
+++ b/include/zen/renderer/gl-base-technique.h
@@ -20,6 +20,7 @@ void znr_gl_base_technique_bind_program(
     struct znr_gl_base_technique* self, struct znr_gl_program* program);
 
 /**
+ * @param name is nullable
  * @param value must be larger than or equeal to (32 * size * count) bits
  */
 void znr_gl_base_technique_gl_uniform_vector(struct znr_gl_base_technique* self,
@@ -28,6 +29,7 @@ void znr_gl_base_technique_gl_uniform_vector(struct znr_gl_base_technique* self,
     uint32_t count, void* value);
 
 /**
+ * @param name is nullable
  * @param value must be larger than or equeal to (32 * col * row * count) bits
  */
 void znr_gl_base_technique_gl_uniform_matrix(struct znr_gl_base_technique* self,

--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,10 @@ if get_option('cui-client') or get_option('clients')
   wayland_client_dep = dependency('wayland-client', version: wayland_req)
 endif
 
+if get_option('clients')
+  glm_dep = dependency('glm')
+endif
+
 if get_option('default-wallpaper')
   wallpaper_files = files(
     'assets/Zen_Wallpaper_Dark_3840x2160.png',

--- a/zgnroot/include/zgnr/gl-base-technique.h
+++ b/zgnroot/include/zgnr/gl-base-technique.h
@@ -41,6 +41,9 @@ struct zgnr_gl_base_technique {
     enum zgnr_gl_base_technique_draw_method draw_method;
     union zgnr_gl_base_technique_draw_args args;
     bool draw_method_changed;
+
+    // apply from the front
+    struct wl_list uniform_variable_list;
   } current;
 
   void *user_data;

--- a/zgnroot/include/zgnr/gl-uniform-variable.h
+++ b/zgnroot/include/zgnr/gl-uniform-variable.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <wayland-server-core.h>
+#include <zigen-gles-v32-protocol.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct zgnr_gl_uniform_variable {
+  uint32_t location;
+  char *name;  // nullable
+  enum zgn_gl_base_technique_uniform_variable_type type;
+  uint32_t col;
+  uint32_t row;
+  uint32_t count;
+  bool transpose;
+  bool newly_comitted;
+  void *value;
+
+  // zgnr_gl_base_technique::current.uniform_variable_list or
+  // zgnr_gl_base_technique_impl::pending.uniform_variable_list (internal use)
+  struct wl_list link;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/zgnroot/meson.build
+++ b/zgnroot/meson.build
@@ -8,6 +8,7 @@ _zgnr_srcs = [
   'src/gl-buffer.c',
   'src/gl-program.c',
   'src/gl-shader.c',
+  'src/gl-uniform-variable.c',
   'src/gl-vertex-array.c',
   'src/gl-vertex-attrib.c',
   'src/mem-storage.c',

--- a/zgnroot/src/gl-base-technique.h
+++ b/zgnroot/src/gl-base-technique.h
@@ -25,6 +25,9 @@ struct zgnr_gl_base_technique_impl {
     enum zgnr_gl_base_technique_draw_method draw_method;
     union zgnr_gl_base_technique_draw_args args;
     bool draw_method_changed;
+
+    // insert from the back, commit from the front
+    struct wl_list uniform_variable_list;
   } pending;
 
   struct wl_listener rendering_unit_destroy_listener;

--- a/zgnroot/src/gl-uniform-variable.c
+++ b/zgnroot/src/gl-uniform-variable.c
@@ -1,0 +1,59 @@
+#include "gl-uniform-variable.h"
+
+#include <zen-common.h>
+
+/**
+ * @returns 0 if two arguments represent the same uniform variable, -1 otherwise
+ */
+int
+zgnr_gl_uniform_variable_compare(struct zgnr_gl_uniform_variable *self,
+    struct zgnr_gl_uniform_variable *other)
+{
+  if (self->name && other->name)
+    return strcmp(self->name, other->name) == 0 ? 0 : -1;
+
+  if (self->name || other->name) return -1;
+
+  return self->location == other->location ? 0 : -1;
+}
+
+struct zgnr_gl_uniform_variable *
+zgnr_gl_uniform_variable_create(uint32_t location, const char *name,
+    enum zgn_gl_base_technique_uniform_variable_type type, uint32_t col,
+    uint32_t row, uint32_t count, bool transpose, void *src)
+{
+  struct zgnr_gl_uniform_variable *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    goto err;
+  }
+
+  self->location = location;
+  self->name = name ? strdup(name) : NULL;
+  self->type = type;
+  self->col = col;
+  self->row = row;
+  self->count = count;
+  self->transpose = transpose;
+  self->newly_comitted = false;
+  wl_list_init(&self->link);
+
+  size_t size = 4 * col * row * count;
+  self->value = malloc(size);
+  memcpy(self->value, src, size);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zgnr_gl_uniform_variable_destroy(struct zgnr_gl_uniform_variable *self)
+{
+  wl_list_remove(&self->link);
+  free(self->value);
+  free(self->name);
+  free(self);
+}

--- a/zgnroot/src/gl-uniform-variable.h
+++ b/zgnroot/src/gl-uniform-variable.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "zgnr/gl-uniform-variable.h"
+
+int zgnr_gl_uniform_variable_compare(struct zgnr_gl_uniform_variable *self,
+    struct zgnr_gl_uniform_variable *other);
+
+/**
+ * @param name nullable
+ * @param src must be larger than 32 * col * row bit
+ */
+struct zgnr_gl_uniform_variable *zgnr_gl_uniform_variable_create(
+    uint32_t location, const char *name,
+    enum zgn_gl_base_technique_uniform_variable_type type, uint32_t col,
+    uint32_t row, uint32_t count, bool transpose, void *src);
+
+void zgnr_gl_uniform_variable_destroy(struct zgnr_gl_uniform_variable *self);

--- a/zna/scene/virtual-object/gl-base-technique.c
+++ b/zna/scene/virtual-object/gl-base-technique.c
@@ -1,6 +1,7 @@
 #include "gl-base-technique.h"
 
 #include <zen-common.h>
+#include <zgnr/gl-uniform-variable.h>
 
 #include "scene/virtual-object/gl-program.h"
 #include "scene/virtual-object/gl-vertex-array.h"
@@ -47,8 +48,10 @@ zna_gl_base_technique_apply_commit(
     struct zna_gl_base_technique* self, bool only_damaged)
 {
   struct znr_session* session = self->system->current_session;
+  struct zgnr_gl_uniform_variable* uniform_variable;
   struct zna_rendering_unit* unit =
       zna_gl_base_technique_get_rendering_unit(self);
+
   if (self->znr_gl_base_technique == NULL) {
     self->znr_gl_base_technique =
         znr_gl_base_technique_create(session, unit->znr_rendering_unit);
@@ -77,6 +80,24 @@ zna_gl_base_technique_apply_commit(
         !only_damaged) {
       znr_gl_base_technique_bind_program(
           self->znr_gl_base_technique, program->znr_gl_program);
+    }
+  }
+
+  wl_list_for_each (uniform_variable,
+      &self->zgnr_gl_base_technique->current.uniform_variable_list, link) {
+    if (uniform_variable->newly_comitted || !only_damaged) {
+      if (uniform_variable->col == 1) {
+        znr_gl_base_technique_gl_uniform_vector(self->znr_gl_base_technique,
+            uniform_variable->location, uniform_variable->name,
+            uniform_variable->type, uniform_variable->row,
+            uniform_variable->count, uniform_variable->value);
+      } else {
+        znr_gl_base_technique_gl_uniform_matrix(self->znr_gl_base_technique,
+            uniform_variable->location, uniform_variable->name,
+            uniform_variable->col, uniform_variable->row,
+            uniform_variable->count, uniform_variable->transpose,
+            uniform_variable->value);
+      }
     }
   }
 

--- a/znr-remote/src/gl-base-technique.cc
+++ b/znr-remote/src/gl-base-technique.cc
@@ -30,21 +30,21 @@ znr_gl_base_technique_gl_uniform_vector(struct znr_gl_base_technique* self,
     enum zgn_gl_base_technique_uniform_variable_type type, uint32_t size,
     uint32_t count, void* value)
 {
-  std::string name_string = name;
+  std::string name_string = name ? name : "";
   switch (type) {
     case ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_INT:
       self->proxy->GlUniformVector(
-          location, name_string, size, count, (int32_t*)value);
+          location, std::move(name_string), size, count, (int32_t*)value);
       break;
 
     case ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_UINT:
       self->proxy->GlUniformVector(
-          location, name_string, size, count, (uint32_t*)value);
+          location, std::move(name_string), size, count, (uint32_t*)value);
       break;
 
     case ZGN_GL_BASE_TECHNIQUE_UNIFORM_VARIABLE_TYPE_FLOAT:
       self->proxy->GlUniformVector(
-          location, name_string, size, count, (float*)value);
+          location, std::move(name_string), size, count, (float*)value);
       break;
 
     default:
@@ -58,8 +58,9 @@ znr_gl_base_technique_gl_uniform_matrix(struct znr_gl_base_technique* self,
     uint32_t location, const char* name, uint32_t col, uint32_t row,
     uint32_t count, bool transpose, float* value)
 {
+  std::string name_string = name ? name : "";
   self->proxy->GlUniformMatrix(
-      location, name, col, row, count, transpose, value);
+      location, std::move(name_string), col, row, count, transpose, value);
 }
 
 void

--- a/znr-remote/src/session.cc
+++ b/znr-remote/src/session.cc
@@ -2,7 +2,7 @@
 
 #include <zen-common.h>
 
-static constexpr float kRefreshRate = 30.0f;
+static constexpr float kRefreshRate = 60.0f;
 static constexpr uint32_t kRefreshIntervalNsec = NSEC_PER_SEC / kRefreshRate;
 
 static int


### PR DESCRIPTION
## Context

By enabling client to use uniform variable, together with frame request implemented in the previous pull request, clients can realize animation.

## Summary

- [x] enable clients to use uniform variable (vector)
- [x] add sample animation 

## How to check behavior

Start zen-box.