### PR TITLE
introduce screen layout

### DIFF
--- a/include/zen/scene.h
+++ b/include/zen/scene.h
@@ -4,14 +4,15 @@
 #include <wlr/render/wlr_texture.h>
 
 struct zn_screen;
+struct zn_screen_layout;
 struct zn_ray;
 struct zn_cursor;
 struct zn_view;
 
 struct zn_scene {
-  struct wl_list screen_list;  // zn_screen::link
-  struct wl_list board_list;   // zn_board::link
-  struct wl_list view_list;    // zn_view::link
+  struct zn_screen_layout *screen_layout;
+  struct wl_list board_list;  // zn_board::link
+  struct wl_list view_list;   // zn_view::link
 
   struct zn_cursor *cursor;  // nonnull
   struct zn_ray *ray;        // nonnull

--- a/include/zen/screen-layout.h
+++ b/include/zen/screen-layout.h
@@ -14,6 +14,12 @@ struct zn_screen_layout {
   } events;
 };
 
+// Returns the screen at the given x, y of the coordinates of screen layout.
+// And sets the screen-local coordinates to dst_{x,y}
+struct zn_screen *zn_screen_layout_get_closest_screen(
+    struct zn_screen_layout *self, double x, double y, double *dest_x,
+    double *dest_y);
+
 void zn_screen_layout_add(
     struct zn_screen_layout *self, struct zn_screen *new_screen);
 

