### PR TITLE
Maximize view by more-general cursor

### DIFF
--- a/include/zen/screen/xdg-toplevel.h
+++ b/include/zen/screen/xdg-toplevel.h
@@ -14,6 +14,7 @@ struct zn_xdg_toplevel {
   struct wl_listener unmap_listener;
   struct wl_listener move_listener;
   struct wl_listener resize_listener;
+  struct wl_listener maximize_listener;
   struct wl_listener wlr_xdg_surface_destroy_listener;
 };
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -16,6 +16,7 @@ struct zn_view_interface {
   void (*get_window_geom)(struct zn_view *view, struct wlr_box *box);
   uint32_t (*get_current_configure_serial)(struct zn_view *view);
   uint32_t (*set_size)(struct zn_view *view, double width, double height);
+  uint32_t (*set_maximized)(struct zn_view *view, bool maximized);
   void (*set_activated)(struct zn_view *view, bool activated);
 };
 
@@ -31,6 +32,15 @@ struct zn_view {
 
   struct zn_board *board;  // nullable
   double x, y;
+
+  // view-local coordinate
+  struct wlr_fbox prev_surface_fbox;
+
+  struct {
+    bool maximized;
+    uint32_t changed_serial;
+    struct wlr_fbox reset_box;
+  } maximize_status;
 
   struct {
     bool resizing;
@@ -61,6 +71,8 @@ void zn_view_bring_to_front(struct zn_view *self);
 
 void zn_view_move(
     struct zn_view *view, struct zn_board *board, double x, double y);
+
+void zn_view_set_maximized(struct zn_view *self, bool maximized);
 
 /** lifetime of given wlr_surface must be longer than zn_view */
 struct zn_view *zn_view_create(struct wlr_surface *surface,

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -18,6 +18,7 @@ struct zn_view_interface {
   uint32_t (*set_size)(struct zn_view *view, double width, double height);
   uint32_t (*set_maximized)(struct zn_view *view, bool maximized);
   void (*set_activated)(struct zn_view *view, bool activated);
+  uint32_t (*schedule_configure)(struct zn_view *view);
 };
 
 /** lifetime of given wlr_surface must be longer than zn_view */

--- a/zen/screen/cursor-grab/move.c
+++ b/zen/screen/cursor-grab/move.c
@@ -16,6 +16,19 @@ zn_move_cursor_grab_motion_relative(
   UNUSED(time_msec);
   struct zn_move_cursor_grab *self = zn_container_of(grab, self, base);
 
+  if (self->view->maximize_status.maximized) {
+    struct wlr_fbox view_fbox;
+    zn_view_get_view_fbox(self->view, &view_fbox);
+    // calculate relative pos
+    self->view->maximize_status.reset_box.x =
+        grab->cursor->x - (self->view->maximize_status.reset_box.width *
+                              (grab->cursor->x / view_fbox.width));
+    self->view->maximize_status.reset_box.y = grab->cursor->y + self->diff_y;
+    self->diff_x = self->view->maximize_status.reset_box.x - grab->cursor->x;
+    self->diff_y = self->view->maximize_status.reset_box.y - grab->cursor->y;
+    zn_view_set_maximized(self->view, false);
+  }
+
   zn_cursor_move_relative(grab->cursor, dx, dy);
 
   zn_view_move(self->view, grab->cursor->board, grab->cursor->x + self->diff_x,

--- a/zen/screen/cursor-grab/resize.c
+++ b/zen/screen/cursor-grab/resize.c
@@ -187,10 +187,6 @@ void
 zn_resize_cursor_grab_start(
     struct zn_cursor *cursor, struct zn_view *view, uint32_t edges)
 {
-  if (view->maximize_status.maximized) {
-    return;
-  }
-
   struct zn_server *server = zn_server_get_singleton();
   struct wlr_seat *seat = server->input_manager->seat->wlr_seat;
 

--- a/zen/screen/cursor-grab/resize.c
+++ b/zen/screen/cursor-grab/resize.c
@@ -201,14 +201,14 @@ zn_resize_cursor_grab_start(
   }
 
   const char *xcursor_name[] = {
-      [WLR_EDGE_TOP] = "n-resize",
-      [WLR_EDGE_BOTTOM] = "s-resize",
-      [WLR_EDGE_LEFT] = "w-resize",
-      [WLR_EDGE_RIGHT] = "e-resize",
-      [WLR_EDGE_TOP | WLR_EDGE_LEFT] = "nw-resize",
-      [WLR_EDGE_TOP | WLR_EDGE_RIGHT] = "ne-resize",
-      [WLR_EDGE_BOTTOM | WLR_EDGE_LEFT] = "sw-resize",
-      [WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT] = "se-resize",
+      [WLR_EDGE_TOP] = "top_corner",
+      [WLR_EDGE_BOTTOM] = "bottom_corner",
+      [WLR_EDGE_LEFT] = "left_corner",
+      [WLR_EDGE_RIGHT] = "right_corner",
+      [WLR_EDGE_TOP | WLR_EDGE_LEFT] = "top_left_corner",
+      [WLR_EDGE_TOP | WLR_EDGE_RIGHT] = "top_right_corner",
+      [WLR_EDGE_BOTTOM | WLR_EDGE_LEFT] = "bottom_left_corner",
+      [WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT] = "bottom_right_corner",
   };
 
   wlr_seat_pointer_clear_focus(seat);

--- a/zen/screen/cursor-grab/resize.c
+++ b/zen/screen/cursor-grab/resize.c
@@ -187,6 +187,10 @@ void
 zn_resize_cursor_grab_start(
     struct zn_cursor *cursor, struct zn_view *view, uint32_t edges)
 {
+  if (view->maximize_status.maximized) {
+    return;
+  }
+
   struct zn_server *server = zn_server_get_singleton();
   struct wlr_seat *seat = server->input_manager->seat->wlr_seat;
 

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -46,10 +46,11 @@ zn_xdg_toplevel_view_impl_set_size(
 static uint32_t
 zn_xdg_toplevel_view_impl_set_maximized(struct zn_view *view, bool maximized)
 {
+  UNUSED(maximized);
   struct zn_xdg_toplevel *self = view->user_data;
 
-  return wlr_xdg_toplevel_set_maximized(
-      self->wlr_xdg_toplevel->base, maximized);
+  return wlr_xdg_toplevel_set_maximized(self->wlr_xdg_toplevel->base,
+      self->wlr_xdg_toplevel->requested.maximized);
 }
 
 static void
@@ -60,6 +61,14 @@ zn_xdg_toplevel_view_impl_set_activated(struct zn_view *view, bool activated)
   wlr_xdg_toplevel_set_activated(self->wlr_xdg_toplevel->base, activated);
 }
 
+static uint32_t
+zn_xdg_toplevel_view_impl_schedule_configure(struct zn_view *view)
+{
+  struct zn_xdg_toplevel *self = view->user_data;
+
+  return wlr_xdg_surface_schedule_configure(self->wlr_xdg_toplevel->base);
+}
+
 static const struct zn_view_interface zn_xdg_toplevel_view_impl = {
     .get_wlr_surface_at = zn_xdg_toplevel_view_impl_get_wlr_surface_at,
     .get_window_geom = zn_xdg_toplevel_view_impl_get_window_geom,
@@ -68,6 +77,7 @@ static const struct zn_view_interface zn_xdg_toplevel_view_impl = {
     .set_size = zn_xdg_toplevel_view_impl_set_size,
     .set_maximized = zn_xdg_toplevel_view_impl_set_maximized,
     .set_activated = zn_xdg_toplevel_view_impl_set_activated,
+    .schedule_configure = zn_xdg_toplevel_view_impl_schedule_configure,
 };
 
 static void

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -46,11 +46,10 @@ zn_xdg_toplevel_view_impl_set_size(
 static uint32_t
 zn_xdg_toplevel_view_impl_set_maximized(struct zn_view *view, bool maximized)
 {
-  UNUSED(maximized);
   struct zn_xdg_toplevel *self = view->user_data;
 
-  return wlr_xdg_toplevel_set_maximized(self->wlr_xdg_toplevel->base,
-      self->wlr_xdg_toplevel->requested.maximized);
+  return wlr_xdg_toplevel_set_maximized(
+      self->wlr_xdg_toplevel->base, maximized);
 }
 
 static void

--- a/zen/screen/xdg-toplevel.c
+++ b/zen/screen/xdg-toplevel.c
@@ -107,7 +107,8 @@ zn_xdg_toplevel_view_handle_maximize(struct wl_listener *listener, void *data)
   UNUSED(data);
   struct zn_xdg_toplevel *self =
       zn_container_of(listener, self, maximize_listener);
-  zn_view_set_maximized(self->view, !self->view->maximize_status.maximized);
+  zn_view_set_maximized(
+      self->view, self->wlr_xdg_toplevel->requested.maximized);
 }
 
 static void

--- a/zen/view.c
+++ b/zen/view.c
@@ -112,8 +112,8 @@ zn_view_handle_commit(struct wl_listener *listener, void *data)
     }
   }
 
-  self->prev_surface_fbox.x = window_geom.x;
-  self->prev_surface_fbox.y = window_geom.y;
+  self->prev_surface_fbox.x = -window_geom.x;
+  self->prev_surface_fbox.y = -window_geom.y;
   self->prev_surface_fbox.width = surface_box.width;
   self->prev_surface_fbox.height = surface_box.height;
 }

--- a/zen/view.c
+++ b/zen/view.c
@@ -54,8 +54,8 @@ zn_view_handle_commit(struct wl_listener *listener, void *data)
   self->impl->get_window_geom(self, &window_geom);
 
   // geometry was changed
-  if (self->prev_surface_fbox.x != window_geom.x ||
-      self->prev_surface_fbox.y != window_geom.y) {
+  if (self->prev_surface_fbox.x != -window_geom.x ||
+      self->prev_surface_fbox.y != -window_geom.y) {
     damage_box = self->prev_surface_fbox;
     damage_box.x += self->x;
     damage_box.y += self->y;

--- a/zen/view.c
+++ b/zen/view.c
@@ -217,10 +217,8 @@ zn_view_move(struct zn_view *self, struct zn_board *board, double x, double y)
 void
 zn_view_set_maximized(struct zn_view *self, bool maximized)
 {
-  if (!self->board) {
-    return;
-  }
-  if (self->maximize_status.maximized == maximized) {
+  if (!self->board || self->maximize_status.maximized == maximized) {
+    self->impl->schedule_configure(self);
     return;
   }
 


### PR DESCRIPTION
## Context

Implement maximizing alike other DE

## Summary

handle maximize request

and, on c5c1828, the cursor names that used when resizing are changed.

## How to check behavior

1. start zen with some client
2. If you launch `weston-foobar`, the view has maximize button. When you press, the view is maximized
3. try to resize after maximizing - almost couldn't
4. try to move after maximizing - the view is unmaximized, and start moving
