### PR TITLE
introduce z-index to zn_view

### DIFF
--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -35,6 +35,8 @@ struct zn_board {
   struct wl_listener screen_destroy_listener;
 };
 
+void zn_board_reorder_view(struct zn_board *self);
+
 bool zn_board_is_dangling(struct zn_board *self);
 
 void zn_board_send_frame_done(struct zn_board *self, struct timespec *when);

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -36,7 +36,7 @@ struct zn_board {
   struct wl_listener screen_destroy_listener;
 };
 
-void zn_board_reorder_view(struct zn_board *self);
+void zn_board_rearrange_view(struct zn_board *self);
 
 bool zn_board_is_dangling(struct zn_board *self);
 

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -10,7 +10,7 @@ struct zn_view;
 
 #define CURSOR_Z_OFFSET_ON_BOARD 0.0005
 #define VIEW_MIN_Z_OFFSET_ON_BOARD 0.0001
-#define VIEW_Z_OFFSET_GAP          0.000001
+#define VIEW_Z_OFFSET_GAP 0.000001
 
 struct zn_board {
   struct wl_list link;  // zn_scene::board_list

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -9,7 +9,8 @@ struct zna_board;
 struct zn_view;
 
 #define CURSOR_Z_OFFSET_ON_BOARD 0.0005
-#define VIEW_Z_OFFSET_ON_BOARD 0.0001
+#define VIEW_MIN_Z_OFFSET_ON_BOARD 0.0001
+#define VIEW_Z_OFFSET_GAP          0.000001
 
 struct zn_board {
   struct wl_list link;  // zn_scene::board_list

--- a/include/zen/board.h
+++ b/include/zen/board.h
@@ -10,7 +10,7 @@ struct zn_view;
 
 #define CURSOR_Z_OFFSET_ON_BOARD 0.0005
 #define VIEW_MIN_Z_OFFSET_ON_BOARD 0.0001
-#define VIEW_Z_OFFSET_GAP 0.000001
+#define VIEW_Z_OFFSET_GAP 0.00001
 
 struct zn_board {
   struct wl_list link;  // zn_scene::board_list

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -36,7 +36,7 @@ struct zn_view {
 
   // controlled by `zn_view_update_z_index`, called from zn_board
   // 1 is the backmost
-  unsigned int z_index;
+  uint32_t z_index;
 
   // view-local coordinate
   struct wlr_fbox prev_surface_fbox;

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -69,7 +69,7 @@ struct zn_view {
   uint32_t appearance_damage;
 };
 
-void zn_view_update_z_index(struct zn_view *self, unsigned int z_index);
+void zn_view_update_z_index(struct zn_view *self, uint32_t z_index);
 
 void zn_view_commit_appearance(struct zn_view *self);
 

--- a/include/zen/view.h
+++ b/include/zen/view.h
@@ -34,6 +34,10 @@ struct zn_view {
   struct zn_board *board;  // nullable
   double x, y;
 
+  // controlled by `zn_view_update_z_index`, called from zn_board
+  // 1 is the backmost
+  unsigned int z_index;
+
   // view-local coordinate
   struct wlr_fbox prev_surface_fbox;
 
@@ -64,6 +68,8 @@ struct zn_view {
   struct zna_view *_appearance;  // be private
   uint32_t appearance_damage;
 };
+
+void zn_view_update_z_index(struct zn_view *self, unsigned int z_index);
 
 void zn_view_commit_appearance(struct zn_view *self);
 

--- a/zen/board.c
+++ b/zen/board.c
@@ -18,7 +18,6 @@ void
 zn_board_reorder_view(struct zn_board *self)
 {
   struct zn_view *view;
-
   unsigned int i = 1;
   wl_list_for_each (view, &self->view_list, board_link) {
     zn_view_update_z_index(view, i++);

--- a/zen/board.c
+++ b/zen/board.c
@@ -14,6 +14,17 @@
 
 #define BOARD_PIXEL_PER_METER 2800.f
 
+void
+zn_board_reorder_view(struct zn_board *self)
+{
+  struct zn_view *view;
+
+  unsigned int i = 1;
+  wl_list_for_each (view, &self->view_list, board_link) {
+    zn_view_update_z_index(view, i++);
+  }
+}
+
 bool
 zn_board_is_dangling(struct zn_board *self)
 {

--- a/zen/board.c
+++ b/zen/board.c
@@ -15,7 +15,7 @@
 #define BOARD_PIXEL_PER_METER 2800.f
 
 void
-zn_board_reorder_view(struct zn_board *self)
+zn_board_rearrange_view(struct zn_board *self)
 {
   struct zn_view *view;
   unsigned int i = 1;

--- a/zen/board.c
+++ b/zen/board.c
@@ -18,7 +18,7 @@ void
 zn_board_rearrange_view(struct zn_board *self)
 {
   struct zn_view *view;
-  unsigned int i = 1;
+  uint32_t i = 1;
   wl_list_for_each (view, &self->view_list, board_link) {
     zn_view_update_z_index(view, i++);
   }

--- a/zen/screen/cursor-grab/default.c
+++ b/zen/screen/cursor-grab/default.c
@@ -11,6 +11,7 @@
 #include "zen/screen.h"
 #include "zen/screen/cursor-grab/down.h"
 #include "zen/server.h"
+#include "zen/view.h"
 
 static void
 zn_default_cursor_grab_send_movement(
@@ -84,6 +85,13 @@ zn_default_cursor_grab_button(struct zn_cursor_grab *grab, uint32_t time_msec,
     zn_board_get_surface_at(
         cursor->board, cursor->x, cursor->y, NULL, NULL, &view);
     zn_scene_set_focused_view(server->scene, view);
+
+    if (view) {
+      struct zn_view *view_iter;
+      wl_list_for_each (view_iter, &view->board->view_list, board_link) {
+        zn_view_commit_appearance(view_iter);
+      }
+    }
 
     if (view && server->input_manager->seat->pressing_button_count == 1) {
       zn_down_cursor_grab_start(cursor, view);

--- a/zen/view.c
+++ b/zen/view.c
@@ -211,7 +211,7 @@ zn_view_bring_to_front(struct zn_view *self)
 
   wl_list_remove(&self->board_link);
   wl_list_insert(self->board->view_list.prev, &self->board_link);
-  zn_board_reorder_view(self->board);
+  zn_board_rearrange_view(self->board);
 
   zn_view_damage_whole(self);
 }
@@ -321,7 +321,7 @@ zn_view_destroy(struct zn_view *self)
   wl_signal_emit(&self->events.destroy, NULL);
 
   wl_list_remove(&self->board_link);
-  zn_board_reorder_view(self->board);
+  zn_board_rearrange_view(self->board);
 
   wl_list_remove(&self->link);
   wl_list_remove(&self->board_destroy_listener.link);

--- a/zen/view.c
+++ b/zen/view.c
@@ -40,9 +40,11 @@ zn_view_update_geometry(struct zn_view *self)
 void
 zn_view_update_z_index(struct zn_view *self, unsigned int z_index)
 {
+  if (self->z_index == z_index) {
+    return;
+  }
   self->z_index = z_index;
   zn_view_update_geometry(self);
-  zn_view_commit_appearance(self);
 }
 
 static void

--- a/zen/view.c
+++ b/zen/view.c
@@ -28,7 +28,7 @@ zn_view_update_geometry(struct zn_view *self)
     glm_mat4_copy(self->board->geometry.transform, self->geometry.transform);
     glm_translate(self->geometry.transform,
         (vec3){board_local_view_geom.x, board_local_view_geom.y,
-            VIEW_Z_OFFSET_ON_BOARD * self->z_index});
+            VIEW_MIN_Z_OFFSET_ON_BOARD + VIEW_Z_OFFSET_GAP * self->z_index});
   } else {
     glm_mat4_identity(self->geometry.transform);
     glm_vec2_zero(self->geometry.size);

--- a/zen/view.c
+++ b/zen/view.c
@@ -38,7 +38,7 @@ zn_view_update_geometry(struct zn_view *self)
 }
 
 void
-zn_view_update_z_index(struct zn_view *self, unsigned int z_index)
+zn_view_update_z_index(struct zn_view *self, uint32_t z_index)
 {
   if (self->z_index == z_index) {
     return;


### PR DESCRIPTION
## Context

In now Immersive Display System, views' z position are same. But the order in the board should be taken into account.

## Summary

Add `z_index` paramater to zn_view

## How to check behavior

Start zen with multiple client and remote client, and change the order of the view by clicking the view
