### PR TITLE
fix typo

### DIFF
--- a/zna/virtual-object/gl-sampler.c
+++ b/zna/virtual-object/gl-sampler.c
@@ -15,7 +15,7 @@ zna_gl_sampler_handle_session_destroyed(
 
   if (self->znr_gl_sampler) {
     znr_gl_sampler_destroy(self->znr_gl_sampler);
-    self->zgnr_gl_sampler = NULL;
+    self->znr_gl_sampler = NULL;
   }
 }
 


### PR DESCRIPTION
## Context

Zen crashes when 
1. Start zen
2. Start zennist
3. Start Oculus Remote Client
4. Stop Oculus Remote Client
5. Restart Oculus Remote Client

## Summary

Fix bug.

## How to check behavior

Check that the bug is fixed.