### PR TITLE
Add config about default space app

### DIFF
--- a/common/cmd.c
+++ b/common/cmd.c
@@ -8,7 +8,7 @@
 #include "zen-common.h"
 
 pid_t
-launch_command(char *command)
+zn_launch_command(char *command)
 {
   pid_t pid = -1;
 

--- a/common/cmd.c
+++ b/common/cmd.c
@@ -1,0 +1,28 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "zen-common.h"
+
+pid_t
+launch_command(char *command)
+{
+  pid_t pid = -1;
+
+  pid = fork();
+  if (pid == -1) {
+    zn_error("Failed to fork the command process: %s", strerror(errno));
+    goto err;
+  } else if (pid == 0) {
+    execl("/bin/sh", "/bin/sh", "-c", command, NULL);
+    fprintf(stderr, "Failed to execute the command (%s): %s\n", command,
+        strerror(errno));
+    _exit(EXIT_FAILURE);
+  }
+
+err:
+  return pid;
+}

--- a/common/include/zen-common.h
+++ b/common/include/zen-common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "zen-common/cmd.h"
 #include "zen-common/log.h"
 #include "zen-common/signal.h"
 #include "zen-common/terminate.h"

--- a/common/include/zen-common/cmd.h
+++ b/common/include/zen-common/cmd.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <sys/types.h>
+
+pid_t launch_command(char *command);

--- a/common/include/zen-common/cmd.h
+++ b/common/include/zen-common/cmd.h
@@ -2,4 +2,4 @@
 
 #include <sys/types.h>
 
-pid_t launch_command(char *command);
+pid_t zn_launch_command(char *command);

--- a/common/meson.build
+++ b/common/meson.build
@@ -1,6 +1,7 @@
 _zen_common_inc = include_directories('include')
 
 _zen_common_srcs = [
+  'cmd.c',
   'log.c',
   'signal.c',
   'terminate.c',

--- a/include/zen/config/config.h
+++ b/include/zen/config/config.h
@@ -3,7 +3,7 @@
 #include <toml.h>
 
 struct zn_config {
-  char *space_default_app;   // nullable
+  char *space_default_app;   // nonnull, non-empty
   char *wallpaper_filepath;  // can be empty string but cannot be null
   int64_t board_initial_count;
 };

--- a/include/zen/config/config.h
+++ b/include/zen/config/config.h
@@ -3,6 +3,7 @@
 #include <toml.h>
 
 struct zn_config {
+  char *space_default_app;   // nullable
   char *wallpaper_filepath;  // can be empty string but cannot be null
   int64_t board_initial_count;
 };

--- a/include/zen/server.h
+++ b/include/zen/server.h
@@ -40,6 +40,8 @@ struct zn_server {
 
   enum zn_display_system_state display_system;
 
+  pid_t default_space_app_pid;
+
   char *socket;
 
   struct wl_listener new_input_listener;

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -76,9 +76,7 @@ err:
 void
 zn_config_destroy(struct zn_config *self)
 {
-  if (self->space_default_app) {
-    free(self->space_default_app);
-  }
+  free(self->space_default_app);
   free(self->wallpaper_filepath);
   free(self);
 }

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -61,23 +61,14 @@ zn_config_create(struct toml_table_t *config_table)
   }
 
   toml_table_t *space = toml_table_in(config_table, "space");
-  if (space == NULL) {
-    zn_error("table 'space' is not found, but it required");
-    goto err_free;
-  }
-  toml_datum_t default_app = toml_string_in(space, "default_app");
-  if (default_app.ok) {
-    free(self->space_default_app);
-    self->space_default_app = strdup(default_app.u.s);
-  } else {
-    zn_error("Please specify space default_app");
-    goto err_free;
+  if (space != NULL) {
+    toml_datum_t default_app = toml_string_in(space, "default_app");
+    if (default_app.ok && strlen(default_app.u.s) != 0) {
+      self->space_default_app = strdup(default_app.u.s);
+    }
   }
 
   return self;
-
-err_free:
-  free(self);
 
 err:
   return NULL;

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -14,6 +14,7 @@ zn_config_set_default(struct zn_config *self)
 {
   // It is freed in zen_config_destroy so DEFAULT_WALLPAPER
   // should not be passed directly.
+  self->space_default_app = NULL;
   self->wallpaper_filepath = strdup(DEFAULT_WALLPAPER);
   self->board_initial_count = BOARD_INITIAL_COUNT_DEFAULT;
 }
@@ -58,6 +59,14 @@ zn_config_create(struct toml_table_t *config_table)
     }
   }
 
+  toml_table_t *space = toml_table_in(config_table, "space");
+  if (space != NULL) {
+    toml_datum_t default_app = toml_string_in(space, "default_app");
+    if (default_app.ok) {
+      self->space_default_app = strdup(default_app.u.s);
+    }
+  }
+
   return self;
 
 err:
@@ -67,6 +76,9 @@ err:
 void
 zn_config_destroy(struct zn_config *self)
 {
+  if (self->space_default_app) {
+    free(self->space_default_app);
+  }
   free(self->wallpaper_filepath);
   free(self);
 }

--- a/zen/config/config.c
+++ b/zen/config/config.c
@@ -12,9 +12,9 @@
 static void
 zn_config_set_default(struct zn_config *self)
 {
+  self->space_default_app = NULL;
   // It is freed in zen_config_destroy so DEFAULT_WALLPAPER
   // should not be passed directly.
-  self->space_default_app = NULL;
   self->wallpaper_filepath = strdup(DEFAULT_WALLPAPER);
   self->board_initial_count = BOARD_INITIAL_COUNT_DEFAULT;
 }

--- a/zen/main.c
+++ b/zen/main.c
@@ -100,8 +100,8 @@ on_signal_child(int signal_number, void *data)
       zn_terminate(EXIT_SUCCESS);
     }
     if (pid == server->default_space_app_pid) {
-      zn_debug("Default space app exited");
-      zn_terminate(EXIT_SUCCESS);
+      zn_error("Default space app exited");
+      zn_terminate(EXIT_FAILURE);
     }
   }
 

