### PR TITLE
send cursor event to the client

### DIFF
--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -39,6 +39,9 @@ void zn_board_send_frame_done(struct zn_board *self, struct timespec *when);
 
 void zn_board_move(struct zn_board *self, vec2 size, mat4 transform);
 
+struct wlr_surface *zn_board_get_surface_at(struct zn_board *self, double x,
+    double y, double *surface_x, double *surface_y);
+
 void zn_board_get_effective_size(
     struct zn_board *self, double *width, double *height);
 

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -6,6 +6,7 @@
 
 struct zn_screen;
 struct zna_board;
+struct zn_view;
 
 #define CURSOR_Z_OFFSET_ON_BOARD 0.0005
 #define VIEW_Z_OFFSET_ON_BOARD 0.0001
@@ -40,7 +41,7 @@ void zn_board_send_frame_done(struct zn_board *self, struct timespec *when);
 void zn_board_move(struct zn_board *self, vec2 size, mat4 transform);
 
 struct wlr_surface *zn_board_get_surface_at(struct zn_board *self, double x,
-    double y, double *surface_x, double *surface_y);
+    double y, double *surface_x, double *surface_y, struct zn_view **view);
 
 void zn_board_get_effective_size(
     struct zn_board *self, double *width, double *height);

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -16,7 +16,7 @@ struct zn_board {
 
   struct zn_screen *screen;  // nullable
 
-  struct wl_list view_list;  // zn_view::board_link
+  struct wl_list view_list;  // zn_view::board_link, sorted from back to front
 
   float color[3];  // FIXME: debugging purpose, remove me later
 

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -3,6 +3,7 @@
 #include <cglm/types.h>
 #include <wayland-server-core.h>
 #include <wlr/render/wlr_texture.h>
+#include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/box.h>
 
@@ -19,6 +20,12 @@ struct zn_cursor_grab_interface {
    */
   void (*motion_absolute)(struct zn_cursor_grab *grab, struct zn_board *board,
       double x, double y, uint32_t time_msec);
+  void (*button)(struct zn_cursor_grab *grab, uint32_t time_msec,
+      uint32_t button, enum wlr_button_state state);
+  void (*axis)(struct zn_cursor_grab *grab, uint32_t time_msec,
+      enum wlr_axis_source source, enum wlr_axis_orientation orientation,
+      double delta, int32_t delta_discrete);
+  void (*frame)(struct zn_cursor_grab *grab);
   void (*enter)(
       struct zn_cursor_grab *grab, struct zn_board *board, double x, double y);
   void (*leave)(struct zn_cursor_grab *grab);

--- a/include/zen/scene.h
+++ b/include/zen/scene.h
@@ -14,8 +14,11 @@ struct zn_scene {
   struct wl_list board_list;  // zn_board::link
   struct wl_list view_list;   // zn_view::link
 
-  struct zn_cursor *cursor;  // nonnull
-  struct zn_ray *ray;        // nonnull
+  struct zn_cursor *cursor;      // nonnull
+  struct zn_ray *ray;            // nonnull
+  struct zn_view *focused_view;  // nullable
+
+  struct wl_listener focused_view_destroy_listener;
 
   struct {
     struct wl_signal new_board;  // (struct zn_board*)
@@ -27,6 +30,8 @@ struct zn_scene {
 void zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen);
 
 void zn_scene_new_view(struct zn_scene *self, struct zn_view *view);
+
+void zn_scene_set_focused_view(struct zn_scene *self, struct zn_view *view);
 
 struct zn_scene *zn_scene_create(void);
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -5,11 +5,27 @@
 
 #include "zen/appearance/view.h"
 
+struct zn_view;
 struct zn_board;
+struct zn_xdg_toplevel;
+
+struct zn_view_impl {
+  struct wlr_surface *(*get_wlr_surface_at)(struct zn_view *view,
+      double view_sx, double view_sy, double *surface_x, double *surface_y);
+};
+
+enum zn_view_type {
+  ZN_VIEW_XDG_TOPLEVEL,
+};
 
 /** lifetime of given wlr_surface must be longer than zn_view */
 struct zn_view {
   struct wlr_surface *surface;  // nonnull
+
+  const struct zn_view_impl *impl;
+  union {
+    struct zn_xdg_toplevel *xdg_toplevel;
+  };
 
   struct wl_list link;        // zn_scene::view_list
   struct wl_list board_link;  // zn_board::view_list

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -9,7 +9,7 @@ struct zn_view;
 struct zn_board;
 struct zn_xdg_toplevel;
 
-struct zn_view_impl {
+struct zn_view_interface {
   struct wlr_surface *(*get_wlr_surface_at)(struct zn_view *view,
       double view_sx, double view_sy, double *surface_x, double *surface_y);
   void (*set_activated)(struct zn_view *view, bool activated);
@@ -17,12 +17,10 @@ struct zn_view_impl {
 
 /** lifetime of given wlr_surface must be longer than zn_view */
 struct zn_view {
+  void *user_data;
   struct wlr_surface *surface;  // nonnull
 
-  const struct zn_view_impl *impl;
-  union {
-    struct zn_xdg_toplevel *xdg_toplevel;
-  };
+  const struct zn_view_interface *impl;
 
   struct wl_list link;        // zn_scene::view_list
   struct wl_list board_link;  // zn_board::view_list
@@ -51,6 +49,7 @@ void zn_view_move(
     struct zn_view *view, struct zn_board *board, double x, double y);
 
 /** lifetime of given wlr_surface must be longer than zn_view */
-struct zn_view *zn_view_create(struct wlr_surface *surface);
+struct zn_view *zn_view_create(struct wlr_surface *surface,
+    const struct zn_view_interface *impl, void *user_data);
 
 void zn_view_destroy(struct zn_view *self);

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -15,10 +15,6 @@ struct zn_view_impl {
   void (*set_activated)(struct zn_view *view, bool activated);
 };
 
-enum zn_view_type {
-  ZN_VIEW_XDG_TOPLEVEL,
-};
-
 /** lifetime of given wlr_surface must be longer than zn_view */
 struct zn_view {
   struct wlr_surface *surface;  // nonnull

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -12,6 +12,7 @@ struct zn_xdg_toplevel;
 struct zn_view_impl {
   struct wlr_surface *(*get_wlr_surface_at)(struct zn_view *view,
       double view_sx, double view_sy, double *surface_x, double *surface_y);
+  void (*set_activated)(struct zn_view *view, bool activated);
 };
 
 enum zn_view_type {

--- a/zen/board.c
+++ b/zen/board.c
@@ -40,6 +40,33 @@ zn_board_move(struct zn_board *self, vec2 size, mat4 transform)
   glm_mat4_copy(transform, self->geometry.transform);
 }
 
+struct wlr_surface *
+zn_board_get_surface_at(struct zn_board *self, double x, double y,
+    double *surface_x, double *surface_y)
+{
+  struct zn_view *view_iterator;
+  double view_sx, view_sy;
+  struct wlr_surface *surface;
+
+  wl_list_for_each_reverse (view_iterator, &self->view_list, board_link) {
+    struct wlr_fbox fbox;
+    zn_view_get_surface_fbox(view_iterator, &fbox);
+    view_sx = x - fbox.x;
+    view_sy = y - fbox.y;
+
+    double sx, sy;
+    surface = view_iterator->impl->get_wlr_surface_at(
+        view_iterator, view_sx, view_sy, &sx, &sy);
+    if (surface) {
+      if (surface_x) *surface_x = sx;
+      if (surface_y) *surface_y = sy;
+      return surface;
+    }
+  }
+
+  return NULL;
+}
+
 void
 zn_board_get_effective_size(
     struct zn_board *self, double *width, double *height)

--- a/zen/board.c
+++ b/zen/board.c
@@ -42,7 +42,7 @@ zn_board_move(struct zn_board *self, vec2 size, mat4 transform)
 
 struct wlr_surface *
 zn_board_get_surface_at(struct zn_board *self, double x, double y,
-    double *surface_x, double *surface_y)
+    double *surface_x, double *surface_y, struct zn_view **view)
 {
   struct zn_view *view_iterator;
   double view_sx, view_sy;
@@ -60,6 +60,7 @@ zn_board_get_surface_at(struct zn_board *self, double x, double y,
     if (surface) {
       if (surface_x) *surface_x = sx;
       if (surface_y) *surface_y = sy;
+      if (view) *view = view_iterator;
       return surface;
     }
   }

--- a/zen/input/pointer.c
+++ b/zen/input/pointer.c
@@ -37,7 +37,9 @@ zn_pointer_handle_button(struct wl_listener *listener, void *data)
   struct wlr_event_pointer_button *event = data;
 
   if (server->display_system == ZN_DISPLAY_SYSTEM_SCREEN) {
-    // TODO: cursor
+    struct zn_cursor *cursor = server->scene->cursor;
+    cursor->grab->impl->button(
+        cursor->grab, event->time_msec, event->button, event->state);
   } else {
     struct zn_ray *ray = server->scene->ray;
     enum zgn_ray_button_state state = 0;
@@ -55,9 +57,12 @@ static void
 zn_pointer_handle_axis(struct wl_listener *listener, void *data)
 {
   UNUSED(listener);
-  UNUSED(data);
+  struct zn_server *server = zn_server_get_singleton();
+  struct wlr_event_pointer_axis *event = data;
 
-  // TODO:
+  struct zn_cursor *cursor = server->scene->cursor;
+  cursor->grab->impl->axis(cursor->grab, event->time_msec, event->source,
+      event->orientation, event->delta, event->delta_discrete);
 }
 
 static void
@@ -65,8 +70,10 @@ zn_pointer_handle_frame(struct wl_listener *listener, void *data)
 {
   UNUSED(listener);
   UNUSED(data);
+  struct zn_server *server = zn_server_get_singleton();
 
-  // TODO:
+  struct zn_cursor *cursor = server->scene->cursor;
+  cursor->grab->impl->frame(cursor->grab);
 }
 
 struct zn_pointer *

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -23,7 +23,7 @@ zn_default_cursor_grab_send_motion(
 
   double surface_x, surface_y;
   struct wlr_surface *surface = zn_board_get_surface_at(grab->cursor->board,
-      grab->cursor->x, grab->cursor->y, &surface_x, &surface_y);
+      grab->cursor->x, grab->cursor->y, &surface_x, &surface_y, NULL);
 
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
@@ -82,8 +82,20 @@ zn_default_cursor_grab_button(struct zn_cursor_grab *grab, uint32_t time_msec,
   UNUSED(grab);
   struct zn_server *server = zn_server_get_singleton();
   struct wlr_seat *seat = server->input_manager->seat->wlr_seat;
+  struct zn_cursor *cursor = grab->cursor;
+
+  if (!cursor->board) {
+    return;
+  }
 
   wlr_seat_pointer_send_button(seat, time_msec, button, state);
+
+  if (state == WLR_BUTTON_PRESSED) {
+    struct zn_view *view;
+    zn_board_get_surface_at(
+        cursor->board, cursor->x, cursor->y, NULL, NULL, &view);
+    zn_scene_set_focused_view(server->scene, view);
+  }
 }
 
 void

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -58,8 +58,6 @@ zn_default_cursor_grab_motion_relative(
   zn_default_cursor_grab_send_motion(grab, time_msec);
 
   zna_cursor_commit(cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
-
-  UNUSED(time_msec);
 }
 
 void

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -89,7 +89,7 @@ zn_default_cursor_grab_button(struct zn_cursor_grab *grab, uint32_t time_msec,
   wlr_seat_pointer_send_button(seat, time_msec, button, state);
 
   if (state == WLR_BUTTON_PRESSED) {
-    struct zn_view *view;
+    struct zn_view *view = NULL;
     zn_board_get_surface_at(
         cursor->board, cursor->x, cursor->y, NULL, NULL, &view);
     zn_scene_set_focused_view(server->scene, view);

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -68,8 +68,6 @@ zn_default_cursor_grab_motion_absolute(struct zn_cursor_grab *grab,
 {
   zn_cursor_move(grab->cursor, board, x, y);
 
-  zn_default_cursor_grab_send_motion(grab, time_msec);
-
   zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
 
   UNUSED(time_msec);

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -11,19 +11,21 @@ static struct wlr_surface *
 zn_xdg_toplevel_view_impl_get_wlr_surface_at(struct zn_view *view,
     double view_sx, double view_sy, double *surface_x, double *surface_y)
 {
-  struct wlr_surface *s =
-      wlr_xdg_surface_surface_at(view->xdg_toplevel->wlr_xdg_toplevel->base,
-          view_sx, view_sy, surface_x, surface_y);
-  return s;
+  struct zn_xdg_toplevel *toplevel = view->user_data;
+
+  return wlr_xdg_surface_surface_at(
+      toplevel->wlr_xdg_toplevel->base, view_sx, view_sy, surface_x, surface_y);
 }
+
 static void
 zn_xdg_toplevel_view_impl_set_activated(struct zn_view *view, bool activated)
 {
-  wlr_xdg_toplevel_set_activated(
-      view->xdg_toplevel->wlr_xdg_toplevel->base, activated);
+  struct zn_xdg_toplevel *toplevel = view->user_data;
+
+  wlr_xdg_toplevel_set_activated(toplevel->wlr_xdg_toplevel->base, activated);
 }
 
-static const struct zn_view_impl zn_xdg_toplevel_view_impl = {
+static const struct zn_view_interface zn_xdg_toplevel_view_impl = {
     .get_wlr_surface_at = zn_xdg_toplevel_view_impl_get_wlr_surface_at,
     .set_activated = zn_xdg_toplevel_view_impl_set_activated,
 };
@@ -40,9 +42,8 @@ zn_xdg_toplevel_handle_map(struct wl_listener *listener, void *data)
     return;
   }
 
-  self->view = zn_view_create(self->wlr_xdg_toplevel->base->surface);
-  self->view->impl = &zn_xdg_toplevel_view_impl;
-  self->view->xdg_toplevel = self;
+  self->view = zn_view_create(
+      self->wlr_xdg_toplevel->base->surface, &zn_xdg_toplevel_view_impl, self);
   zn_scene_new_view(server->scene, self->view);
 }
 

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -11,8 +11,10 @@ static struct wlr_surface *
 zn_xdg_toplevel_view_impl_get_wlr_surface_at(struct zn_view *view,
     double view_sx, double view_sy, double *surface_x, double *surface_y)
 {
-  return wlr_xdg_surface_surface_at(view->xdg_toplevel->wlr_xdg_toplevel->base,
-      view_sx, view_sy, surface_x, surface_y);
+  struct wlr_surface *s =
+      wlr_xdg_surface_surface_at(view->xdg_toplevel->wlr_xdg_toplevel->base,
+          view_sx, view_sy, surface_x, surface_y);
+  return s;
 }
 
 static const struct zn_view_impl zn_xdg_toplevel_view_impl = {

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -7,6 +7,18 @@
 
 static void zn_xdg_toplevel_destroy(struct zn_xdg_toplevel *self);
 
+static struct wlr_surface *
+zn_xdg_toplevel_view_impl_get_wlr_surface_at(struct zn_view *view,
+    double view_sx, double view_sy, double *surface_x, double *surface_y)
+{
+  return wlr_xdg_surface_surface_at(view->xdg_toplevel->wlr_xdg_toplevel->base,
+      view_sx, view_sy, surface_x, surface_y);
+}
+
+static const struct zn_view_impl zn_xdg_toplevel_view_impl = {
+    .get_wlr_surface_at = zn_xdg_toplevel_view_impl_get_wlr_surface_at,
+};
+
 static void
 zn_xdg_toplevel_handle_map(struct wl_listener *listener, void *data)
 {
@@ -20,6 +32,8 @@ zn_xdg_toplevel_handle_map(struct wl_listener *listener, void *data)
   }
 
   self->view = zn_view_create(self->wlr_xdg_toplevel->base->surface);
+  self->view->impl = &zn_xdg_toplevel_view_impl;
+  self->view->xdg_toplevel = self;
   zn_scene_new_view(server->scene, self->view);
 }
 

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -16,9 +16,16 @@ zn_xdg_toplevel_view_impl_get_wlr_surface_at(struct zn_view *view,
           view_sx, view_sy, surface_x, surface_y);
   return s;
 }
+static void
+zn_xdg_toplevel_view_impl_set_activated(struct zn_view *view, bool activated)
+{
+  wlr_xdg_toplevel_set_activated(
+      view->xdg_toplevel->wlr_xdg_toplevel->base, activated);
+}
 
 static const struct zn_view_impl zn_xdg_toplevel_view_impl = {
     .get_wlr_surface_at = zn_xdg_toplevel_view_impl_get_wlr_surface_at,
+    .set_activated = zn_xdg_toplevel_view_impl_set_activated,
 };
 
 static void

--- a/zen/view.c
+++ b/zen/view.c
@@ -136,7 +136,8 @@ zn_view_move(struct zn_view *self, struct zn_board *board, double x, double y)
 }
 
 struct zn_view *
-zn_view_create(struct wlr_surface *surface)
+zn_view_create(struct wlr_surface *surface,
+    const struct zn_view_interface *impl, void *user_data)
 {
   struct zn_view *self;
   struct zn_server *server = zn_server_get_singleton();
@@ -148,6 +149,8 @@ zn_view_create(struct wlr_surface *surface)
   }
 
   self->surface = surface;
+  self->impl = impl;
+  self->user_data = user_data;
 
   self->appearance = zna_view_create(self, server->appearance_system);
   if (self->appearance == NULL) {


### PR DESCRIPTION
## Context

Previous zen could send the cursor event to the client

## Summary

Re-implement sending cursor event and focusing to the view

## How to check behavior

1. start zen
2. start some client with `WAYLAND_DEBUG=1`
3. move your input device
4. cursor event (such as `motion`, `frame`) will sent
