### PR TITLE
add `zn_data_device_manager`

### DIFF
--- a/include/zen/data_device_manager.h
+++ b/include/zen/data_device_manager.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <wayland-server-core.h>
+#include <wlr/types/wlr_data_device.h>
+
+struct zn_data_device_manager {
+  // This object will be automatically destroyed when wl_display is destroyed
+  struct wlr_data_device_manager *wlr_data_device_manager;
+};
+
+struct zn_data_device_manager *zn_data_device_manager_create(
+    struct wl_display *display);
+
+void zn_data_device_manager_destroy(struct zn_data_device_manager *self);

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -9,6 +9,7 @@
 
 #include "zen/appearance/system.h"
 #include "zen/config/config.h"
+#include "zen/data_device_manager.h"
 #include "zen/input/input-manager.h"
 #include "zen/scene.h"
 #include "zen/screen/compositor.h"
@@ -29,6 +30,7 @@ struct zn_server {
 
   struct zn_screen_compositor *screen_compositor;
 
+  struct zn_data_device_manager *data_device_manager;
   struct zn_input_manager *input_manager;
   struct znr_remote *remote;
   struct zna_system *appearance_system;

--- a/zen/data_device_manager.c
+++ b/zen/data_device_manager.c
@@ -1,0 +1,37 @@
+#include "zen/data_device_manager.h"
+
+#include <wlr/types/wlr_primary_selection_v1.h>
+#include <zen-common.h>
+
+struct zn_data_device_manager *
+zn_data_device_manager_create(struct wl_display *display)
+{
+  struct zn_data_device_manager *self;
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  self->wlr_data_device_manager = wlr_data_device_manager_create(display);
+  if (self->wlr_data_device_manager == NULL) {
+    zn_error("Failed to create wlr_data_device_manager");
+    goto err_free;
+  }
+
+  wlr_primary_selection_v1_device_manager_create(display);
+
+  return self;
+
+err_free:
+  free(self);
+
+err:
+  return NULL;
+}
+
+void
+zn_data_device_manager_destroy(struct zn_data_device_manager *self)
+{
+  free(self);
+}

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -1,6 +1,7 @@
 _zen_srcs = [
   'board.c',
   'cursor.c',
+  'data_device_manager.c',
   'ray.c',
   'scene.c',
   'screen.c',

--- a/zen/server.c
+++ b/zen/server.c
@@ -252,6 +252,12 @@ zn_server_create(struct wl_display *display)
     goto err_shell;
   }
 
+  self->data_device_manager = zn_data_device_manager_create(self->display);
+  if (self->data_device_manager == NULL) {
+    zn_error("Failed to create data device manager");
+    goto err_input_manager;
+  }
+
   self->new_input_listener.notify = zn_server_handle_new_input;
   wl_signal_add(
       &self->wlr_backend->events.new_input, &self->new_input_listener);
@@ -271,6 +277,9 @@ zn_server_create(struct wl_display *display)
   zgnr_backend_activate(self->zgnr_backend);
 
   return self;
+
+err_input_manager:
+  zn_input_manager_destroy(self->input_manager);
 
 err_shell:
   zn_shell_destroy(self->shell);
@@ -325,6 +334,7 @@ zn_server_destroy_resources(struct zn_server *self)
 void
 zn_server_destroy(struct zn_server *self)
 {
+  zn_data_device_manager_destroy(self->data_device_manager);
   zn_input_manager_destroy(self->input_manager);
   zn_shell_destroy(self->shell);
   free(self->socket);


### PR DESCRIPTION
## Context

Some client such as Google Chrome cannot be launched due to error message: `Gdk: gdk_seat_get_keyboard: assertion 'GDK_IS_SEAT (seat)' failed`. It occurred because zen hasn't data device manager.

## Summary

Create `wlr_data_device_manager`. I also added `wlr_primary_selection_v1_device_manager`; make possible to paste selected text by wheel click.

## How to check behavior

1. start zen
2. try launch Google Chrome with these args: `--enable-features=UseOzonePlatform --ozone-platform=wayland` : Chrome starts up
4. Open some page with Chrome, select some text, and click wheel at text box : Selected text will be pasted
