### PR TITLE
Rebase cursor when switching to SDS

### DIFF
--- a/include/zen/cursor.h
+++ b/include/zen/cursor.h
@@ -68,6 +68,8 @@ struct zn_cursor {
   uint32_t appearance_damage;
 };
 
+bool zn_cursor_is_visible_in_screen(struct zn_cursor *self);
+
 void zn_cursor_get_fbox(struct zn_cursor *self, struct wlr_fbox *fbox);
 
 void zn_cursor_damage(struct zn_cursor *self);

--- a/include/zen/scene.h
+++ b/include/zen/scene.h
@@ -20,6 +20,7 @@ struct zn_scene {
   struct zn_view *focused_view;  // nullable
 
   struct wl_listener focused_view_destroy_listener;
+  struct wl_listener display_system_changed_listener;
 
   struct {
     struct wl_signal new_board;  // (struct zn_board*)

--- a/zen/cursor.c
+++ b/zen/cursor.c
@@ -99,6 +99,17 @@ zn_cursor_handle_surface_destroy(struct wl_listener *listener, void *data)
   zn_cursor_commit_appearance(self);
 }
 
+bool
+zn_cursor_is_visible_in_screen(struct zn_cursor *self)
+{
+  struct zn_board *board = self->board;
+
+  if (!board) return false;
+  if (!board->screen) return false;
+
+  return board == board->screen->current_board;
+}
+
 void
 zn_cursor_get_fbox(struct zn_cursor *self, struct wlr_fbox *fbox)
 {


### PR DESCRIPTION
## Context

With current implementation, cursor is lost when switching to screen display system if the ray is not intersected with board then.

## Summary

Rebase cursor when switching to SDS

## How to check behavior

Switching to SDS while the ray is not intersects with board.