### PR TITLE
Add config about autostart app

### DIFF
--- a/common/cmd.c
+++ b/common/cmd.c
@@ -1,0 +1,28 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "zen-common.h"
+
+pid_t
+launch_command(char *command)
+{
+  pid_t pid = -1;
+
+  pid = fork();
+  if (pid == -1) {
+    zn_error("Failed to fork the command process: %s", strerror(errno));
+    goto err;
+  } else if (pid == 0) {
+    execl("/bin/sh", "/bin/sh", "-c", command, NULL);
+    fprintf(stderr, "Failed to execute the command (%s): %s\n", command,
+        strerror(errno));
+    _exit(EXIT_FAILURE);
+  }
+
+err:
+  return pid;
+}

--- a/common/include/zen-common.h
+++ b/common/include/zen-common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "zen-common/cmd.h"
 #include "zen-common/log.h"
 #include "zen-common/signal.h"
 #include "zen-common/terminate.h"

--- a/common/include/zen-common/cmd.h
+++ b/common/include/zen-common/cmd.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <sys/types.h>
+
+pid_t launch_command(char *command);

--- a/common/meson.build
+++ b/common/meson.build
@@ -1,6 +1,7 @@
 _zen_common_inc = include_directories('include')
 
 _zen_common_srcs = [
+  'cmd.c',
   'log.c',
   'signal.c',
   'terminate.c',

--- a/include/zen/config/autostart.h
+++ b/include/zen/config/autostart.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <wayland-server-core.h>
+
+struct zn_autostart {
+  char *command;
+  struct wl_list link;
+};
+
+void zn_autostart_exec(struct zn_autostart *self);
+
+struct zn_autostart *zn_autostart_create(char *command);
+
+void zn_autostart_destroy(struct zn_autostart *self);

--- a/include/zen/config/config.h
+++ b/include/zen/config/config.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <toml.h>
+#include <wayland-server-core.h>
 
 struct zn_config {
+  struct wl_list autostart_list;
   char *wallpaper_filepath;  // can be empty string but cannot be null
   int64_t board_initial_count;
 };

--- a/zen/config/autostart.c
+++ b/zen/config/autostart.c
@@ -1,0 +1,39 @@
+#include "zen/config/autostart.h"
+
+#include <string.h>
+#include <zen-common.h>
+
+void
+zn_autostart_exec(struct zn_autostart *self)
+{
+  launch_command(self->command);
+}
+
+struct zn_autostart *
+zn_autostart_create(char *command)
+{
+  struct zn_autostart *self;
+
+  self = zalloc(sizeof *self);
+  if (self == NULL) {
+    zn_error("Failed to allocate memory");
+    goto err;
+  }
+
+  wl_list_init(&self->link);
+
+  self->command = strdup(command);
+
+  return self;
+
+err:
+  return NULL;
+}
+
+void
+zn_autostart_destroy(struct zn_autostart *self)
+{
+  wl_list_remove(&self->link);
+  free(self->command);
+  free(self);
+}

--- a/zen/meson.build
+++ b/zen/meson.build
@@ -14,6 +14,7 @@ _zen_srcs = [
 
   'wlr/texture.c',
 
+  'config/autostart.c',
   'config/config.c',
   'config/config-parser.c',
 

--- a/zen/server.c
+++ b/zen/server.c
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_output.h>
 #include <zen-common.h>
 
+#include "zen/config/autostart.h"
 #include "zen/config/config-parser.h"
 #include "zen/config/config.h"
 #include "zen/cursor.h"
@@ -262,6 +263,11 @@ zn_server_create(struct wl_display *display)
       &self->new_virtual_object_listener);
 
   zgnr_backend_activate(self->zgnr_backend);
+
+  struct zn_autostart *autostart;
+  wl_list_for_each (autostart, &self->config->autostart_list, link) {
+    zn_autostart_exec(autostart);
+  }
 
   return self;
 


### PR DESCRIPTION
## Context

We want to launch some app by default.

## Summary

Add `general` table and `autostart` key to config file.

## How to check behavior

Edit your config file, and start zen. The app you specified will be launched.

```toml
[general]
autostart = [
  "weston-terminal", 
  # and more
]
```