--- a/zen/main.c
+++ b/zen/main.c
@@ -110,26 +110,6 @@ on_signal_child(int signal_number, void *data)
   return 1;
 }
 
-static pid_t
-launch_startup_command(char *command)
-{
-  pid_t pid = -1;
-
-  pid = fork();
-  if (pid == -1) {
-    zn_error("Failed to fork startup command process: %s", strerror(errno));
-    goto err;
-  } else if (pid == 0) {
-    execl("/bin/sh", "/bin/sh", "-c", command, NULL);
-    fprintf(stderr, "Failed to execute startup command (%s): %s\n", command,
-        strerror(errno));
-    _exit(EXIT_FAILURE);
-  }
-
-err:
-  return pid;
-}
-
 int
 main(int argc, char *argv[])
 {
@@ -219,7 +199,7 @@ main(int argc, char *argv[])
   }
 
   if (startup_command) {
-    startup_command_pid = launch_startup_command(startup_command);
+    startup_command_pid = zn_launch_command(startup_command);
     if (startup_command_pid < 0) goto err_server;
   }
 

--- a/zen/main.c
+++ b/zen/main.c
@@ -92,10 +92,15 @@ on_signal_child(int signal_number, void *data)
   int status;
   UNUSED(data);
   UNUSED(signal_number);
+  struct zn_server *server = zn_server_get_singleton();
 
   while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
     if (startup_command_pid != -1 && pid == startup_command_pid) {
       zn_debug("Startup command exited");
+      zn_terminate(EXIT_SUCCESS);
+    }
+    if (pid == server->default_space_app_pid) {
+      zn_debug("Default space app exited");
       zn_terminate(EXIT_SUCCESS);
     }
   }

