### PR TITLE
Add config about initial number of the board

### DIFF
--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -51,7 +51,7 @@ void zn_board_box_effective_to_local_geom(
     struct zn_board *self, struct wlr_fbox *effective, struct wlr_fbox *geom);
 
 /**
- * @param screen is nullable
+ * @param screen is nullable only when used from this board's method
  */
 void zn_board_set_screen(struct zn_board *self, struct zn_screen *screen);
 

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -16,7 +16,7 @@ struct zn_board {
 
   struct wl_list screen_link;  // zn_screen::board_list
 
-  // nonnull when the screen exists
+  // nonnull when there are one or more screens in the scene
   struct zn_screen *screen;
 
   struct wl_list view_list;  // zn_view::board_link, sorted from back to front

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -14,7 +14,10 @@ struct zn_view;
 struct zn_board {
   struct wl_list link;  // zn_scene::board_list
 
-  struct zn_screen *screen;  // nullable
+  struct wl_list screen_link;  // zn_screen::board_list
+
+  // nonnull when the screen exists
+  struct zn_screen *screen;
 
   struct wl_list view_list;  // zn_view::board_link, sorted from back to front
 

--- a/include/zen/config/config.h
+++ b/include/zen/config/config.h
@@ -4,6 +4,7 @@
 
 struct zn_config {
   char *wallpaper_filepath;  // can be empty string but cannot be null
+  int64_t board_initial_count;
 };
 
 struct zn_config *zn_config_create(struct toml_table_t *config_table);

--- a/include/zen/scene.h
+++ b/include/zen/scene.h
@@ -28,13 +28,14 @@ struct zn_scene {
   struct wlr_texture *wallpaper;  // nullable
 };
 
-struct zn_board *zn_scene_create_new_board(struct zn_scene *self);
-
 void zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen);
 
 void zn_scene_new_view(struct zn_scene *self, struct zn_view *view);
 
 void zn_scene_set_focused_view(struct zn_scene *self, struct zn_view *view);
+
+void zn_scene_initialize_boards(
+    struct zn_scene *self, int64_t board_initial_count);
 
 struct zn_scene *zn_scene_create(void);
 

--- a/include/zen/scene.h
+++ b/include/zen/scene.h
@@ -3,6 +3,7 @@
 #include <wayland-server-core.h>
 #include <wlr/render/wlr_texture.h>
 
+struct zn_board;
 struct zn_screen;
 struct zn_screen_layout;
 struct zn_ray;
@@ -26,6 +27,8 @@ struct zn_scene {
 
   struct wlr_texture *wallpaper;  // nullable
 };
+
+struct zn_board *zn_scene_create_new_board(struct zn_scene *self);
 
 void zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen);
 

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -26,7 +26,7 @@ struct zn_screen {
   struct wl_list board_list;  // zn_board::screen_link
 
   // nonnull when screen display system and mapped to zn_scene
-  // if not null, this->board->screen == this
+  // if not null, this->current_board->screen == this
   struct zn_board *current_board;
 
   struct wl_listener current_board_destroy_listener;

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -24,7 +24,7 @@ struct zn_screen {
 
   // nonnull when screen display system and mapped to zn_scene
   // controlled by zn_scene, if not null, this->board->screen == this
-  struct zn_board *board;
+  struct zn_board *current_board;
 
   struct {
     struct wl_signal destroy;  // (NULL)

--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -22,9 +22,14 @@ struct zn_screen {
 
   struct wl_list link;  // zn_screen_layout::screen_list
 
+  // inserted by zn_board
+  struct wl_list board_list;  // zn_board::screen_link
+
   // nonnull when screen display system and mapped to zn_scene
-  // controlled by zn_scene, if not null, this->board->screen == this
+  // if not null, this->board->screen == this
   struct zn_board *current_board;
+
+  struct wl_listener current_board_destroy_listener;
 
   struct {
     struct wl_signal destroy;  // (NULL)
@@ -52,6 +57,9 @@ void zn_screen_get_screen_layout_coords(
 
 void zn_screen_get_effective_size(
     struct zn_screen *self, double *width, double *height);
+
+void zn_screen_set_current_board(
+    struct zn_screen *self, struct zn_board *board);
 
 struct zn_screen *zn_screen_create(
     const struct zn_screen_interface *implementation, void *user_data);

--- a/zen/board.c
+++ b/zen/board.c
@@ -104,25 +104,25 @@ zn_board_handle_screen_destroy(struct wl_listener *listener, void *data)
   UNUSED(data);
   struct zn_board *self =
       zn_container_of(listener, self, screen_destroy_listener);
+  struct zn_server *server = zn_server_get_singleton();
+  struct zn_screen_layout *screen_layout = server->scene->screen_layout;
 
-  zn_board_set_screen(self, NULL);
+  struct zn_screen *screen = NULL;
+  if (!wl_list_empty(&screen_layout->screen_list)) {
+    screen = zn_container_of(screen_layout->screen_list.next, screen, link);
+  }
+
+  zn_board_set_screen(self, screen);
 }
 
 void
 zn_board_set_screen(struct zn_board *self, struct zn_screen *screen)
 {
-  struct zn_server *server = zn_server_get_singleton();
-  struct zn_screen_layout *screen_layout = server->scene->screen_layout;
-
   if (self->screen) {
     wl_list_remove(&self->screen_destroy_listener.link);
     wl_list_init(&self->screen_destroy_listener.link);
     wl_list_remove(&self->screen_link);
     wl_list_init(&self->screen_link);
-  }
-
-  if (!screen && wl_list_length(&screen_layout->screen_list) > 0) {
-    screen = zn_container_of(screen_layout->screen_list.next, screen, link);
   }
 
   if (screen) {

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -6,8 +6,8 @@
 #include "zen-common/log.h"
 #include "zen-common/util.h"
 
-#define MAX_BOARD_INITIAL_COUNT 5
-#define DEFAULT_BOARD_INITIAL_COUNT 0
+#define BOARD_INITIAL_COUNT_MAX 5
+#define BOARD_INITIAL_COUNT_DEFAULT 0
 
 static void
 zn_config_set_default(struct zn_config *self)
@@ -15,7 +15,7 @@ zn_config_set_default(struct zn_config *self)
   // It is freed in zen_config_destroy so DEFAULT_WALLPAPER
   // should not be passed directly.
   self->wallpaper_filepath = strdup(DEFAULT_WALLPAPER);
-  self->board_initial_count = DEFAULT_BOARD_INITIAL_COUNT;
+  self->board_initial_count = BOARD_INITIAL_COUNT_DEFAULT;
 }
 
 struct zn_config *
@@ -48,12 +48,12 @@ zn_config_create(struct toml_table_t *config_table)
     toml_datum_t initial_count = toml_int_in(board, "initial_count");
     if (initial_count.ok) {
       self->board_initial_count = initial_count.u.i;
-      if (self->board_initial_count > MAX_BOARD_INITIAL_COUNT) {
+      if (self->board_initial_count > BOARD_INITIAL_COUNT_MAX) {
         zn_warn(
             "The number of the board is limited to less than %d, "
             "but requested %ld",
-            MAX_BOARD_INITIAL_COUNT, self->board_initial_count);
-        self->board_initial_count = MAX_BOARD_INITIAL_COUNT;
+            BOARD_INITIAL_COUNT_MAX, self->board_initial_count);
+        self->board_initial_count = BOARD_INITIAL_COUNT_MAX;
       }
     }
   }

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -6,12 +6,16 @@
 #include "zen-common/log.h"
 #include "zen-common/util.h"
 
+#define MAX_BOARD_INITIAL_COUNT 5
+#define DEFAULT_BOARD_INITIAL_COUNT 0
+
 static void
 zn_config_set_default(struct zn_config *self)
 {
   // It is freed in zen_config_destroy so DEFAULT_WALLPAPER
   // should not be passed directly.
   self->wallpaper_filepath = strdup(DEFAULT_WALLPAPER);
+  self->board_initial_count = DEFAULT_BOARD_INITIAL_COUNT;
 }
 
 struct zn_config *
@@ -37,6 +41,21 @@ zn_config_create(struct toml_table_t *config_table)
     toml_datum_t filepath = toml_string_in(bg, "filepath");
     free(self->wallpaper_filepath);
     self->wallpaper_filepath = filepath.u.s;
+  }
+
+  toml_table_t *board = toml_table_in(config_table, "board");
+  if (board != NULL) {
+    toml_datum_t initial_count = toml_int_in(board, "initial_count");
+    if (initial_count.ok) {
+      self->board_initial_count = initial_count.u.i;
+      if (self->board_initial_count > MAX_BOARD_INITIAL_COUNT) {
+        zn_warn(
+            "The number of the board is limited to less than %d, "
+            "but requested %ld",
+            MAX_BOARD_INITIAL_COUNT, self->board_initial_count);
+        self->board_initial_count = MAX_BOARD_INITIAL_COUNT;
+      }
+    }
   }
 
   return self;

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -50,7 +50,7 @@ zn_config_create(struct toml_table_t *config_table)
       self->board_initial_count = initial_count.u.i;
       if (self->board_initial_count > BOARD_INITIAL_COUNT_MAX) {
         zn_warn(
-            "The number of the board is limited to less than %d, "
+            "The number of initial boards is limited to no more than %d, "
             "but requested %ld",
             BOARD_INITIAL_COUNT_MAX, self->board_initial_count);
         self->board_initial_count = BOARD_INITIAL_COUNT_MAX;

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -83,6 +83,7 @@ zn_cursor_handle_surface_commit(struct wl_listener *listener, void *data)
 
   zn_cursor_update_geometry(self);
 
+  self->appearance_damage |= ZNA_CURSOR_DAMAGE_TEXTURE;
   zn_cursor_commit_appearance(self);
 }
 

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -264,7 +264,7 @@ zn_cursor_move_relative(struct zn_cursor *self, double dx, double dy)
   struct zn_screen *screen = zn_screen_layout_get_closest_screen(
       server->scene->screen_layout, layout_x, layout_y, &screen_x, &screen_y);
 
-  zn_cursor_move(self, screen->board, screen_x, screen_y);
+  zn_cursor_move(self, screen->current_board, screen_x, screen_y);
 }
 
 void

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -47,7 +47,7 @@ zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen)
   struct zn_board *board = zn_scene_ensure_dangling_board(self);
 
   zn_board_set_screen(board, screen);
-  screen->board = board;
+  screen->current_board = board;
 
   if (server->display_system == ZN_DISPLAY_SYSTEM_SCREEN &&
       zn_screen_layout_screen_count(self->screen_layout) == 1) {

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -38,11 +38,15 @@ zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen)
 {
   zn_screen_layout_add(self->screen_layout, screen);
   struct zn_server *server = zn_server_get_singleton();
+  struct zn_board *board = NULL;
 
-  struct zn_board *board;
-  wl_list_for_each (board, &self->board_list, link) {
-    if (zn_board_is_dangling(board)) {
-      zn_board_set_screen(board, screen);
+  struct zn_board *board_iter = NULL;
+  wl_list_for_each (board_iter, &self->board_list, link) {
+    if (zn_board_is_dangling(board_iter)) {
+      if (!board) {
+        board = board_iter;
+      }
+      zn_board_set_screen(board_iter, screen);
     }
   }
 

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -21,7 +21,7 @@ zn_scene_handle_focused_view_destroy(struct wl_listener *listener, void *data)
   zn_scene_set_focused_view(self, NULL);
 }
 
-struct zn_board *
+static struct zn_board *
 zn_scene_create_new_board(struct zn_scene *self)
 {
   struct zn_board *board = zn_board_create();
@@ -143,6 +143,14 @@ zn_scene_set_focused_view(struct zn_scene *self, struct zn_view *view)
   }
 
   self->focused_view = view;
+}
+
+void
+zn_scene_initialize_boards(struct zn_scene *self, int64_t board_initial_count)
+{
+  for (int i = 0; i < board_initial_count; ++i) {
+    zn_scene_create_new_board(self);
+  }
 }
 
 struct zn_scene *

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -50,7 +50,7 @@ zn_scene_new_screen(struct zn_scene *self, struct zn_screen *screen)
     }
   }
 
-  if (wl_list_length(&screen->board_list) == 0) {
+  if (wl_list_empty(&screen->board_list)) {
     board = zn_scene_create_new_board(self);
     zn_board_set_screen(board, screen);
   }

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -95,9 +95,12 @@ zn_scene_new_view(struct zn_scene *self, struct zn_view *view)
 {
   wl_list_insert(&self->view_list, &view->link);
 
-  if (wl_list_empty(&self->board_list)) return;
+  struct zn_board *board = self->cursor->board;
 
-  struct zn_board *board = zn_container_of(self->board_list.next, board, link);
+  if (!board) {
+    if (wl_list_empty(&self->board_list)) return;
+    board = zn_container_of(self->board_list.next, board, link);
+  }
 
   struct wlr_fbox view_fbox;
   double board_width, board_height;

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -7,7 +7,7 @@
 #include "zen/server.h"
 
 void
-zn_screen_handle_current_board_destoy(struct wl_listener *listener, void *data)
+zn_screen_handle_current_board_destroy(struct wl_listener *listener, void *data)
 {
   UNUSED(data);
   struct zn_screen *self =
@@ -96,7 +96,7 @@ zn_screen_create(
   wl_signal_init(&self->events.destroy);
 
   self->current_board_destroy_listener.notify =
-      zn_screen_handle_current_board_destoy;
+      zn_screen_handle_current_board_destroy;
   wl_list_init(&self->current_board_destroy_listener.link);
 
   return self;

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -112,6 +112,7 @@ zn_screen_destroy(struct zn_screen *self)
   zn_screen_layout_remove(server->scene->screen_layout, self);
   wl_signal_emit(&self->events.destroy, NULL);
 
+  wl_list_remove(&self->board_list);
   wl_list_remove(&self->current_board_destroy_listener.link);
   wl_list_remove(&self->events.destroy.listener_list);
   free(self);

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -27,7 +27,7 @@ zn_screen_damage_whole(struct zn_screen *self)
 void
 zn_screen_send_frame_done(struct zn_screen *self, struct timespec *when)
 {
-  if (self->board) zn_board_send_frame_done(self->board, when);
+  if (self->current_board) zn_board_send_frame_done(self->current_board, when);
 }
 
 void
@@ -60,7 +60,7 @@ zn_screen_create(
   self->user_data = user_data;
   self->implementation = implementation;
   wl_list_init(&self->link);
-  self->board = NULL;
+  self->current_board = NULL;
 
   wl_signal_init(&self->events.destroy);
 

--- a/zen/screen/renderer.c
+++ b/zen/screen/renderer.c
@@ -160,7 +160,7 @@ zn_screen_renderer_render(struct zn_output *output,
     struct wlr_renderer *renderer, pixman_region32_t *damage)
 {
   struct zn_server *server = zn_server_get_singleton();
-  struct zn_board *board = output->screen->board;
+  struct zn_board *board = output->screen->current_board;
   pixman_region32_t screen_damage;
   int output_width, output_height;
 

--- a/zen/server.c
+++ b/zen/server.c
@@ -243,9 +243,7 @@ zn_server_create(struct wl_display *display)
     goto err_socket;
   }
 
-  for (int i = 0; i < self->config->board_initial_count; ++i) {
-    zn_scene_create_new_board(self->scene);
-  }
+  zn_scene_initialize_boards(self->scene, self->config->board_initial_count);
 
   zn_ray_set_default_grab(
       self->scene->ray, zn_shell_get_default_grab(self->shell));

--- a/zen/server.c
+++ b/zen/server.c
@@ -243,6 +243,10 @@ zn_server_create(struct wl_display *display)
     goto err_socket;
   }
 
+  for (int i = 0; i < self->config->board_initial_count; ++i) {
+    zn_scene_create_new_board(self->scene);
+  }
+
   zn_ray_set_default_grab(
       self->scene->ray, zn_shell_get_default_grab(self->shell));
 


### PR DESCRIPTION
## Context

Manage initial number of the board by config file. This PR make possible to place multiple board at Immersive Display System.

## Summary

Add `board` table and `initial_count` key to config file.

(I incidentally fixed about issue about cursor texture at 7046285)


## How to check behavior

First, edit `~/.config/zen-desktop/config.toml` like following:

```toml
[board]
# 0~5 is acceptable
initial_count = 3
```

And start zen and remote display system. You can see the multiple board.