### PR TITLE
give znr_session to zn_peer

### DIFF
--- a/include/zen/peer.h
+++ b/include/zen/peer.h
@@ -4,10 +4,17 @@
 
 struct zn_peer {
   struct znr_remote_peer *znr_remote_peer;
+  char *host;
+
+  // nonnull when the peer has the session
+  struct znr_session *session;
 
   struct wl_listener znr_remote_peer_destroy_listener;
+  struct wl_listener znr_session_disconnected_listener;
 
   struct wl_list link;  // zn_remote::peer_list
 };
 
 struct zn_peer *zn_peer_create(struct znr_remote_peer *znr_remote_peer);
+
+void zn_peer_set_session(struct zn_peer *self, struct znr_session *session);

--- a/zen/peer.c
+++ b/zen/peer.c
@@ -1,7 +1,9 @@
 #include "zen/peer.h"
 
+#include <string.h>
 #include <zen-common.h>
 
+#include "zen/renderer/session.h"
 #include "zen/server.h"
 
 static void zn_peer_destroy(struct zn_peer *self);
@@ -13,7 +15,33 @@ zn_peer_handle_znr_remote_peer_destroy(struct wl_listener *listener, void *data)
   struct zn_peer *self =
       zn_container_of(listener, self, znr_remote_peer_destroy_listener);
 
+  self->znr_remote_peer = NULL;
+
+  if (!self->session) {
+    zn_peer_destroy(self);
+  }
+}
+
+static void
+zn_peer_handle_znr_session_disconnected(
+    struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zn_peer *self =
+      zn_container_of(listener, self, znr_session_disconnected_listener);
   zn_peer_destroy(self);
+}
+
+void
+zn_peer_set_session(struct zn_peer *self, struct znr_session *session)
+{
+  if (!zn_assert(!self->session, "session already exists")) {
+    return;
+  }
+
+  self->session = session;
+  wl_signal_add(
+      &session->events.disconnected, &self->znr_session_disconnected_listener);
 }
 
 struct zn_peer *
@@ -27,16 +55,29 @@ zn_peer_create(struct znr_remote_peer *znr_remote_peer)
     goto err;
   }
 
+  self->host = strdup(znr_remote_peer->host);
+  if (!self->host) {
+    zn_error("Failed to duplicate host name");
+    goto err_free;
+  }
+
   self->znr_remote_peer_destroy_listener.notify =
       zn_peer_handle_znr_remote_peer_destroy;
   wl_signal_add(&znr_remote_peer->events.destroy,
       &self->znr_remote_peer_destroy_listener);
+
+  self->znr_session_disconnected_listener.notify =
+      zn_peer_handle_znr_session_disconnected;
+  wl_list_init(&self->znr_session_disconnected_listener.link);
 
   self->znr_remote_peer = znr_remote_peer;
 
   wl_list_init(&self->link);
 
   return self;
+
+err_free:
+  free(self);
 
 err:
   return NULL;
@@ -47,6 +88,7 @@ zn_peer_destroy(struct zn_peer *self)
 {
   struct zn_server *server = zn_server_get_singleton();
 
+  free(self->host);
   wl_list_remove(&self->link);
   wl_list_remove(&self->znr_remote_peer_destroy_listener.link);
   free(self);

--- a/zen/peer.c
+++ b/zen/peer.c
@@ -89,6 +89,7 @@ zn_peer_destroy(struct zn_peer *self)
   struct zn_server *server = zn_server_get_singleton();
 
   free(self->host);
+  wl_list_remove(&self->znr_session_disconnected_listener.link);
   wl_list_remove(&self->link);
   wl_list_remove(&self->znr_remote_peer_destroy_listener.link);
   free(self);

--- a/zen/remote.c
+++ b/zen/remote.c
@@ -27,6 +27,7 @@ zn_remote_handle_new_peer(struct wl_listener *listener, void *data)
         znr_remote_create_session(self->znr_remote, peer->znr_remote_peer);
     if (session == NULL) return;
 
+    zn_peer_set_session(peer, session);
     zna_system_set_current_session(server->appearance_system, session);
   }
 }

--- a/znr-remote/include/znr-remote.h
+++ b/znr-remote/include/znr-remote.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 struct znr_remote_peer {
-  const char *host;  // null-terminated ip address string
+  char *host;  // null-terminated ip address string
 
   struct {
     struct wl_signal destroy;  // (NULL)

--- a/znr-remote/src/peer.cc
+++ b/znr-remote/src/peer.cc
@@ -1,5 +1,6 @@
 #include "peer.h"
 
+#include <string.h>
 #include <zen-common.h>
 
 znr_remote_peer_impl *
@@ -13,7 +14,7 @@ znr_remote_peer_create(std::shared_ptr<zen::remote::server::IPeer> proxy)
   }
 
   wl_signal_init(&self->base.events.destroy);
-  self->base.host = proxy->host().c_str();
+  self->base.host = strdup(proxy->host().c_str());
   self->proxy = proxy;
 
   return self;
@@ -27,6 +28,7 @@ znr_remote_peer_destroy(znr_remote_peer_impl *self)
 {
   wl_signal_emit(&self->base.events.destroy, nullptr);
 
+  free(self->base.host);
   wl_list_remove(&self->base.events.destroy.listener_list);
   delete self;
 }


### PR DESCRIPTION
## Context

We want to get session information (ex: host name) from peer, but now the peer is destroyed when the connection is created.

## Summary

Keep alive zn_peer, and give znr_session to zn_peer.

## How to check behavior

none