### PR TITLE
Fix program commit

### DIFF
--- a/zgnroot/include/zgnr/gl-program.h
+++ b/zgnroot/include/zgnr/gl-program.h
@@ -14,7 +14,9 @@ struct zgnr_gl_program {
   struct {
     struct wl_list program_shader_list;  // zgnr_program_shader::link
 
+    // User may assign false to this; zgnr will only assign true to this.
     bool should_link;
+
     bool linked;
   } current;
 

--- a/zgnroot/src/gl-program.h
+++ b/zgnroot/src/gl-program.h
@@ -8,6 +8,7 @@ struct zgnr_gl_program_impl {
   struct {
     struct wl_list program_shader_list;  // zgnr_program_shader::link
     bool should_link;
+    bool damaged;
   } pending;
 
   struct wl_resource *resource;  // nonnull

--- a/zna/virtual-object/gl-program.c
+++ b/zna/virtual-object/gl-program.c
@@ -53,6 +53,7 @@ zna_gl_program_apply_commit(struct zna_gl_program *self, bool only_damaged)
       znr_gl_program_attach_shader(self->znr_gl_program, shader->znr_gl_shader);
     }
     znr_gl_program_link(self->znr_gl_program);
+    self->zgnr_gl_program->current.should_link = false;
   }
 }
 


### PR DESCRIPTION
## Summary

Resolve link problem when the same program is attached to multiple rendering units.

This PR solves the following problems.
- The same shader is linked many times.
- When connecting zen remote client, sometimes rendering unit is not rendered.

## How to check behavior

Multiple clients to attach the same program to multiple rendering units. (ex. zennist)
