### PR TITLE
move/resize by client-given cursor texture

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -90,6 +90,8 @@ void zn_cursor_set_xcursor(struct zn_cursor *self, const char *name);
 void zn_cursor_move(
     struct zn_cursor *self, struct zn_board *board, double x, double y);
 
+void zn_cursor_move_relative(struct zn_cursor *self, double dx, double dy);
+
 void zn_cursor_start_grab(struct zn_cursor *self, struct zn_cursor_grab *grab);
 
 void zn_cursor_end_grab(struct zn_cursor *self);

--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -43,11 +43,15 @@ struct zn_cursor {
   struct zn_default_cursor_grab *default_grab;  // nonnull
 
   double x, y;
+  bool visible;
   struct zn_board *board;  // nullable
+
+  struct wlr_surface *surface;  // nullable
+  double surface_hotspot_x, surface_hotspot_y;
 
   char *xcursor_name;                   // nonnull
   struct wlr_texture *xcursor_texture;  // nullable
-  double hotspot_x, hotspot_y;
+  double xcursor_hotspot_x, xcursor_hotspot_y;
 
   struct {
     vec2 size;
@@ -57,6 +61,8 @@ struct zn_cursor {
   struct wlr_xcursor_manager *xcursor_manager;  // nonnull
 
   struct wl_listener board_destroy_listener;
+  struct wl_listener surface_commit_listener;
+  struct wl_listener surface_destroy_listener;
 
   struct zna_cursor *appearance;
 };
@@ -69,6 +75,9 @@ void zn_cursor_damage(struct zn_cursor *self);
  * @returns cursor texture, nullable
  */
 struct wlr_texture *zn_cursor_get_texture(struct zn_cursor *self);
+
+void zn_cursor_set_surface(struct zn_cursor *self, struct wlr_surface *surface,
+    int hotspot_x, int hotspot_y);
 
 /**
  * @param name cannot be NULL

--- a/include/zen/input/seat.h
+++ b/include/zen/input/seat.h
@@ -13,11 +13,11 @@ struct zn_seat {
   struct zgnr_seat *zgnr_seat;
   struct wl_list devices;  // zn_input_device::link
 
+  struct wl_listener request_set_cursor_listener;
+
   struct {
     struct wl_signal destroy;
   } events;
-
-  // TODO: struct wl_listener request_set_cursor_listener;
 };
 
 void zn_seat_add_device(

--- a/include/zen/screen/cursor-grab/move.h
+++ b/include/zen/screen/cursor-grab/move.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "zen/cursor.h"
+
+struct zn_view;
+struct zn_board;
+
+struct zn_move_cursor_grab {
+  struct zn_cursor_grab base;
+  struct zn_view *view;  // nonnull
+
+  struct zn_board *init_board;
+  double init_x, init_y;
+  double diff_x, diff_y;
+
+  struct wl_listener view_destroy_listener;
+  struct wl_listener init_board_destroy_listener;
+};
+
+void zn_move_cursor_grab_start(struct zn_cursor *cursor, struct zn_view *view);

--- a/include/zen/screen/cursor-grab/resize.h
+++ b/include/zen/screen/cursor-grab/resize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+#include "zen/cursor.h"
+
+struct zn_view;
+
+struct zn_resize_cursor_grab {
+  struct zn_cursor_grab base;
+  struct zn_view *view;
+
+  double init_view_width, init_view_height;
+  double init_cursor_x, init_cursor_y;
+
+  struct wl_listener view_destroy_listener;
+};
+
+void zn_resize_cursor_grab_start(
+    struct zn_cursor *cursor, struct zn_view *view, uint32_t edges);

--- a/include/zen/screen/xdg-toplevel.h
+++ b/include/zen/screen/xdg-toplevel.h
@@ -12,6 +12,7 @@ struct zn_xdg_toplevel {
 
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
+  struct wl_listener move_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;
 };
 

--- a/include/zen/screen/xdg-toplevel.h
+++ b/include/zen/screen/xdg-toplevel.h
@@ -13,7 +13,9 @@ struct zn_xdg_toplevel {
   struct wl_listener map_listener;
   struct wl_listener unmap_listener;
   struct wl_listener move_listener;
+  struct wl_listener resize_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;
+  struct wl_listener wlr_surface_commit_listener;
 };
 
 struct zn_xdg_toplevel *zn_xdg_toplevel_create(

--- a/include/zen/screen/xdg-toplevel.h
+++ b/include/zen/screen/xdg-toplevel.h
@@ -15,7 +15,6 @@ struct zn_xdg_toplevel {
   struct wl_listener move_listener;
   struct wl_listener resize_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;
-  struct wl_listener wlr_surface_commit_listener;
 };
 
 struct zn_xdg_toplevel *zn_xdg_toplevel_create(

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -13,6 +13,7 @@ struct zn_view_interface {
   struct wlr_surface *(*get_wlr_surface_at)(struct zn_view *view,
       double view_sx, double view_sy, double *surface_x, double *surface_y);
   void (*get_window_geom)(struct zn_view *view, struct wlr_box *box);
+  uint32_t (*set_size)(struct zn_view *view, double width, double height);
   void (*set_activated)(struct zn_view *view, bool activated);
 };
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -31,6 +31,12 @@ struct zn_view {
   double x, y;
 
   struct {
+    bool resizing;
+    uint32_t edges;
+    uint32_t last_serial;
+  } resize_status;
+
+  struct {
     vec2 size;
     mat4 transform;  // translation and rotation only
   } geometry;
@@ -44,6 +50,8 @@ struct zn_view {
 
   struct zna_view *appearance;
 };
+
+void zn_view_damage(struct zn_view *self);
 
 void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -13,6 +13,7 @@ struct zn_view_interface {
   struct wlr_surface *(*get_wlr_surface_at)(struct zn_view *view,
       double view_sx, double view_sy, double *surface_x, double *surface_y);
   void (*get_window_geom)(struct zn_view *view, struct wlr_box *box);
+  uint32_t (*get_current_configure_serial)(struct zn_view *view);
   uint32_t (*set_size)(struct zn_view *view, double width, double height);
   void (*set_activated)(struct zn_view *view, bool activated);
 };
@@ -50,8 +51,6 @@ struct zn_view {
 
   struct zna_view *appearance;
 };
-
-void zn_view_damage(struct zn_view *self);
 
 void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -57,6 +57,8 @@ void zn_view_get_surface_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
 void zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox);
 
+void zn_view_bring_to_front(struct zn_view *self);
+
 void zn_view_move(
     struct zn_view *view, struct zn_board *board, double x, double y);
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -40,9 +40,14 @@ zn_cursor_handle_surface_commit(struct wl_listener *listener, void *data)
     return;
   }
 
+  zn_cursor_damage(self);
+
   self->visible = wlr_surface_has_buffer(self->surface);
+  self->surface_hotspot_x -= self->surface->current.dx;
+  self->surface_hotspot_y -= self->surface->current.dy;
 
   zn_cursor_damage(self);
+
   zna_cursor_commit(self->appearance, ZNA_CURSOR_DAMAGE_TEXTURE);
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -8,6 +8,7 @@
 
 #include "zen/appearance/cursor.h"
 #include "zen/board.h"
+#include "zen/screen-layout.h"
 #include "zen/screen.h"
 #include "zen/screen/cursor-grab/default.h"
 #include "zen/server.h"
@@ -212,6 +213,22 @@ zn_cursor_move(
     glm_vec2_zero(self->geometry.size);
     glm_mat4_identity(self->geometry.transform);
   }
+}
+
+void
+zn_cursor_move_relative(struct zn_cursor *self, double dx, double dy)
+{
+  struct zn_server *server = zn_server_get_singleton();
+
+  double layout_x, layout_y;
+  zn_screen_get_screen_layout_coords(
+      self->board->screen, self->x + dx, self->y + dy, &layout_x, &layout_y);
+
+  double screen_x, screen_y;
+  struct zn_screen *screen = zn_screen_layout_get_closest_screen(
+      server->scene->screen_layout, layout_x, layout_y, &screen_x, &screen_y);
+
+  zn_cursor_move(self, screen->board, screen_x, screen_y);
 }
 
 static bool

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -224,6 +224,10 @@ zn_cursor_move(
 void
 zn_cursor_move_relative(struct zn_cursor *self, double dx, double dy)
 {
+  if (!self->board || !self->board->screen) {
+    return;
+  }
+
   struct zn_server *server = zn_server_get_singleton();
 
   double layout_x, layout_y;

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -43,6 +43,7 @@ zn_cursor_handle_surface_commit(struct wl_listener *listener, void *data)
   self->visible = wlr_surface_has_buffer(self->surface);
 
   zn_cursor_damage(self);
+  zna_cursor_commit(self->appearance, ZNA_CURSOR_DAMAGE_TEXTURE);
 }
 
 static void

--- a/zen/input/seat.c
+++ b/zen/input/seat.c
@@ -14,16 +14,10 @@ zn_seat_handle_request_set_cursor(struct wl_listener *listener, void *data)
   struct zn_seat *self =
       zn_container_of(listener, self, request_set_cursor_listener);
   struct wlr_seat_pointer_request_set_cursor_event *event = data;
-
-  struct wlr_surface *focused_surface =
-      self->wlr_seat->pointer_state.focused_surface;
-  struct wl_client *focused_client = NULL;
-  if (focused_surface != NULL) {
-    focused_client = wl_resource_get_client(focused_surface->resource);
-  }
-
   struct zn_server *server = zn_server_get_singleton();
-  if (event->seat_client->client == focused_client) {
+
+  if (event->seat_client->client ==
+      self->wlr_seat->pointer_state.focused_client->client) {
     zn_cursor_set_surface(server->scene->cursor, event->surface,
         event->hotspot_x, event->hotspot_y);
   }

--- a/zen/input/seat.c
+++ b/zen/input/seat.c
@@ -16,8 +16,7 @@ zn_seat_handle_request_set_cursor(struct wl_listener *listener, void *data)
   struct wlr_seat_pointer_request_set_cursor_event *event = data;
   struct zn_server *server = zn_server_get_singleton();
 
-  if (event->seat_client->client ==
-      self->wlr_seat->pointer_state.focused_client->client) {
+  if (event->seat_client == self->wlr_seat->pointer_state.focused_client) {
     zn_cursor_set_surface(server->scene->cursor, event->surface,
         event->hotspot_x, event->hotspot_y);
   }

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -19,6 +19,7 @@ _zen_srcs = [
   'screen/renderer.c',
   'screen/xdg-toplevel.c',
   'screen/cursor-grab/default.c',
+  'screen/cursor-grab/move.c',
 
   'input/binding.c',
   'input/input-device.c',

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -20,6 +20,7 @@ _zen_srcs = [
   'screen/xdg-toplevel.c',
   'screen/cursor-grab/default.c',
   'screen/cursor-grab/move.c',
+  'screen/cursor-grab/resize.c',
 
   'input/binding.c',
   'input/input-device.c',

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -91,7 +91,12 @@ zn_scene_new_view(struct zn_scene *self, struct zn_view *view)
 
   struct zn_board *board = zn_container_of(self->board_list.next, board, link);
 
-  zn_view_move(view, board, 0, 0);
+  struct wlr_fbox view_fbox;
+  double board_width, board_height;
+  zn_view_get_view_fbox(view, &view_fbox);
+  zn_board_get_effective_size(board, &board_width, &board_height);
+  zn_view_move(view, board, (board_width - view_fbox.width) / 2,
+      (board_height - view_fbox.height) / 2);
 
   zn_scene_set_focused_view(self, view);
 

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -93,6 +93,8 @@ zn_scene_new_view(struct zn_scene *self, struct zn_view *view)
 
   zn_view_move(view, board, 0, 0);
 
+  zn_scene_set_focused_view(self, view);
+
   zna_view_commit(view->appearance, ZNA_VIEW_DAMAGE_GEOMETRY);
 }
 
@@ -112,6 +114,7 @@ zn_scene_set_focused_view(struct zn_scene *self, struct zn_view *view)
   if (view != NULL) {
     view->impl->set_activated(view, true);
     wl_signal_add(&view->events.destroy, &self->focused_view_destroy_listener);
+    zn_view_bring_to_front(view);
     // TODO: enter seat_keyboard
   }
 

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -38,26 +38,15 @@ void
 zn_default_cursor_grab_motion_relative(
     struct zn_cursor_grab *grab, double dx, double dy, uint32_t time_msec)
 {
-  struct zn_server *server = zn_server_get_singleton();
-  struct zn_cursor *cursor = grab->cursor;
-
-  if (!cursor->board || !cursor->board->screen) {
+  if (!grab->cursor->board || !grab->cursor->board->screen) {
     return;
   }
 
-  double layout_x, layout_y;
-  zn_screen_get_screen_layout_coords(cursor->board->screen, cursor->x + dx,
-      cursor->y + dy, &layout_x, &layout_y);
-
-  double screen_x, screen_y;
-  struct zn_screen *screen = zn_screen_layout_get_closest_screen(
-      server->scene->screen_layout, layout_x, layout_y, &screen_x, &screen_y);
-
-  zn_cursor_move(cursor, screen->board, screen_x, screen_y);
+  zn_cursor_move_relative(grab->cursor, dx, dy);
 
   zn_default_cursor_grab_send_motion(grab, time_msec);
 
-  zna_cursor_commit(cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
 }
 
 void

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -1,5 +1,6 @@
 #include "zen/screen/cursor-grab/default.h"
 
+#include <time.h>
 #include <zen-common.h>
 
 #include "zen/appearance/cursor.h"
@@ -128,7 +129,9 @@ zn_default_cursor_grab_leave(struct zn_cursor_grab *grab)
 void
 zn_default_cursor_grab_rebase(struct zn_cursor_grab *grab)
 {
-  UNUSED(grab);
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  zn_default_cursor_grab_send_motion(grab, timespec_to_msec(&now));
 }
 
 void

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -12,8 +12,8 @@
 #include "zen/server.h"
 
 static void
-zn_default_cursor_grab_enter_to_surface(
-    struct zn_cursor_grab *grab, uint32_t time_msec, bool send_motion)
+zn_default_cursor_grab_send_movement(
+    struct zn_cursor_grab *grab, uint32_t time_msec, bool no_motion)
 {
   if (!grab->cursor->board) {
     return;
@@ -28,7 +28,7 @@ zn_default_cursor_grab_enter_to_surface(
 
   if (surface) {
     wlr_seat_pointer_enter(seat, surface, surface_x, surface_y);
-    if (send_motion) {
+    if (!no_motion) {
       wlr_seat_pointer_send_motion(seat, time_msec, surface_x, surface_y);
     }
   } else {
@@ -47,7 +47,7 @@ zn_default_cursor_grab_motion_relative(
 
   zn_cursor_move_relative(grab->cursor, dx, dy);
 
-  zn_default_cursor_grab_enter_to_surface(grab, time_msec, true);
+  zn_default_cursor_grab_send_movement(grab, time_msec, false);
 
   zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
 }
@@ -58,7 +58,7 @@ zn_default_cursor_grab_motion_absolute(struct zn_cursor_grab *grab,
 {
   zn_cursor_move(grab->cursor, board, x, y);
 
-  zn_default_cursor_grab_enter_to_surface(grab, time_msec, true);
+  zn_default_cursor_grab_send_movement(grab, time_msec, false);
 
   zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
 
@@ -131,7 +131,7 @@ zn_default_cursor_grab_leave(struct zn_cursor_grab *grab)
 void
 zn_default_cursor_grab_rebase(struct zn_cursor_grab *grab)
 {
-  zn_default_cursor_grab_enter_to_surface(grab, 0, false);
+  zn_default_cursor_grab_send_movement(grab, 0, true);
 }
 
 void

--- a/zen/screen/cursor-grab/move.c
+++ b/zen/screen/cursor-grab/move.c
@@ -1,0 +1,194 @@
+#include "zen/screen/cursor-grab/move.h"
+
+#include "zen-common.h"
+#include "zen/appearance/cursor.h"
+#include "zen/board.h"
+#include "zen/cursor.h"
+#include "zen/server.h"
+#include "zen/view.h"
+
+static void zn_move_cursor_grab_destroy(struct zn_move_cursor_grab *self);
+
+static void
+zn_move_cursor_grab_motion_relative(
+    struct zn_cursor_grab *grab, double dx, double dy, uint32_t time_msec)
+{
+  UNUSED(time_msec);
+  struct zn_move_cursor_grab *self = zn_container_of(grab, self, base);
+  struct zn_board *board = self->view->board;
+  const struct zn_board *prev_board = grab->cursor->board;
+
+  zn_cursor_move_relative(grab->cursor, dx, dy);
+
+  if (grab->cursor->board != prev_board) {
+    board = grab->cursor->board;
+  }
+
+  zn_view_move(self->view, board, grab->cursor->x + self->diff_x,
+      grab->cursor->y + self->diff_y);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+static void
+zn_move_cursor_grab_motion_absolute(struct zn_cursor_grab *grab,
+    struct zn_board *board, double x, double y, uint32_t time_msec)
+{
+  UNUSED(time_msec);
+
+  zn_cursor_move(grab->cursor, board, x, y);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+static void
+zn_move_cursor_grab_button(struct zn_cursor_grab *grab, uint32_t time_msec,
+    uint32_t button, enum wlr_button_state state)
+{
+  UNUSED(time_msec);
+  UNUSED(button);
+  struct zn_move_cursor_grab *self = zn_container_of(grab, self, base);
+
+  if (state == WLR_BUTTON_RELEASED) {
+    zn_cursor_end_grab(grab->cursor);
+  }
+}
+
+static void
+zn_move_cursor_grab_axis(struct zn_cursor_grab *grab, uint32_t time_msec,
+    enum wlr_axis_source source, enum wlr_axis_orientation orientation,
+    double delta, int32_t delta_discrete)
+{
+  UNUSED(grab);
+  UNUSED(time_msec);
+  UNUSED(source);
+  UNUSED(orientation);
+  UNUSED(delta);
+  UNUSED(delta_discrete);
+}
+
+static void
+zn_move_cursor_grab_frame(struct zn_cursor_grab *grab)
+{
+  UNUSED(grab);
+}
+
+void
+zn_move_cursor_grab_enter(
+    struct zn_cursor_grab *grab, struct zn_board *board, double x, double y)
+{
+  zn_cursor_move(grab->cursor, board, x, y);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+void
+zn_move_cursor_grab_leave(struct zn_cursor_grab *grab)
+{
+  zn_cursor_move(grab->cursor, NULL, 0, 0);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+static void
+zn_move_cursor_grab_rebase(struct zn_cursor_grab *grab)
+{
+  struct zn_move_cursor_grab *self = zn_container_of(grab, self, base);
+  zn_view_move(self->view, grab->cursor->board, grab->cursor->x + self->diff_x,
+      grab->cursor->y + self->diff_y);
+}
+
+static void
+zn_move_cursor_grab_cancel(struct zn_cursor_grab *grab)
+{
+  struct zn_move_cursor_grab *self = zn_container_of(grab, self, base);
+  zn_cursor_set_xcursor(self->base.cursor, "left_ptr");
+  zn_move_cursor_grab_destroy(self);
+}
+
+static const struct zn_cursor_grab_interface implementation = {
+    .motion_relative = zn_move_cursor_grab_motion_relative,
+    .motion_absolute = zn_move_cursor_grab_motion_absolute,
+    .button = zn_move_cursor_grab_button,
+    .axis = zn_move_cursor_grab_axis,
+    .frame = zn_move_cursor_grab_frame,
+    .enter = zn_move_cursor_grab_enter,
+    .leave = zn_move_cursor_grab_leave,
+    .rebase = zn_move_cursor_grab_rebase,
+    .cancel = zn_move_cursor_grab_cancel,
+};
+
+static void
+zn_move_cursor_grab_handle_view_unmap(struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zn_move_cursor_grab *self =
+      zn_container_of(listener, self, view_destroy_listener);
+  zn_cursor_end_grab(self->base.cursor);
+}
+
+static void
+zn_move_cursor_grab_handle_init_board_destroy(
+    struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zn_move_cursor_grab *self =
+      zn_container_of(listener, self, init_board_destroy_listener);
+  zn_cursor_end_grab(self->base.cursor);
+}
+
+static struct zn_move_cursor_grab *
+zn_move_cursor_grab_create(struct zn_cursor *cursor, struct zn_view *view)
+{
+  struct zn_move_cursor_grab *self;
+  self = zalloc(sizeof *self);
+
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    return NULL;
+  }
+
+  struct wlr_fbox view_box;
+  zn_view_get_view_fbox(view, &view_box);
+  self->init_board = view->board;
+  self->init_x = view_box.x;
+  self->init_y = view_box.y;
+  self->diff_x = view_box.x - cursor->x;
+  self->diff_y = view_box.y - cursor->y;
+  self->view = view;
+  self->base.impl = &implementation;
+  self->base.cursor = cursor;
+
+  self->view_destroy_listener.notify = zn_move_cursor_grab_handle_view_unmap;
+  wl_signal_add(&view->events.destroy, &self->view_destroy_listener);
+
+  self->init_board_destroy_listener.notify =
+      zn_move_cursor_grab_handle_init_board_destroy;
+  wl_signal_add(
+      &view->board->events.destroy, &self->init_board_destroy_listener);
+
+  return self;
+}
+
+static void
+zn_move_cursor_grab_destroy(struct zn_move_cursor_grab *self)
+{
+  wl_list_remove(&self->view_destroy_listener.link);
+  wl_list_remove(&self->init_board_destroy_listener.link);
+  free(self);
+}
+
+void
+zn_move_cursor_grab_start(struct zn_cursor *cursor, struct zn_view *view)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct wlr_seat *seat = server->input_manager->seat->wlr_seat;
+  struct zn_move_cursor_grab *self = zn_move_cursor_grab_create(cursor, view);
+  if (!self) {
+    return;
+  }
+
+  zn_cursor_set_xcursor(cursor, "grabbing");
+  wlr_seat_pointer_clear_focus(seat);
+  zn_cursor_start_grab(cursor, &self->base);
+}

--- a/zen/screen/cursor-grab/resize.c
+++ b/zen/screen/cursor-grab/resize.c
@@ -121,7 +121,7 @@ zn_resize_cursor_grab_cancel(struct zn_cursor_grab *grab)
   zn_resize_cursor_grab_destroy(self);
 }
 
-static const struct zn_cursor_grab_interface zn_resize_cursor_grab_interface = {
+static const struct zn_cursor_grab_interface implementation = {
     .motion_relative = zn_resize_cursor_grab_motion_relative,
     .motion_absolute = zn_resize_cursor_grab_motion_absolute,
     .button = zn_resize_cursor_grab_button,
@@ -164,7 +164,7 @@ zn_resize_cursor_grab_create(
   self->init_cursor_y = cursor->y;
 
   self->view = view;
-  self->base.impl = &zn_resize_cursor_grab_interface;
+  self->base.impl = &implementation;
   self->base.cursor = cursor;
 
   view->resize_status.edges = edges;

--- a/zen/screen/cursor-grab/resize.c
+++ b/zen/screen/cursor-grab/resize.c
@@ -1,0 +1,213 @@
+#include "zen/screen/cursor-grab/resize.h"
+
+#include "zen-common.h"
+#include "zen/appearance/cursor.h"
+#include "zen/board.h"
+#include "zen/cursor.h"
+#include "zen/server.h"
+#include "zen/view.h"
+
+static void zn_resize_cursor_grab_destroy(struct zn_resize_cursor_grab *self);
+
+static void
+zn_resize_cursor_grab_motion_relative(
+    struct zn_cursor_grab *grab, double dx, double dy, uint32_t time_msec)
+{
+  UNUSED(time_msec);
+  struct zn_resize_cursor_grab *self = zn_container_of(grab, self, base);
+
+  zn_cursor_move_relative(grab->cursor, dx, dy);
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+
+  if (self->view->board != grab->cursor->board) {
+    return;
+  }
+
+  double width = self->init_view_width;
+  double height = self->init_view_height;
+  const double diff_width = grab->cursor->x - self->init_cursor_x;
+  const double diff_height = grab->cursor->y - self->init_cursor_y;
+
+  if (self->view->resize_status.edges & WLR_EDGE_LEFT) {
+    width -= diff_width;
+  }
+  if (self->view->resize_status.edges & WLR_EDGE_RIGHT) {
+    width += diff_width;
+  }
+  if (self->view->resize_status.edges & WLR_EDGE_TOP) {
+    height -= diff_height;
+  }
+  if (self->view->resize_status.edges & WLR_EDGE_BOTTOM) {
+    height += diff_height;
+  }
+
+  self->view->resize_status.resizing = true;
+  self->view->resize_status.last_serial =
+      self->view->impl->set_size(self->view, width, height);
+}
+
+static void
+zn_resize_cursor_grab_motion_absolute(struct zn_cursor_grab *grab,
+    struct zn_board *board, double x, double y, uint32_t time_msec)
+{
+  UNUSED(time_msec);
+
+  zn_cursor_move(grab->cursor, board, x, y);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+static void
+zn_resize_cursor_grab_button(struct zn_cursor_grab *grab, uint32_t time_msec,
+    uint32_t button, enum wlr_button_state state)
+{
+  UNUSED(time_msec);
+  UNUSED(button);
+  struct zn_resize_cursor_grab *self = zn_container_of(grab, self, base);
+
+  if (state == WLR_BUTTON_RELEASED) {
+    zn_cursor_end_grab(grab->cursor);
+  }
+}
+
+static void
+zn_resize_cursor_grab_axis(struct zn_cursor_grab *grab, uint32_t time_msec,
+    enum wlr_axis_source source, enum wlr_axis_orientation orientation,
+    double delta, int32_t delta_discrete)
+{
+  UNUSED(grab);
+  UNUSED(time_msec);
+  UNUSED(source);
+  UNUSED(orientation);
+  UNUSED(delta);
+  UNUSED(delta_discrete);
+}
+
+static void
+zn_resize_cursor_grab_frame(struct zn_cursor_grab *grab)
+{
+  UNUSED(grab);
+}
+
+void
+zn_resize_cursor_grab_enter(
+    struct zn_cursor_grab *grab, struct zn_board *board, double x, double y)
+{
+  zn_cursor_move(grab->cursor, board, x, y);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+void
+zn_resize_cursor_grab_leave(struct zn_cursor_grab *grab)
+{
+  zn_cursor_move(grab->cursor, NULL, 0, 0);
+
+  zna_cursor_commit(grab->cursor->appearance, ZNA_CURSOR_DAMAGE_GEOMETRY);
+}
+
+static void
+zn_resize_cursor_grab_rebase(struct zn_cursor_grab *grab)
+{
+  UNUSED(grab);
+}
+
+static void
+zn_resize_cursor_grab_cancel(struct zn_cursor_grab *grab)
+{
+  struct zn_resize_cursor_grab *self = zn_container_of(grab, self, base);
+
+  zn_cursor_set_xcursor(self->base.cursor, "left_ptr");
+  zn_resize_cursor_grab_destroy(self);
+}
+
+static const struct zn_cursor_grab_interface zn_resize_cursor_grab_interface = {
+    .motion_relative = zn_resize_cursor_grab_motion_relative,
+    .motion_absolute = zn_resize_cursor_grab_motion_absolute,
+    .button = zn_resize_cursor_grab_button,
+    .axis = zn_resize_cursor_grab_axis,
+    .frame = zn_resize_cursor_grab_frame,
+    .enter = zn_resize_cursor_grab_enter,
+    .leave = zn_resize_cursor_grab_leave,
+    .rebase = zn_resize_cursor_grab_rebase,
+    .cancel = zn_resize_cursor_grab_cancel,
+};
+
+static void
+zn_resize_cursor_grab_handle_view_destroy(
+    struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zn_resize_cursor_grab *self =
+      zn_container_of(listener, self, view_destroy_listener);
+  zn_cursor_end_grab(self->base.cursor);
+}
+
+static struct zn_resize_cursor_grab *
+zn_resize_cursor_grab_create(
+    struct zn_cursor *cursor, struct zn_view *view, uint32_t edges)
+{
+  struct zn_resize_cursor_grab *self;
+  self = zalloc(sizeof *self);
+
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    return NULL;
+  }
+
+  struct wlr_fbox box;
+  zn_view_get_view_fbox(view, &box);
+
+  self->init_view_width = box.width;
+  self->init_view_height = box.height;
+  self->init_cursor_x = cursor->x;
+  self->init_cursor_y = cursor->y;
+
+  self->view = view;
+  self->base.impl = &zn_resize_cursor_grab_interface;
+  self->base.cursor = cursor;
+
+  view->resize_status.edges = edges;
+
+  self->view_destroy_listener.notify =
+      zn_resize_cursor_grab_handle_view_destroy;
+  wl_signal_add(&view->events.destroy, &self->view_destroy_listener);
+
+  return self;
+}
+
+static void
+zn_resize_cursor_grab_destroy(struct zn_resize_cursor_grab *self)
+{
+  wl_list_remove(&self->view_destroy_listener.link);
+  free(self);
+}
+
+void
+zn_resize_cursor_grab_start(
+    struct zn_cursor *cursor, struct zn_view *view, uint32_t edges)
+{
+  struct zn_server *server = zn_server_get_singleton();
+  struct wlr_seat *seat = server->input_manager->seat->wlr_seat;
+
+  struct zn_resize_cursor_grab *self =
+      zn_resize_cursor_grab_create(cursor, view, edges);
+  if (!self) {
+    return;
+  }
+
+  const char *xcursor_name[] = {
+      [WLR_EDGE_TOP] = "n-resize",
+      [WLR_EDGE_BOTTOM] = "s-resize",
+      [WLR_EDGE_LEFT] = "w-resize",
+      [WLR_EDGE_RIGHT] = "e-resize",
+      [WLR_EDGE_TOP | WLR_EDGE_LEFT] = "nw-resize",
+      [WLR_EDGE_TOP | WLR_EDGE_RIGHT] = "ne-resize",
+      [WLR_EDGE_BOTTOM | WLR_EDGE_LEFT] = "sw-resize",
+      [WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT] = "se-resize",
+  };
+
+  wlr_seat_pointer_clear_focus(seat);
+  zn_cursor_set_xcursor(cursor, xcursor_name[edges]);
+  zn_cursor_start_grab(cursor, &self->base);
+}

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -204,7 +204,9 @@ zn_xdg_toplevel_destroy(struct zn_xdg_toplevel *self)
   wl_list_remove(&self->unmap_listener.link);
   wl_list_remove(&self->map_listener.link);
   wl_list_remove(&self->move_listener.link);
+  wl_list_remove(&self->resize_listener.link);
   wl_list_remove(&self->wlr_xdg_surface_destroy_listener.link);
+  wl_list_remove(&self->wlr_surface_commit_listener.link);
   if (self->view) zn_view_destroy(self->view);
   free(self);
 }

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -26,6 +26,15 @@ zn_xdg_toplevel_view_impl_get_window_geom(
   wlr_xdg_surface_get_geometry(self->wlr_xdg_toplevel->base, box);
 }
 
+static uint32_t
+zn_xdg_toplevel_view_impl_set_size(
+    struct zn_view *view, double width, double height)
+{
+  struct zn_xdg_toplevel *self = view->user_data;
+
+  return wlr_xdg_toplevel_set_size(self->wlr_xdg_toplevel->base, width, height);
+}
+
 static void
 zn_xdg_toplevel_view_impl_set_activated(struct zn_view *view, bool activated)
 {
@@ -37,6 +46,7 @@ zn_xdg_toplevel_view_impl_set_activated(struct zn_view *view, bool activated)
 static const struct zn_view_interface zn_xdg_toplevel_view_impl = {
     .get_wlr_surface_at = zn_xdg_toplevel_view_impl_get_wlr_surface_at,
     .get_window_geom = zn_xdg_toplevel_view_impl_get_window_geom,
+    .set_size = zn_xdg_toplevel_view_impl_set_size,
     .set_activated = zn_xdg_toplevel_view_impl_set_activated,
 };
 

--- a/zen/view.c
+++ b/zen/view.c
@@ -152,6 +152,7 @@ zn_view_move(struct zn_view *self, struct zn_board *board, double x, double y)
       wl_list_remove(&self->board_destroy_listener.link);
       wl_list_init(&self->board_destroy_listener.link);
       wl_list_remove(&self->board_link);
+      wl_list_init(&self->board_link);
     }
 
     if (board) {

--- a/zen/view.c
+++ b/zen/view.c
@@ -134,6 +134,10 @@ zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 void
 zn_view_bring_to_front(struct zn_view *self)
 {
+  if (!self->board) {
+    return;
+  }
+
   wl_list_remove(&self->board_link);
   wl_list_insert(self->board->view_list.prev, &self->board_link);
 

--- a/zen/view.c
+++ b/zen/view.c
@@ -132,6 +132,15 @@ zn_view_get_view_fbox(struct zn_view *self, struct wlr_fbox *fbox)
 }
 
 void
+zn_view_bring_to_front(struct zn_view *self)
+{
+  wl_list_remove(&self->board_link);
+  wl_list_insert(self->board->view_list.prev, &self->board_link);
+
+  zn_view_damage_whole(self);
+}
+
+void
 zn_view_move(struct zn_view *self, struct zn_board *board, double x, double y)
 {
   if (self->board != board) {


### PR DESCRIPTION
## Context

implement changing the cursor texture, move / resize the view, rebase event

## Summary

- 228ee3e8956b4877ec7edcdd9515fae89c62c9e5 : Listen set_cursor signal, update cursor texture when the client gives the cursor texture
- b5495d90b6bd35282c203c32c72ea2e072ba048b : make possible to move the view
- cdc1fbfe02b0b746ae9473a70d10759587a85c48 : make possible to resize the view
- ea14dd779d56657527a0be062aa35ed4ddf6e1bb : implement `rebase` to cursor grab
  - fix bug that moving was not able when move had just finished
- ea14dd779d56657527a0be062aa35ed4ddf6e1bb : focus and restack the view
- a0383cfcf4a309305176f69f45b399e9d07fa28a : change initial view pos to center

## How to check behavior

1. start zen with some client - the view is at the center of the board, and focused
2. move cursor onto the client surface; the cursor is may changed
  1. you can check this behavior with `weston-terminal`
4. try to move / resize the client
5. launch another client - the view is mapped to the forefront