### PR TITLE
add zn_board and zn_screen

### DIFF
--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+struct zn_screen;
+
+struct zn_board {
+  struct wl_list link;  // zn_scene::board_list
+
+  struct zn_screen *screen;  // nullable
+
+  struct wl_listener screen_destroy_listener;
+
+  float color[3];  // FIXME: debugging purpose, remove me later
+};
+
+bool zn_board_is_dangling(struct zn_board *self);
+
+/**
+ * @param screen is nullable
+ */
+void zn_board_set_screen(struct zn_board *self, struct zn_screen *screen);
+
+struct zn_board *zn_board_create(void);
+
+void zn_board_destroy(struct zn_board *self);

--- a/include/zen/scene.h
+++ b/include/zen/scene.h
@@ -2,9 +2,14 @@
 
 #include <wayland-server-core.h>
 
+struct zn_screen;
+
 struct zn_scene {
-  struct wl_list board_list;
+  struct wl_list screen_list;  // zn_screen::link;
+  struct wl_list board_list;   // zn_board::link
 };
+
+void zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen);
 
 struct zn_scene *zn_scene_create(void);
 

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <wlr/util/box.h>
+
+struct zn_screen;
+struct zn_board;
+
+struct zn_screen_interface {
+  /**
+   * @param box : effective coordinate system
+   */
+  void (*damage)(void *user_data, struct wlr_fbox *box);
+};
+
+struct zn_screen {
+  void *user_data;
+  const struct zn_screen_interface *implementation;
+
+  struct wl_list link;  // zn_scene::screen_list; used by zn_scene
+
+  // nonnull when screen display system and mapped to zn_scene
+  // controlled by zn_scene, if not null, this->board->screen == this
+  struct zn_board *board;
+
+  struct {
+    struct wl_signal destroy;  // (NULL)
+  } events;
+};
+
+/**
+ * @param box : effective coordinate system
+ */
+void zn_screen_damage(struct zn_screen *self, struct wlr_fbox *box);
+
+struct zn_screen *zn_screen_create(
+    const struct zn_screen_interface *implementation, void *user_data);
+
+void zn_screen_destroy(struct zn_screen *self);

--- a/include/zen/screen/output.h
+++ b/include/zen/screen/output.h
@@ -4,11 +4,15 @@
 #include <wlr/types/wlr_output.h>
 #include <wlr/types/wlr_output_damage.h>
 