--- a/include/zen/screen-layout.h
+++ b/include/zen/screen-layout.h
@@ -7,7 +7,7 @@ struct zn_screen;
 
 struct zn_screen_layout {
   struct zn_scene *scene;
-  struct wl_list screens;  // zn_screen::link
+  struct wl_list screen_list;  // zn_screen::link
 
   struct {
     struct wl_signal new_screen;  // (struct zn_screen*)
@@ -26,7 +26,7 @@ void zn_screen_layout_add(
 void zn_screen_layout_remove(
     struct zn_screen_layout *self, struct zn_screen *screen);
 
-int zn_screen_layout_len(struct zn_screen_layout *self);
+int zn_screen_layout_screen_count(struct zn_screen_layout *self);
 
 struct zn_screen_layout *zn_screen_layout_create(struct zn_scene *scene);
 

--- a/include/zen/screen-layout.h
+++ b/include/zen/screen-layout.h
@@ -6,12 +6,7 @@ struct zn_scene;
 struct zn_screen;
 
 struct zn_screen_layout {
-  struct zn_scene *scene;
   struct wl_list screen_list;  // zn_screen::link
-
-  struct {
-    struct wl_signal new_screen;  // (struct zn_screen*)
-  } events;
 };
 
 // Returns the screen at the given x, y of the coordinates of screen layout.
@@ -28,6 +23,6 @@ void zn_screen_layout_remove(
 
 int zn_screen_layout_screen_count(struct zn_screen_layout *self);
 
-struct zn_screen_layout *zn_screen_layout_create(struct zn_scene *scene);
+struct zn_screen_layout *zn_screen_layout_create(void);
 
 void zn_screen_layout_destroy(struct zn_screen_layout *self);

--- a/include/zen/screen-layout.h
+++ b/include/zen/screen-layout.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <wlr/util/box.h>
+
+struct zn_scene;
+struct zn_screen;
+
+struct zn_screen_layout {
+  struct zn_scene *scene;
+  struct wl_list screens;  // zn_screen::link
+
+  struct {
+    struct wl_signal new_screen;  // (struct zn_screen*)
+  } events;
+};
+
+void zn_screen_layout_add(
+    struct zn_screen_layout *self, struct zn_screen *new_screen);
+
+void zn_screen_layout_remove(
+    struct zn_screen_layout *self, struct zn_screen *screen);
+
+int zn_screen_layout_len(struct zn_screen_layout *self);
+
+struct zn_screen_layout *zn_screen_layout_create(struct zn_scene *scene);
+
+void zn_screen_layout_destroy(struct zn_screen_layout *self);

--- a/include/zen/screen-layout.h
+++ b/include/zen/screen-layout.h
@@ -10,7 +10,7 @@ struct zn_screen_layout {
 };
 
 // Returns the screen at the given x, y of the coordinates of screen layout.
-// And sets the screen-local coordinates to dst_{x,y}
+// And sets the screen-local coordinates to dest_{x,y}
 struct zn_screen *zn_screen_layout_get_closest_screen(
     struct zn_screen_layout *self, double x, double y, double *dest_x,
     double *dest_y);

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -38,6 +38,9 @@ void zn_screen_damage(struct zn_screen *self, struct wlr_fbox *box);
 
 void zn_screen_damage_whole(struct zn_screen *self);
 
+void zn_screen_get_screen_layout_coords(
+    struct zn_screen *self, double x, double y, double *dest_x, double *dest_y);
+
 void zn_screen_get_effective_size(
     struct zn_screen *self, double *width, double *height);
 

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -18,7 +18,9 @@ struct zn_screen {
   void *user_data;
   const struct zn_screen_interface *implementation;
 
-  struct wl_list link;  // zn_scene::screen_list; used by zn_scene
+  double x, y;
+
+  struct wl_list link;  // zn_screen_layout::screens
 
   // nonnull when screen display system and mapped to zn_scene
   // controlled by zn_scene, if not null, this->board->screen == this

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -38,6 +38,13 @@ void zn_screen_damage(struct zn_screen *self, struct wlr_fbox *box);
 
 void zn_screen_damage_whole(struct zn_screen *self);
 
+/**
+ * Convert screen local effective coordinates to layout coordinates
+ * @param x screen local effective coordinates
+ * @param y screen local effective coordinates
+ * @param dest_x layout coordinates
+ * @param dest_y layout coordinates
+ */
 void zn_screen_get_screen_layout_coords(
     struct zn_screen *self, double x, double y, double *dest_x, double *dest_y);
 

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -20,7 +20,7 @@ struct zn_screen {
 
   double x, y;
 
-  struct wl_list link;  // zn_screen_layout::screens
+  struct wl_list link;  // zn_screen_layout::screen_list
 
   // nonnull when screen display system and mapped to zn_scene
   // controlled by zn_scene, if not null, this->board->screen == this

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -18,7 +18,7 @@ struct zn_screen {
   void *user_data;
   const struct zn_screen_interface *implementation;
 
-  double x, y;
+  double x, y;  // layout coordinate, controlled by zn_screen_layout
 
   struct wl_list link;  // zn_screen_layout::screen_list
 

--- a/include/zen/wlr/box.h
+++ b/include/zen/wlr/box.h
@@ -2,5 +2,5 @@
 
 #include <wlr/util/box.h>
 
-void zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,
-    double* dest_x, double* dest_y);
+void zn_wlr_fbox_closest_point(const struct wlr_fbox *box, double x, double y,
+    double *dest_x, double *dest_y);

--- a/include/zen/wlr/box.h
+++ b/include/zen/wlr/box.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <wlr/util/box.h>
+
+void zn_wlr_fbox_closest_point(const struct wlr_fbox* box, double x, double y,
+    double* dest_x, double* dest_y);

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -4,6 +4,7 @@ _zen_srcs = [
   'ray.c',
   'scene.c',
   'screen.c',
+  'screen-layout.c',
   'server.c',
   'view.c',
   'virtual-object.c',

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -26,6 +26,8 @@ _zen_srcs = [
   'input/keyboard.c',
   'input/pointer.c',
   'input/seat.c',
+
+  'wlr/box.c',
 ]
 
 _zen_srcs_pub = [

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -5,6 +5,7 @@
 #include "zen/board.h"
 #include "zen/cursor.h"
 #include "zen/ray.h"
+#include "zen/screen-layout.h"
 #include "zen/screen.h"
 #include "zen/server.h"
 #include "zen/view.h"
@@ -30,7 +31,7 @@ zn_scene_ensure_dangling_board(struct zn_scene *self)
 void
 zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen)
 {
-  wl_list_insert(&self->screen_list, &screen->link);
+  zn_screen_layout_add(self->screen_layout, screen);
   struct zn_server *server = zn_server_get_singleton();
 
   struct zn_board *board = zn_scene_ensure_dangling_board(self);
@@ -39,7 +40,7 @@ zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen)
   screen->board = board;
 
   if (server->display_system == ZN_DISPLAY_SYSTEM_SCREEN &&
-      wl_list_length(&self->screen_list) == 1) {
+      zn_screen_layout_len(self->screen_layout) == 1) {
     double width, height;
     zn_board_get_effective_size(board, &width, &height);
     zn_cursor_move(server->scene->cursor, board, width / 2.f, height / 2.f);
@@ -96,10 +97,16 @@ zn_scene_create(void)
     goto err;
   }
 
+  self->screen_layout = zn_screen_layout_create(self);
+  if (self->screen_layout == NULL) {
+    zn_error("Failed to create a screen_layout");
+    goto err_free;
+  }
+
   self->ray = zn_ray_create();
   if (self->ray == NULL) {
     zn_error("Failed to create a ray");
-    goto err_free;
+    goto err_screen_layout;
   }
 
   self->cursor = zn_cursor_create();
@@ -111,7 +118,6 @@ zn_scene_create(void)
   struct zn_server *server = zn_server_get_singleton();
   zn_scene_setup_wallpaper(self, server->config->wallpaper_filepath);
 
-  wl_list_init(&self->screen_list);
   wl_list_init(&self->board_list);
   wl_list_init(&self->view_list);
   wl_signal_init(&self->events.new_board);
@@ -120,6 +126,9 @@ zn_scene_create(void)
 
 err_ray:
   zn_ray_destroy(self->ray);
+
+err_screen_layout:
+  zn_screen_layout_destroy(self->screen_layout);
 
 err_free:
   free(self);
@@ -143,9 +152,9 @@ void
 zn_scene_destroy(struct zn_scene *self)
 {
   wl_list_remove(&self->events.new_board.listener_list);
-  wl_list_remove(&self->screen_list);
   wl_list_remove(&self->view_list);
   if (self->wallpaper != NULL) wlr_texture_destroy(self->wallpaper);
+  zn_screen_layout_destroy(self->screen_layout);
   zn_cursor_destroy(self->cursor);
   zn_ray_destroy(self->ray);
   free(self);

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -40,7 +40,7 @@ zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen)
   screen->board = board;
 
   if (server->display_system == ZN_DISPLAY_SYSTEM_SCREEN &&
-      zn_screen_layout_len(self->screen_layout) == 1) {
+      zn_screen_layout_screen_count(self->screen_layout) == 1) {
     double width, height;
     zn_board_get_effective_size(board, &width, &height);
     zn_cursor_move(server->scene->cursor, board, width / 2.f, height / 2.f);

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -97,7 +97,7 @@ zn_scene_create(void)
     goto err;
   }
 
-  self->screen_layout = zn_screen_layout_create(self);
+  self->screen_layout = zn_screen_layout_create();
   if (self->screen_layout == NULL) {
     zn_error("Failed to create a screen_layout");
     goto err_free;

--- a/zen/screen-layout.c
+++ b/zen/screen-layout.c
@@ -62,6 +62,7 @@ void
 zn_screen_layout_remove(struct zn_screen_layout *self, struct zn_screen *screen)
 {
   wl_list_remove(&screen->link);
+  wl_list_init(&screen->link);
   zn_screen_layout_rearrange(self);
 }
 

--- a/zen/screen-layout.c
+++ b/zen/screen-layout.c
@@ -1,0 +1,70 @@
+#include "zen/screen-layout.h"
+
+#include <zen-common.h>
+
+#include "zen/screen.h"
+
+static void
+zn_screen_layout_rearrange(struct zn_screen_layout *self)
+{
+  int x = 0;
+  struct zn_screen *screen;
+  double width, height;
+
+  wl_list_for_each (screen, &self->screens, link) {
+    zn_screen_get_effective_size(screen, &width, &height);
+    screen->x = x;
+    screen->y = 0;
+    x += width;
+  }
+}
+
+void
+zn_screen_layout_add(
+    struct zn_screen_layout *self, struct zn_screen *new_screen)
+{
+  wl_list_insert(&self->screens, &new_screen->link);
+  zn_screen_layout_rearrange(self);
+  wl_signal_emit(&self->events.new_screen, new_screen);
+}
+
+void
+zn_screen_layout_remove(struct zn_screen_layout *self, struct zn_screen *screen)
+{
+  wl_list_remove(&screen->link);
+  zn_screen_layout_rearrange(self);
+}
+
+int
+zn_screen_layout_len(struct zn_screen_layout *self)
+{
+  return wl_list_length(&self->screens);
+}
+
+struct zn_screen_layout *
+zn_screen_layout_create(struct zn_scene *scene)
+{
+  struct zn_screen_layout *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->scene = scene;
+  wl_list_init(&self->screens);
+
+  wl_signal_init(&self->events.new_screen);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_screen_layout_destroy(struct zn_screen_layout *self)
+{
+  free(self);
+}

--- a/zen/screen-layout.c
+++ b/zen/screen-layout.c
@@ -13,7 +13,7 @@ zn_screen_layout_rearrange(struct zn_screen_layout *self)
   struct zn_screen *screen;
   double width, height;
 
-  wl_list_for_each (screen, &self->screens, link) {
+  wl_list_for_each (screen, &self->screen_list, link) {
     zn_screen_get_effective_size(screen, &width, &height);
     screen->x = x;
     screen->y = 0;
@@ -29,7 +29,7 @@ zn_screen_layout_get_closest_screen(struct zn_screen_layout *self, double x,
   struct zn_screen *closest_screen = NULL;
   struct zn_screen *screen;
 
-  wl_list_for_each (screen, &self->screens, link) {
+  wl_list_for_each (screen, &self->screen_list, link) {
     double current_closest_x, current_closest_y, current_closest_distance;
     struct wlr_fbox box = {.x = screen->x, .y = screen->y};
     zn_screen_get_effective_size(screen, &box.width, &box.height);
@@ -54,7 +54,7 @@ void
 zn_screen_layout_add(
     struct zn_screen_layout *self, struct zn_screen *new_screen)
 {
-  wl_list_insert(&self->screens, &new_screen->link);
+  wl_list_insert(&self->screen_list, &new_screen->link);
   zn_screen_layout_rearrange(self);
   wl_signal_emit(&self->events.new_screen, new_screen);
 }
@@ -67,9 +67,9 @@ zn_screen_layout_remove(struct zn_screen_layout *self, struct zn_screen *screen)
 }
 
 int
-zn_screen_layout_len(struct zn_screen_layout *self)
+zn_screen_layout_screen_count(struct zn_screen_layout *self)
 {
-  return wl_list_length(&self->screens);
+  return wl_list_length(&self->screen_list);
 }
 
 struct zn_screen_layout *
@@ -84,7 +84,7 @@ zn_screen_layout_create(struct zn_scene *scene)
   }
 
   self->scene = scene;
-  wl_list_init(&self->screens);
+  wl_list_init(&self->screen_list);
 
   wl_signal_init(&self->events.new_screen);
 

--- a/zen/screen-layout.c
+++ b/zen/screen-layout.c
@@ -56,7 +56,6 @@ zn_screen_layout_add(
 {
   wl_list_insert(&self->screen_list, &new_screen->link);
   zn_screen_layout_rearrange(self);
-  wl_signal_emit(&self->events.new_screen, new_screen);
 }
 
 void
@@ -73,7 +72,7 @@ zn_screen_layout_screen_count(struct zn_screen_layout *self)
 }
 
 struct zn_screen_layout *
-zn_screen_layout_create(struct zn_scene *scene)
+zn_screen_layout_create(void)
 {
   struct zn_screen_layout *self;
 
@@ -83,10 +82,7 @@ zn_screen_layout_create(struct zn_scene *scene)
     goto err;
   }
 
-  self->scene = scene;
   wl_list_init(&self->screen_list);
-
-  wl_signal_init(&self->events.new_screen);
 
   return self;
 
@@ -97,5 +93,6 @@ err:
 void
 zn_screen_layout_destroy(struct zn_screen_layout *self)
 {
+  wl_list_remove(&self->screen_list);
   free(self);
 }

--- a/zen/screen-layout.c
+++ b/zen/screen-layout.c
@@ -1,8 +1,10 @@
 #include "zen/screen-layout.h"
 
+#include <float.h>
 #include <zen-common.h>
 
 #include "zen/screen.h"
+#include "zen/wlr/box.h"
 
 static void
 zn_screen_layout_rearrange(struct zn_screen_layout *self)
@@ -17,6 +19,35 @@ zn_screen_layout_rearrange(struct zn_screen_layout *self)
     screen->y = 0;
     x += width;
   }
+}
+
+struct zn_screen *
+zn_screen_layout_get_closest_screen(struct zn_screen_layout *self, double x,
+    double y, double *dst_x, double *dst_y)
+{
+  double closest_x = 0, closest_y = 0, closest_distance = DBL_MAX;
+  struct zn_screen *closest_screen = NULL;
+  struct zn_screen *screen;
+
+  wl_list_for_each (screen, &self->screens, link) {
+    double current_closest_x, current_closest_y, current_closest_distance;
+    struct wlr_fbox box = {.x = screen->x, .y = screen->y};
+    zn_screen_get_effective_size(screen, &box.width, &box.height);
+    zn_wlr_fbox_closest_point(
+        &box, x, y, &current_closest_x, &current_closest_y);
+    current_closest_distance =
+        pow(x - current_closest_x, 2) + pow(y - current_closest_y, 2);
+    if (current_closest_distance < closest_distance) {
+      closest_x = current_closest_x;
+      closest_y = current_closest_y;
+      closest_distance = current_closest_distance;
+      closest_screen = screen;
+    }
+  }
+
+  *dst_x = closest_x - closest_screen->x;
+  *dst_y = closest_y - closest_screen->y;
+  return closest_screen;
 }
 
 void

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -23,6 +23,14 @@ zn_screen_damage_whole(struct zn_screen *self)
 }
 
 void
+zn_screen_get_screen_layout_coords(
+    struct zn_screen *self, double x, double y, double *dest_x, double *dest_y)
+{
+  *dest_x = self->x + x;
+  *dest_y = self->y + y;
+}
+
+void
 zn_screen_get_effective_size(
     struct zn_screen *self, double *width, double *height)
 {

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -67,9 +67,9 @@ void
 zn_screen_destroy(struct zn_screen *self)
 {
   struct zn_server *server = zn_server_get_singleton();
+  zn_screen_layout_remove(server->scene->screen_layout, self);
   wl_signal_emit(&self->events.destroy, NULL);
 
   wl_list_remove(&self->events.destroy.listener_list);
-  zn_screen_layout_remove(server->scene->screen_layout, self);
   free(self);
 }

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -2,6 +2,7 @@
 
 #include <zen-common.h>
 
+#include "zen/screen-layout.h"
 #include "zen/server.h"
 
 void
@@ -65,9 +66,10 @@ err:
 void
 zn_screen_destroy(struct zn_screen *self)
 {
+  struct zn_server *server = zn_server_get_singleton();
   wl_signal_emit(&self->events.destroy, NULL);
 
   wl_list_remove(&self->events.destroy.listener_list);
-  wl_list_remove(&self->link);
+  zn_screen_layout_remove(server->scene->screen_layout, self);
   free(self);
 }

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -3,14 +3,28 @@
 #include <zen-common.h>
 
 #include "zen/appearance/cursor.h"
+#include "zen/board.h"
+#include "zen/scene.h"
+#include "zen/screen-layout.h"
+#include "zen/screen.h"
+#include "zen/server.h"
 
 void
 zn_default_cursor_grab_motion_relative(
     struct zn_cursor_grab *grab, double dx, double dy, uint32_t time_msec)
 {
+  struct zn_server *server = zn_server_get_singleton();
   struct zn_cursor *cursor = grab->cursor;
 
-  zn_cursor_move(cursor, cursor->board, cursor->x + dx, cursor->y + dy);
+  double layout_x, layout_y;
+  zn_screen_get_screen_layout_coords(cursor->board->screen, cursor->x + dx,
+      cursor->y + dy, &layout_x, &layout_y);
+
+  double screen_x, screen_y;
+  struct zn_screen *scr = zn_screen_layout_get_closest_screen(
+      server->scene->screen_layout, layout_x, layout_y, &screen_x, &screen_y);
+
+  zn_cursor_move(cursor, scr->board, screen_x, screen_y);
 
   zna_cursor_commit(cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
 

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -21,10 +21,10 @@ zn_default_cursor_grab_motion_relative(
       cursor->y + dy, &layout_x, &layout_y);
 
   double screen_x, screen_y;
-  struct zn_screen *scr = zn_screen_layout_get_closest_screen(
+  struct zn_screen *screen = zn_screen_layout_get_closest_screen(
       server->scene->screen_layout, layout_x, layout_y, &screen_x, &screen_y);
 
-  zn_cursor_move(cursor, scr->board, screen_x, screen_y);
+  zn_cursor_move(cursor, screen->board, screen_x, screen_y);
 
   zna_cursor_commit(cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
 

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -16,6 +16,10 @@ zn_default_cursor_grab_motion_relative(
   struct zn_server *server = zn_server_get_singleton();
   struct zn_cursor *cursor = grab->cursor;
 
+  if (!cursor->board || !cursor->board->screen) {
+    return;
+  }
+
   double layout_x, layout_y;
   zn_screen_get_screen_layout_coords(cursor->board->screen, cursor->x + dx,
       cursor->y + dy, &layout_x, &layout_y);

--- a/zen/server.c
+++ b/zen/server.c
@@ -91,7 +91,7 @@ zn_server_change_display_system(
 
   self->display_system = ZN_DISPLAY_SYSTEM_SCREEN;  // enable screen damage
 
-  wl_list_for_each (screen, &self->scene->screen_layout->screens, link) {
+  wl_list_for_each (screen, &self->scene->screen_layout->screen_list, link) {
     zn_screen_damage_whole(screen);
   }
 

--- a/zen/server.c
+++ b/zen/server.c
@@ -8,6 +8,7 @@
 #include "zen/config/config-parser.h"
 #include "zen/config/config.h"
 #include "zen/ray.h"
+#include "zen/screen-layout.h"
 #include "zen/screen/output.h"
 #include "zen/virtual-object.h"
 
@@ -90,7 +91,7 @@ zn_server_change_display_system(
 
   self->display_system = ZN_DISPLAY_SYSTEM_SCREEN;  // enable screen damage
 
-  wl_list_for_each (screen, &self->scene->screen_list, link) {
+  wl_list_for_each (screen, &self->scene->screen_layout->screens, link) {
     zn_screen_damage_whole(screen);
   }
 

--- a/zen/wlr/box.c
+++ b/zen/wlr/box.c
@@ -1,0 +1,35 @@
+#include "zen/wlr/box.h"
+
+#include <zen-common.h>
+
+// from wlroots::wlr_box_closest_point
+void
+zn_wlr_fbox_closest_point(const struct wlr_fbox *box, double x, double y,
+    double *dest_x, double *dest_y)
+{
+  // if box is empty, then it contains no points, so no closest point either
+  if (box->width <= 0 || box->height <= 0) {
+    *dest_x = NAN;
+    *dest_y = NAN;
+    return;
+  }
+
+  // find the closest x point
+  if (x < box->x) {
+    *dest_x = box->x;
+  } else if (x >= box->x + box->width) {
+    *dest_x = box->x + box->width;
+  } else {
+    *dest_x = x;
+  }
+
+  // find closest y point
+  if (y < box->y) {
+    *dest_y = box->y;
+  } else if (y >= box->y + box->height) {
+    *dest_y = box->y + box->height;
+  } else {
+    *dest_y = y;
+  }
+  zn_debug(">> closest: %lf, %lf", *dest_x, *dest_y);
+}

--- a/zen/wlr/box.c
+++ b/zen/wlr/box.c
@@ -31,5 +31,4 @@ zn_wlr_fbox_closest_point(const struct wlr_fbox *box, double x, double y,
   } else {
     *dest_y = y;
   }
-  zn_debug(">> closest: %lf, %lf", *dest_x, *dest_y);
 }


### PR DESCRIPTION
## Context

See #249 

## Summary

Re-introduce #72 (`zn_screen_layout`). limit the cursor's pos, move between screens.

## How to check behavior

1. start zen with multiple output (monitor)
2. move the cursor to the edge where outputs are adjacent; the cursor is moved to another output
3. try to move the cursor to outside of the output; it's not able
