### PR TITLE
stop using glGenTexImage

### DIFF
--- a/zna/base-unit.c
+++ b/zna/base-unit.c
@@ -30,10 +30,37 @@ zna_base_unit_read_wlr_texture(
 
   struct wlr_egl *egl = wlr_glew_renderer_get_egl(server->renderer);
   wlr_egl_make_current(egl);
-  glBindTexture(texture_attrib.target, texture_attrib.tex);
-  glGetTexImage(
-      texture_attrib.target, 0, GL_RGBA, GL_UNSIGNED_BYTE, storage->data);
-  glBindTexture(texture_attrib.target, 0);
+
+  GLuint framebuffer;
+  glGenFramebuffers(1, &framebuffer);
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+
+  GLuint depth_texture;
+  {
+    glGenTextures(1, &depth_texture);
+    glBindTexture(GL_TEXTURE_2D, depth_texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, texture->width,
+        texture->height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+  }
+
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+      texture_attrib.tex, 0);
+  glFramebufferTexture2D(
+      GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth_texture, 0);
+
+  glReadPixels(0, 0, texture->width, texture->height, GL_RGBA, GL_UNSIGNED_BYTE,
+      storage->data);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glDeleteTextures(1, &depth_texture);
+  glDeleteFramebuffers(1, &framebuffer);
+
   wlr_egl_unset_current(egl);
 
   if (self->has_texture_data == false) {


### PR DESCRIPTION
## Context

Previously, we used glGenTexImage but its not available in GLES.

## Summary

Stop using glGetTexImage and use glReadPixel instead.
