### PR TITLE
frame done event in immersive display system

### DIFF
--- a/zen/view.c
+++ b/zen/view.c
@@ -57,6 +57,11 @@ zn_view_handle_commit(struct wl_listener *listener, void *data)
     zn_view_add_damage_fbox(self, &damage_box);
   }
 
+  if (pixman_region32_not_empty(&damage)) {
+    // FIXME: Update only sub image
+    zna_view_commit(self->appearance, ZNA_VIEW_DAMAGE_TEXTURE);
+  }
+
   pixman_region32_fini(&damage);
 
   // FIXME: add damages of synced subsurfaces

--- a/zna/board.h
+++ b/zna/board.h
@@ -14,4 +14,5 @@ struct zna_board {
 
   struct wl_listener session_created_listener;
   struct wl_listener session_destroyed_listener;
+  struct wl_listener session_frame_listener;
 };


### PR DESCRIPTION
## Context

Enable animation in immersive display system

## Summary

- [x] Send frame done event in immersive display system.
- [x] Resend texture when view's surface is damaged.

## How to check behavior

Start `weston-simple-egl`.