### PR TITLE
Decoupled update_frame from update_texture

### DIFF
--- a/zen/ui/nodes/vr-modal/headset-dialog.c
+++ b/zen/ui/nodes/vr-modal/headset-dialog.c
@@ -23,6 +23,7 @@ zn_vr_modal_item_headset_dialog_handle_peer_list_changed(
   struct zn_vr_modal_item_headset_dialog *self =
       zn_container_of(listener, self, peer_list_changed_listener);
   struct zn_server *server = zn_server_get_singleton();
+  zigzag_node_update_frame(self->zigzag_node);
   zigzag_node_update_texture(self->zigzag_node, server->renderer);
 }
 

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -78,6 +78,8 @@ cairo_surface_t *zigzag_node_render_cairo_surface(struct zigzag_node *self,
 void zigzag_node_update_texture(
     struct zigzag_node *self, struct wlr_renderer *renderer);
 
+void zigzag_node_update_frame(struct zigzag_node *self);
+
 bool zigzag_node_contains_point(struct zigzag_node *self, double x, double y);
 
 void zigzag_node_show_texture_with_matrix(struct zigzag_node *self,

--- a/zigzag/src/node.c
+++ b/zigzag/src/node.c
@@ -55,12 +55,18 @@ zigzag_node_render_texture(
 }
 
 void
-zigzag_node_update_texture(
-    struct zigzag_node *self, struct wlr_renderer *renderer)
+zigzag_node_update_frame(struct zigzag_node *self)
 {
   self->layout->implementation->on_damage(self);
   self->implementation->set_frame(
       self, self->layout->screen_width, self->layout->screen_height);
+  self->layout->implementation->on_damage(self);
+}
+
+void
+zigzag_node_update_texture(
+    struct zigzag_node *self, struct wlr_renderer *renderer)
+{
   struct wlr_texture *original = self->texture;
   self->texture = zigzag_node_render_texture(self, renderer);
   if (self->texture == NULL) {


### PR DESCRIPTION
## Context
#299 

## Summary
Updated the implementation  of `zigzag_node_update_texture`. Now, the caller needs to explicitly call `zigzag_node_update_frame` if it wants to change the position & size of the node.

## How to check behavior
Confirm that UI components (VR modal, power button... etc) work as expected.