### PR TITLE
Dynamically set frames of zigzag_node

### DIFF
--- a/zigzag/src/node.c
+++ b/zigzag/src/node.c
@@ -58,6 +58,9 @@ void
 zigzag_node_update_texture(
     struct zigzag_node *self, struct wlr_renderer *renderer)
 {
+  self->layout->implementation->on_damage(self);
+  self->implementation->set_frame(
+      self, self->layout->screen_width, self->layout->screen_height);
   struct wlr_texture *original = self->texture;
   self->texture = zigzag_node_render_texture(self, renderer);
   if (self->texture == NULL) {


### PR DESCRIPTION
## Context
https://github.com/zigen-project/zen/pull/295#discussion_r1063582636

In the current design, it is impossible to change the rendering & click region of a zigzag_node.

## Summary
Updaed `zigzag_node_update_texture` so that the frame is reset every time the texture is updated. 

## How to check behavior
- Update `zn_power_set_frame` in `zen/ui/nodes/power-button.c` to assign `node->frame.y = rand() % 100`
- Confirm that position of the button changes every second.
