### PR TITLE
fix FT_Face destruction

### DIFF
--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -25,7 +25,6 @@ struct zigzag_layout {
   struct wl_list node_list;  // zigzag_node::link
 
   cairo_font_face_t *system_font;
-  cairo_user_data_key_t ft_font_face_key;
   cairo_user_data_key_t ft_library_key;
 
   void *user_data;

--- a/zigzag/src/layout.c
+++ b/zigzag/src/layout.c
@@ -29,12 +29,6 @@ zigzag_layout_create(const struct zigzag_layout_impl *implementation,
   if (FT_New_Face(library, font_file_path, 0, &ft_face) == 0) {
     self->system_font = cairo_ft_font_face_create_for_ft_face(ft_face, 0);
     cairo_status_t status = cairo_font_face_set_user_data(self->system_font,
-        &self->ft_font_face_key, ft_face, (cairo_destroy_func_t)FT_Done_Face);
-    if (status) {
-      zn_error("Failed to bind the FT_Face to cairo_font_face_t");
-      goto err_font;
-    }
-    status = cairo_font_face_set_user_data(self->system_font,
         &self->ft_library_key, library, (cairo_destroy_func_t)FT_Done_FreeType);
     if (status) {
       zn_error("Failed to bind the FT_Library to cairo_font_face_t");
@@ -50,7 +44,6 @@ zigzag_layout_create(const struct zigzag_layout_impl *implementation,
   return self;
 err_font:
   cairo_font_face_destroy(self->system_font);
-  FT_Done_Face(ft_face);
   FT_Done_FreeType(library);
 err:
   return NULL;


### PR DESCRIPTION
## Context

FT_Face created from a FT_Library will be destroyed when the FT_Library is destroyed.
Destroying both results in double free.

ref: https://freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_library

## Summary

Fix FT_Face destruction process.

## How to check behavior