+#include "zen/screen.h"
+
 struct zn_output {
   struct wlr_output *wlr_output;  // nonnull, reference
 
   /** nonnull, automatically destroyed when wlr_output is destroyed */
   struct wlr_output_damage *damage;
+
+  struct zn_screen *screen;  // nonnull, owning
 
   struct wl_listener wlr_output_destroy_listener;
   struct wl_listener damage_frame_listener;

--- a/zen/board.c
+++ b/zen/board.c
@@ -1,0 +1,74 @@
+#include "zen/board.h"
+
+#include <time.h>
+#include <zen-common.h>
+
+#include "zen/screen.h"
+
+bool
+zn_board_is_dangling(struct zn_board *self)
+{
+  return self->screen == NULL;
+}
+
+static void
+zn_board_handle_screen_destroy(struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zn_board *self =
+      zn_container_of(listener, self, screen_destroy_listener);
+
+  zn_board_set_screen(self, NULL);
+}
+
+void
+zn_board_set_screen(struct zn_board *self, struct zn_screen *screen)
+{
+  if (self->screen) {
+    wl_list_remove(&self->screen_destroy_listener.link);
+    wl_list_init(&self->screen_destroy_listener.link);
+  }
+
+  if (screen) {
+    wl_signal_add(&screen->events.destroy, &self->screen_destroy_listener);
+  }
+
+  self->screen = screen;
+}
+
+struct zn_board *
+zn_board_create(void)
+{
+  struct zn_board *self;
+  struct timespec time;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  wl_list_init(&self->link);
+  self->screen = NULL;
+
+  self->screen_destroy_listener.notify = zn_board_handle_screen_destroy;
+  wl_list_init(&self->screen_destroy_listener.link);
+
+  clock_gettime(CLOCK_MONOTONIC, &time);
+  self->color[0] = (float)(time.tv_nsec % 255) / 255.f;
+  self->color[1] = (float)(time.tv_nsec % 254) / 254.f;
+  self->color[2] = (float)(time.tv_nsec % 253) / 253.f;
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_board_destroy(struct zn_board *self)
+{
+  wl_list_remove(&self->screen_destroy_listener.link);
+  wl_list_remove(&self->link);
+  free(self);
+}

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -1,5 +1,7 @@
 _zen_srcs = [
+  'board.c',
   'scene.c',
+  'screen.c',
   'server.c',
 
   'screen/output.c',

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -1,0 +1,44 @@
+#include "zen/screen.h"
+
+#include <zen-common.h>
+
+void
+zn_screen_damage(struct zn_screen *self, struct wlr_fbox *box)
+{
+  self->implementation->damage(self->user_data, box);
+}
+
+struct zn_screen *
+zn_screen_create(
+    const struct zn_screen_interface *implementation, void *user_data)
+{
+  struct zn_screen *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->user_data = user_data;
+  self->implementation = implementation;
+  wl_list_init(&self->link);
+  self->board = NULL;
+
+  wl_signal_init(&self->events.destroy);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_screen_destroy(struct zn_screen *self)
+{
+  wl_signal_emit(&self->events.destroy, NULL);
+
+  wl_list_remove(&self->events.destroy.listener_list);
+  wl_list_remove(&self->link);
+  free(self);
+}

--- a/zen/screen/output.c
+++ b/zen/screen/output.c
@@ -1,10 +1,44 @@
 #include "zen/screen/output.h"
 
+#include <math.h>
 #include <pixman.h>
 #include <wlr/render/wlr_renderer.h>
 #include <zen-common.h>
 
+#include "zen/board.h"
+
 static void zn_output_destroy(struct zn_output *self);
+
+static inline int
+scale_length(float length, float offset, float scale)
+{
+  return round((offset + length) * scale) - round(offset * scale);
+}
+
+static void
+zn_output_box_effective_to_transformed_coords(struct zn_output *self,
+    struct wlr_fbox *effective, struct wlr_box *transformed)
+{
+  float scale = self->wlr_output->scale;
+  transformed->x = round(effective->x * scale);
+  transformed->y = round(effective->y * scale);
+  transformed->width = scale_length(effective->width, effective->x, scale);
+  transformed->height = scale_length(effective->height, effective->y, scale);
+}
+
+static void
+zn_output_handle_screen_damage(void *user_data, struct wlr_fbox *box)
+{
+  struct wlr_box transformed;
+  struct zn_output *self = user_data;
+
+  zn_output_box_effective_to_transformed_coords(self, box, &transformed);
+  wlr_output_damage_add_box(self->damage, &transformed);
+}
+
+const struct zn_screen_interface screen_implementation = {
+    .damage = zn_output_handle_screen_damage,
+};
 
 static void
 zn_output_handle_wlr_output_destroy(struct wl_listener *listener, void *data)
@@ -35,7 +69,15 @@ zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
   if (needs_frame) {
     wlr_renderer_begin(
         renderer, self->wlr_output->width, self->wlr_output->height);
-    wlr_renderer_clear(renderer, (float[]){1.0f, 1.0f, 0.0f, 1.0f});
+
+    float color[4] = {1.0f, 1.0f, 0.0f, 1.0f};
+    if (self->screen->board) {
+      color[0] = self->screen->board->color[0];
+      color[1] = self->screen->board->color[1];
+      color[2] = self->screen->board->color[2];
+    }
+
+    wlr_renderer_clear(renderer, color);
     wlr_renderer_end(renderer);
     wlr_output_commit(self->wlr_output);
   } else {
@@ -68,6 +110,12 @@ zn_output_create(struct wlr_output *wlr_output)
     goto err_free;
   }
 
+  self->screen = zn_screen_create(&screen_implementation, self);
+  if (self->screen == NULL) {
+    zn_error("Failed to create z zn_screen");
+    goto err_damage;
+  }
+
   self->wlr_output_destroy_listener.notify =
       zn_output_handle_wlr_output_destroy;
   wl_signal_add(
@@ -78,23 +126,26 @@ zn_output_create(struct wlr_output *wlr_output)
 
   if (wl_list_empty(&self->wlr_output->modes)) {
     zn_error("Failed to get output mode");
-    goto err_damage;
+    goto err_screen;
   }
 
   mode = wlr_output_preferred_mode(self->wlr_output);
   if (mode == NULL) {
     zn_error("Failed to get preferred output mode");
-    goto err_damage;
+    goto err_screen;
   }
 
   wlr_output_set_mode(self->wlr_output, mode);
   wlr_output_enable(self->wlr_output, true);
   if (wlr_output_commit(self->wlr_output) == false) {
     zn_error("Failed to set output mode");
-    goto err_damage;
+    goto err_screen;
   }
 
   return self;
+
+err_screen:
+  zn_screen_destroy(self->screen);
 
 err_damage:
   wlr_output_damage_destroy(self->damage);
@@ -111,6 +162,7 @@ zn_output_destroy(struct zn_output *self)
 {
   wl_list_remove(&self->damage_frame_listener.link);
   wl_list_remove(&self->wlr_output_destroy_listener.link);
+  zn_screen_destroy(self->screen);
   wlr_output_destroy_global(self->wlr_output);
   free(self);
 }

--- a/zen/server.c
+++ b/zen/server.c
@@ -45,6 +45,8 @@ zn_server_handle_new_output(struct wl_listener *listener, void *data)
     zn_error("Failed to create a zn_output");
     return;
   }
+
+  zn_scene_new_screen(self->scene, output->screen);
 }
 
 struct zn_server *


### PR DESCRIPTION
## Context

Add board and screen

## Summary

Add zn_board and zn_screen

## How to check behavior

Every time zn_board is created, random color is assigned to each board, and a board is assigned to a output.
You can see random color on your screen.