### PR TITLE
mipmap

### DIFF
--- a/include/zen/renderer/gl-texture.h
+++ b/include/zen/renderer/gl-texture.h
@@ -13,6 +13,9 @@ void znr_gl_texture_image_2d(struct znr_gl_texture *self, uint32_t target,
     int32_t border, uint32_t format, uint32_t type,
     struct zgnr_mem_storage *storage);
 
+void znr_gl_texture_generate_mipmap(
+    struct znr_gl_texture *self, uint32_t target);
+
 struct znr_gl_texture *znr_gl_texture_create(
     struct znr_session *session, struct wl_display *display);
 

--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = '0.15.1.1'
-zen_remote_server_req = '0.1.0.24'
+zen_remote_server_req = '0.1.0.25'
 zigen_protocols_req = '0.0.2'
 
 # dependencies

--- a/zgnroot/include/zgnr/gl-texture.h
+++ b/zgnroot/include/zgnr/gl-texture.h
@@ -28,6 +28,10 @@ struct zgnr_gl_texture {
 
     // User may assign false to this; zgnr will only assign true to this.
     bool data_damaged;
+
+    // User may assign false to this; zgnr will only assign true to this.
+    bool generate_mipmap_target_damaged;
+    uint32_t generate_mipmap_target;
   } current;
 
   void *user_data;

--- a/zgnroot/src/gl-texture.h
+++ b/zgnroot/src/gl-texture.h
@@ -17,6 +17,8 @@ struct zgnr_gl_texture_impl {
     int32_t border;
     uint32_t format;
     uint32_t type;
+
+    uint32_t generate_mipmap_target;
   } pending;
 };
 

--- a/zna/virtual-object/gl-texture.c
+++ b/zna/virtual-object/gl-texture.c
@@ -50,6 +50,13 @@ zna_gl_texture_apply_commit(struct zna_gl_texture *self, bool only_damaged)
         self->zgnr_gl_texture->current.data);
     self->zgnr_gl_texture->current.data_damaged = false;
   }
+
+  if (self->zgnr_gl_texture->current.generate_mipmap_target_damaged ||
+      !only_damaged) {
+    znr_gl_texture_generate_mipmap(self->znr_gl_texture,
+        self->zgnr_gl_texture->current.generate_mipmap_target);
+    self->zgnr_gl_texture->current.generate_mipmap_target_damaged = false;
+  }
 }
 
 struct zna_gl_texture *

--- a/znr-remote/src/gl-texture.cc
+++ b/znr-remote/src/gl-texture.cc
@@ -23,6 +23,12 @@ znr_gl_texture_image_2d(struct znr_gl_texture *self, uint32_t target,
       border, format, type, std::move(buffer));
 }
 
+void
+znr_gl_texture_generate_mipmap(struct znr_gl_texture *self, uint32_t target)
+{
+  self->proxy->GlGenerateMipmap(target);
+}
+
 struct znr_gl_texture *
 znr_gl_texture_create(
     struct znr_session *session_base, struct wl_display *display)


### PR DESCRIPTION
## Context

Enable to generate mipmap for antialiasing

## Summary

Enable clients to generate mipmap for a texture.

## How to check behavior

See https://github.com/zigen-project/zennist/pull/8