### PR TITLE
frame and view damage

### DIFF
--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -36,6 +36,8 @@ struct zn_board {
 
 bool zn_board_is_dangling(struct zn_board *self);
 
+void zn_board_send_frame_done(struct zn_board *self, struct timespec *when);
+
 void zn_board_move(
     struct zn_board *self, vec3 center, vec2 size, versor quaternion);
 

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -38,6 +38,8 @@ void zn_screen_damage(struct zn_screen *self, struct wlr_fbox *box);
 
 void zn_screen_damage_whole(struct zn_screen *self);
 
+void zn_screen_send_frame_done(struct zn_screen *self, struct timespec *when);
+
 /**
  * Convert screen local effective coordinates to layout coordinates
  * @param x screen local effective coordinates

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -23,11 +23,12 @@ struct zn_view {
     versor quaternion;
   } geometry;
 
-  struct wl_listener board_destroy_listener;
-
   struct {
     struct wl_signal destroy;  // (NULL)
   } events;
+
+  struct wl_listener board_destroy_listener;
+  struct wl_listener commit_listener;
 
   struct zna_view *appearance;
 };

--- a/zen/board.c
+++ b/zen/board.c
@@ -9,6 +9,7 @@
 #include "zen/appearance/board.h"
 #include "zen/screen.h"
 #include "zen/server.h"
+#include "zen/view.h"
 
 #define BOARD_PIXEL_PER_METER 2800.f
 
@@ -16,6 +17,20 @@ bool
 zn_board_is_dangling(struct zn_board *self)
 {
   return self->screen == NULL;
+}
+
+void
+zn_board_send_frame_done(struct zn_board *self, struct timespec *when)
+{
+  struct zn_view *view;
+
+  wl_list_for_each (view, &self->view_list, board_link) {
+    wlr_surface_send_frame_done(view->surface, when);
+
+    // TODO: Popups, subsurfaces?
+  }
+
+  // TODO: client-defined cursor
 }
 
 void

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -2,6 +2,7 @@
 
 #include <zen-common.h>
 
+#include "zen/board.h"
 #include "zen/screen-layout.h"
 #include "zen/server.h"
 
@@ -21,6 +22,12 @@ zn_screen_damage_whole(struct zn_screen *self)
   if (server->display_system != ZN_DISPLAY_SYSTEM_SCREEN) return;
 
   self->implementation->damage_whole(self->user_data);
+}
+
+void
+zn_screen_send_frame_done(struct zn_screen *self, struct timespec *when)
+{
+  if (self->board) zn_board_send_frame_done(self->board, when);
 }
 
 void

--- a/zen/screen/output.c
+++ b/zen/screen/output.c
@@ -6,6 +6,7 @@
 #include <zen-common.h>
 
 #include "zen/screen/renderer.h"
+#include "zen/server.h"
 
 static void zn_output_destroy(struct zn_output *self);
 
@@ -74,11 +75,18 @@ static void
 zn_output_handle_damage_frame(struct wl_listener *listener, void *data)
 {
   UNUSED(data);
+  struct zn_server *server = zn_server_get_singleton();
   struct zn_output *self =
       zn_container_of(listener, self, damage_frame_listener);
   struct wlr_renderer *renderer = self->wlr_output->renderer;
   bool needs_frame;
   pixman_region32_t damage;
+
+  if (server->display_system == ZN_DISPLAY_SYSTEM_SCREEN) {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    zn_screen_send_frame_done(self->screen, &now);
+  }
 
   pixman_region32_init(&damage);
 


### PR DESCRIPTION
## Context

https://wayland.app/protocols/wayland#wl_surface:request:frame
https://wayland.app/protocols/wayland#wl_surface:request:damage

## Summary

- [x] Implement view damage.
- [x] Implement frame done callback event. 

## How to check behavior

Run `weston-simple-egl` or `weston-simple-shm`