### PR TITLE
Fontconfig

### DIFF
--- a/common/font.c
+++ b/common/font.c
@@ -1,0 +1,60 @@
+#include <fontconfig/fontconfig.h>
+#include <string.h>
+
+#include "zen-common.h"
+
+char *
+zn_fontconfig_get_font_path(FcConfig **config, char *font_name)
+{
+  if (!FcInit()) {
+    zn_error("Failed to initialize fontconfig");
+    return NULL;
+  }
+  *config = FcInitLoadConfigAndFonts();
+  if (!config) {
+    zn_error("Failed to load config and fonts");
+    return NULL;
+  }
+
+  FcPattern *substitute_pattern = FcNameParse((const FcChar8 *)font_name);
+  if (!substitute_pattern) {
+    zn_error("Failed to create pattern");
+    return NULL;
+  }
+  if (!FcConfigSubstitute(*config, substitute_pattern, FcMatchPattern)) {
+    zn_error("Failed to configure substitute");
+    FcPatternDestroy(substitute_pattern);
+    return NULL;
+  }
+  FcDefaultSubstitute(substitute_pattern);
+
+  FcPattern *match_pattern;
+  {
+    FcResult result;
+    match_pattern = FcFontMatch(*config, substitute_pattern, &result);
+  }
+  FcPatternDestroy(substitute_pattern);
+  if (!match_pattern) {
+    zn_error("Failed to search font");
+    return NULL;
+  }
+
+  FcChar8 *fc_file_path;
+  FcResult result =
+      FcPatternGetString(match_pattern, FC_FILE, 0, &fc_file_path);
+
+  char *file_path = NULL;
+  if (result == FcResultMatch) {
+    file_path = strdup((char *)fc_file_path);
+  }
+
+  FcPatternDestroy(match_pattern);
+  return file_path;
+}
+
+void
+zn_fontconfig_fini(FcConfig *config)
+{
+  FcConfigDestroy(config);
+  FcFini();
+}

--- a/common/include/zen-common.h
+++ b/common/include/zen-common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "zen-common/cmd.h"
+#include "zen-common/font.h"
 #include "zen-common/log.h"
 #include "zen-common/signal.h"
 #include "zen-common/terminate.h"

--- a/common/include/zen-common/font.h
+++ b/common/include/zen-common/font.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <fontconfig/fontconfig.h>
+
+char *zn_fontconfig_get_font_path(FcConfig **config, char *font_name);
+
+void zn_fontconfig_fini(FcConfig *config);

--- a/common/meson.build
+++ b/common/meson.build
@@ -2,6 +2,7 @@ _zen_common_inc = include_directories('include')
 
 _zen_common_srcs = [
   'cmd.c',
+  'font.c',
   'log.c',
   'signal.c',
   'terminate.c',
@@ -11,6 +12,7 @@ _zen_common_srcs = [
 
 _zen_common_deps = [
   cglm_dep,
+  fontconfig_dep,
   wayland_server_dep.partial_dependency(includes: true),
 ]
 

--- a/meson.build
+++ b/meson.build
@@ -150,9 +150,6 @@ else
   cdata.set_quoted('DEFAULT_WALLPAPER', '')
 endif
 
-# TODO: Add an item for the font file in config
-cdata.set_quoted('DEFAULT_SYSTEM_FONT', '/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf')
-
 configure_file(
   output: 'constants.h',
   configuration: cdata,

--- a/meson.build
+++ b/meson.build
@@ -102,6 +102,7 @@ zigen_protocols_req = '0.0.2'
 
 cairo_dep = dependency('cairo')
 cglm_dep = dependency('cglm')
+fontconfig_dep = dependency('fontconfig')
 gl_dep = dependency('gl')
 m_dep = cc.find_library('m')
 pixman_dep = dependency('pixman-1')

--- a/zen/ui/zigzag-layout.c
+++ b/zen/ui/zigzag-layout.c
@@ -1,5 +1,6 @@
 #include "zen/ui/zigzag-layout.h"
 
+#include <fontconfig/fontconfig.h>
 #include <time.h>
 #include <wlr/render/wlr_renderer.h>
 #include <zen-common.h>
@@ -53,8 +54,17 @@ zn_zigzag_layout_create(struct zn_screen *screen, struct wlr_renderer *renderer)
   double screen_width, screen_height;
   zn_screen_get_effective_size(screen, &screen_width, &screen_height);
 
+  FcConfig *config = NULL;
+  char *font_path = zn_fontconfig_get_font_path(&config, "Ubuntu");
+  if (!font_path) {
+    zn_error("Failed to get font path");
+  }
+
   struct zigzag_layout *zigzag_layout = zigzag_layout_create(
-      &implementation, screen_width, screen_height, DEFAULT_SYSTEM_FONT, self);
+      &implementation, screen_width, screen_height, font_path, self);
+
+  free(font_path);
+  zn_fontconfig_fini(config);
 
   if (zigzag_layout == NULL) {
     zn_error("Failed to create a zigzag_layout");


### PR DESCRIPTION
## Context

In Ubuntu, `Ubuntu-R.ttf` is at `/usr/share/fonts/truetype/ubuntu`.

But in Arch Linux, it's at `/usr/share/fonts/ubuntu`.

We should absorb this enviromental difference.

## Summary

Get font file path by fontconfig

## How to check behavior

Start zen. UI components like clock are rendered correctly.