### PR TITLE
native congestion control

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = '0.15.1.1'
-zen_remote_server_req = '0.1.0.23'
+zen_remote_server_req = '0.1.0.24'
 zigen_protocols_req = '0.0.2'
 
 # dependencies

--- a/znr-remote/src/session.cc
+++ b/znr-remote/src/session.cc
@@ -10,7 +10,9 @@ znr_session_handle_frame_timer(void *data)
 {
   auto self = static_cast<znr_session_impl *>(data);
 
-  wl_signal_emit(&self->base.events.frame, nullptr);
+  if (self->proxy->GetPendingGrpcQueueCount() < 100) {
+    wl_signal_emit(&self->base.events.frame, nullptr);
+  }
 
   auto now = std::chrono::steady_clock::now();
   std::chrono::steady_clock::time_point next = self->prev_frame;


### PR DESCRIPTION
## Context

https://github.com/zigen-project/zen-remote/pull/61

## Summary

Do not send frame done events to clients if network is busy.

## How to check behavior

Start several numbers of `weston-simple-egl`. 

FPS of each clients decreases.
Ray becomes heavy but not totally uncontrollable.