### PR TITLE
Enable to damage screen in immersive display system for vr modal

### DIFF
--- a/include/zen/screen.h
+++ b/include/zen/screen.h
@@ -38,6 +38,8 @@ struct zn_screen {
   } events;
 };
 
+void zn_screen_damage_force(struct zn_screen *self, struct wlr_fbox *box);
+
 /**
  * @param box : effective coordinate system
  */

--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = '0.15.1.1'
-zen_remote_server_req = '0.1.0.26'
+zen_remote_server_req = '0.1.0.27'
 zigen_protocols_req = '0.0.2'
 
 # dependencies

--- a/zen/remote.c
+++ b/zen/remote.c
@@ -20,7 +20,8 @@ zn_remote_handle_new_peer(struct wl_listener *listener, void *data)
 
   wl_list_insert(&self->peer_list, &peer->link);
 
-  {  // FIXME: Do this when user clicks "Connect" button
+  if (server->display_system == ZN_DISPLAY_SYSTEM_SCREEN) {
+    // FIXME: Do this when user clicks "Connect" button
     struct znr_session *session =
         znr_remote_create_session(self->znr_remote, peer->znr_remote_peer);
     if (session == NULL) return;

--- a/zen/screen.c
+++ b/zen/screen.c
@@ -22,12 +22,18 @@ zn_screen_handle_current_board_destroy(struct wl_listener *listener, void *data)
 }
 
 void
+zn_screen_damage_force(struct zn_screen *self, struct wlr_fbox *box)
+{
+  self->implementation->damage(self->user_data, box);
+}
+
+void
 zn_screen_damage(struct zn_screen *self, struct wlr_fbox *box)
 {
   struct zn_server *server = zn_server_get_singleton();
   if (server->display_system != ZN_DISPLAY_SYSTEM_SCREEN) return;
 
-  self->implementation->damage(self->user_data, box);
+  zn_screen_damage_force(self, box);
 }
 
 void

--- a/zen/ui/zigzag-layout.c
+++ b/zen/ui/zigzag-layout.c
@@ -31,7 +31,7 @@ static void
 zn_zigzag_layout_on_damage(struct zigzag_node *node)
 {
   struct zn_zigzag_layout *self = node->layout->user_data;
-  zn_screen_damage(self->screen, &node->frame);
+  zn_screen_damage_force(self->screen, &node->frame);
 }
 
 static const struct zigzag_layout_impl implementation = {


### PR DESCRIPTION
## Context

Screen will not be damaged while in Immersive Display System.
But sometimes like vr_modal need to damage screen.

## Summary

- add `zn_screen_damage_force`

## How to check behavior

With one Oculus Quest, try to connect via both wifi and adb port forward.

You can see two HMDs at first (wifi and adb port forward), but wifi's one will be disappear in few seconds.