--- a/zen/server.c
+++ b/zen/server.c
@@ -101,13 +101,11 @@ zn_server_run(struct zn_server *self)
     return EXIT_FAILURE;
   }
 
-  if (self->config->space_default_app ||
-      strlen(self->config->space_default_app) == 0) {
-    self->default_space_app_pid =
-        zn_launch_command(self->config->space_default_app);
-    if (self->default_space_app_pid < 0) {
-      zn_error("Failed to launch default space app");
-    }
+  self->default_space_app_pid =
+      zn_launch_command(self->config->space_default_app);
+  if (self->default_space_app_pid < 0) {
+    zn_error("Failed to launch default space app");
+    return EXIT_FAILURE;
   }
 
   if (!self->exitted) {

--- a/zen/server.c
+++ b/zen/server.c
@@ -270,6 +270,10 @@ zn_server_create(struct wl_display *display)
 
   zgnr_backend_activate(self->zgnr_backend);
 
+  if (self->config->space_default_app) {
+    launch_command(self->config->space_default_app);
+  }
+
   return self;
 
 err_input_manager:

--- a/zen/server.c
+++ b/zen/server.c
@@ -273,7 +273,7 @@ zn_server_create(struct wl_display *display)
   if (self->config->space_default_app ||
       strlen(self->config->space_default_app) == 0) {
     self->default_space_app_pid =
-        launch_command(self->config->space_default_app);
+        zn_launch_command(self->config->space_default_app);
     if (self->default_space_app_pid < 0) {
       zn_error("Failed to launch default space app");
       goto err_data_device_manager;

--- a/zen/server.c
+++ b/zen/server.c
@@ -101,6 +101,15 @@ zn_server_run(struct zn_server *self)
     return EXIT_FAILURE;
   }
 
+  if (self->config->space_default_app ||
+      strlen(self->config->space_default_app) == 0) {
+    self->default_space_app_pid =
+        zn_launch_command(self->config->space_default_app);
+    if (self->default_space_app_pid < 0) {
+      zn_error("Failed to launch default space app");
+    }
+  }
+
   if (!self->exitted) {
     wl_display_run(self->display);
   }
@@ -270,20 +279,7 @@ zn_server_create(struct wl_display *display)
 
   zgnr_backend_activate(self->zgnr_backend);
 
-  if (self->config->space_default_app ||
-      strlen(self->config->space_default_app) == 0) {
-    self->default_space_app_pid =
-        zn_launch_command(self->config->space_default_app);
-    if (self->default_space_app_pid < 0) {
-      zn_error("Failed to launch default space app");
-      goto err_data_device_manager;
-    }
-  }
-
   return self;
-
-err_data_device_manager:
-  zn_data_device_manager_destroy(self->data_device_manager);
 
 err_input_manager:
   zn_input_manager_destroy(self->input_manager);

--- a/zen/server.c
+++ b/zen/server.c
@@ -270,11 +270,20 @@ zn_server_create(struct wl_display *display)
 
   zgnr_backend_activate(self->zgnr_backend);
 
-  if (self->config->space_default_app) {
-    launch_command(self->config->space_default_app);
+  if (self->config->space_default_app ||
+      strlen(self->config->space_default_app) == 0) {
+    self->default_space_app_pid =
+        launch_command(self->config->space_default_app);
+    if (self->default_space_app_pid < 0) {
+      zn_error("Failed to launch default space app");
+      goto err_data_device_manager;
+    }
   }
 
   return self;
+
+err_data_device_manager:
+  zn_data_device_manager_destroy(self->data_device_manager);
 
 err_input_manager:
   zn_input_manager_destroy(self->input_manager);


### PR DESCRIPTION
## Context

We want to launch space app by default.

## Summary

Add `space` table and `default_app` key to config file.

## How to check behavior

Edit your config file, and start zen. The app you specified will be launched automatically.

```toml
[space]
default_app = "zennist"
```
