### PR TITLE
set initial board pos

### DIFF
--- a/include/zen/shell/shell.h
+++ b/include/zen/shell/shell.h
@@ -6,6 +6,8 @@ struct zn_shell;
 struct zn_scene;
 struct zn_ray_grab;
 
+void zn_shell_rearrange_board(struct zn_shell *self);
+
 /** Always returns the same pointer */
 struct zn_ray_grab *zn_shell_get_default_grab(struct zn_shell *self);
 

--- a/zen/scene.c
+++ b/zen/scene.c
@@ -148,9 +148,11 @@ zn_scene_set_focused_view(struct zn_scene *self, struct zn_view *view)
 void
 zn_scene_initialize_boards(struct zn_scene *self, int64_t board_initial_count)
 {
+  struct zn_server *server = zn_server_get_singleton();
   for (int i = 0; i < board_initial_count; ++i) {
     zn_scene_create_new_board(self);
   }
+  zn_shell_rearrange_board(server->shell);
 }
 
 struct zn_scene *

--- a/zns/seat-capsule.c
+++ b/zns/seat-capsule.c
@@ -130,6 +130,7 @@ zns_seat_capsule_add_board(
 {
   wl_list_insert(&self->board_list, &board->seat_capsule_link);
 
+    // TODO: calculate better initial position
   zns_seat_capsule_move_board(self, board, M_PI / 2.f, M_PI / 1.8f);
 
   zna_board_commit(board->zn_board->appearance);

--- a/zns/seat-capsule.c
+++ b/zns/seat-capsule.c
@@ -15,19 +15,20 @@
 void
 zns_seat_capsule_rearrange(struct zns_seat_capsule *self)
 {
-  int board_len = wl_list_length(&self->board_list);
+  int board_length = wl_list_length(&self->board_list);
   int i = 0;
-  float prev_azim;
+  float prev_azimuthal;
   struct zns_board *board;
   wl_list_for_each (board, &self->board_list, seat_capsule_link) {
-    float azim;
+    float azimuthal;
     if (i == 0) {
-      azim = M_PI / 2 + (board_len % 2 ? 0.f : INITIAL_BOARD_GAP);
+      azimuthal = M_PI / 2 + (board_length % 2 ? 0.f : INITIAL_BOARD_GAP);
     } else {
-      azim = prev_azim + (i % 2 ? -1 : 1) * (2 * i * INITIAL_BOARD_GAP);
+      azimuthal =
+          prev_azimuthal + (i % 2 ? -1 : 1) * (2 * i * INITIAL_BOARD_GAP);
     }
-    zns_seat_capsule_move_board(self, board, azim, M_PI / 1.8f);
-    prev_azim = azim;
+    zns_seat_capsule_move_board(self, board, azimuthal, M_PI / 1.8f);
+    prev_azimuthal = azimuthal;
     ++i;
   }
 }
@@ -130,7 +131,7 @@ zns_seat_capsule_add_board(
 {
   wl_list_insert(&self->board_list, &board->seat_capsule_link);
 
-    // TODO: calculate better initial position
+  // TODO: calculate better initial position
   zns_seat_capsule_move_board(self, board, M_PI / 2.f, M_PI / 1.8f);
 
   zna_board_commit(board->zn_board->appearance);

--- a/zns/seat-capsule.h
+++ b/zns/seat-capsule.h
@@ -15,6 +15,8 @@ struct zns_seat_capsule {
   struct wl_list board_list;    // zns_board::seat_capsule_link
 };
 
+void zns_seat_capsule_rearrange(struct zns_seat_capsule *self);
+
 void zns_seat_capsule_move_bounded(struct zns_seat_capsule *self,
     struct zns_bounded *bounded, float azimuthal, float polar);
 

--- a/zns/shell.c
+++ b/zns/shell.c
@@ -163,6 +163,12 @@ zn_shell_handle_focus_node_destroy(struct wl_listener *listener, void *data)
   zn_shell_set_ray_focus_node(self, NULL);
 }
 
+void
+zn_shell_rearrange_board(struct zn_shell *self)
+{
+  zns_seat_capsule_rearrange(self->seat_capsule);
+}
+
 struct zn_ray_grab *
 zn_shell_get_default_grab(struct zn_shell *self)
 {


### PR DESCRIPTION
## Context

We can change the number of initial board, but they are overlapped.

## Summary
Place board at the different pos on seat_capsule by `zns_seat_capsule_rearrange()`.

## How to check behavior

Edit `config.toml`, and start zen and with remote display system
