### PR TITLE
Refactor zigzag

### DIFF
--- a/include/zen/ui/nodes/app-launcher.h
+++ b/include/zen/ui/nodes/app-launcher.h
@@ -21,7 +21,7 @@ struct zn_app_launcher {
 };
 
 struct zn_app_launcher *zn_app_launcher_create(
-    struct zigzag_layout *zigzag_layout, struct wlr_renderer *renderer,
+    struct zigzag_layout *zigzag_layout,
     const struct zn_app_launcher_data *data, int idx);
 
 void zn_app_launcher_destroy(struct zn_app_launcher *self);

--- a/include/zen/ui/nodes/vr-menu/connect-button.h
+++ b/include/zen/ui/nodes/vr-menu/connect-button.h
@@ -12,8 +12,8 @@ struct zn_vr_menu_headset_connect_button {
 };
 
 struct zn_vr_menu_headset_connect_button *
-zn_vr_menu_headset_connect_button_create(struct zigzag_layout *zigzag_layout,
-    struct wlr_renderer *renderer, struct zn_peer *peer, int idx);
+zn_vr_menu_headset_connect_button_create(
+    struct zigzag_layout *zigzag_layout, struct zn_peer *peer, int idx);
 
 void zn_vr_menu_headset_connect_button_destroy(
     struct zn_vr_menu_headset_connect_button *self);

--- a/include/zen/ui/nodes/vr-menu/vr-menu.h
+++ b/include/zen/ui/nodes/vr-menu/vr-menu.h
@@ -15,7 +15,7 @@ struct zn_vr_menu {
   struct wl_listener peer_list_changed_listener;
 };
 
-struct zn_vr_menu *zn_vr_menu_create(struct zigzag_layout *zigzag_layout,
-    struct wlr_renderer *renderer, double tip_x);
+struct zn_vr_menu *zn_vr_menu_create(
+    struct zigzag_layout *zigzag_layout, double tip_x);
 
 void zn_vr_menu_destroy(struct zn_vr_menu *self);

--- a/include/zen/ui/nodes/vr-modal/headset-dialog.h
+++ b/include/zen/ui/nodes/vr-modal/headset-dialog.h
@@ -12,7 +12,7 @@ struct zn_vr_modal_item_headset_dialog {
 };
 
 struct zn_vr_modal_item_headset_dialog *zn_vr_modal_item_headset_dialog_create(
-    struct zigzag_layout *zigzag_layout, struct wlr_renderer *renderer);
+    struct zigzag_layout *zigzag_layout);
 
 void zn_vr_modal_item_headset_dialog_destroy(
     struct zn_vr_modal_item_headset_dialog *self);

--- a/zen/ui/nodes/power-menu/clock.c
+++ b/zen/ui/nodes/power-menu/clock.c
@@ -52,28 +52,28 @@ zn_power_menu_item_clock_render(struct zigzag_node *node, cairo_t *cr)
   return true;
 }
 
-static void
-zn_power_menu_item_clock_set_frame(
-    struct zigzag_node *node, double screen_width, double screen_height)
-{
-  node->frame.x =
-      screen_width - power_menu_bubble_width - power_menu_space_right;
-  node->frame.y =
-      screen_height - power_menu_bubble_height - menu_bar_height + 5.;
-  node->frame.width = power_menu_bubble_width;
-  node->frame.height = power_menu_clock_height;
-}
-
 static const struct zigzag_node_impl implementation = {
     .on_click = zn_power_menu_item_clock_on_click,
-    .set_frame = zn_power_menu_item_clock_set_frame,
     .render = zn_power_menu_item_clock_render,
 };
+
+static void
+zn_power_menu_item_clock_init_frame(
+    struct zigzag_node *node, double screen_width, double screen_height)
+{
+  node->pending.frame.x =
+      screen_width - power_menu_bubble_width - power_menu_space_right;
+  node->pending.frame.y =
+      screen_height - power_menu_bubble_height - menu_bar_height + 5.;
+  node->pending.frame.width = power_menu_bubble_width;
+  node->pending.frame.height = power_menu_clock_height;
+}
 
 struct zn_power_menu_item_clock *
 zn_power_menu_item_clock_create(
     struct zigzag_layout *zigzag_layout, struct wlr_renderer *renderer)
 {
+  UNUSED(renderer);
   struct zn_power_menu_item_clock *self;
 
   self = zalloc(sizeof *self);
@@ -83,7 +83,7 @@ zn_power_menu_item_clock_create(
   }
 
   struct zigzag_node *zigzag_node =
-      zigzag_node_create(&implementation, zigzag_layout, renderer, true, self);
+      zigzag_node_create(&implementation, zigzag_layout, true, self);
 
   if (zigzag_node == NULL) {
     zn_error("Failed to create a zigzag_node");
@@ -100,6 +100,10 @@ zn_power_menu_item_clock_create(
   int ms_delay = MSEC_PER_SEC - time_ms % MSEC_PER_SEC;
   if (ms_delay <= 0) ms_delay = 1;
   wl_event_source_timer_update(self->second_timer_source, ms_delay);
+
+  zn_power_menu_item_clock_init_frame(self->zigzag_node,
+      self->zigzag_node->layout->screen_width,
+      self->zigzag_node->layout->screen_height);
 
   return self;
 

--- a/zen/ui/nodes/power-menu/logout.c
+++ b/zen/ui/nodes/power-menu/logout.c
@@ -33,29 +33,29 @@ zn_power_menu_item_logout_render(struct zigzag_node *node, cairo_t *cr)
   return true;
 }
 
-static void
-zn_power_menu_item_logout_set_frame(
-    struct zigzag_node *node, double screen_width, double screen_height)
-{
-  node->frame.x =
-      screen_width - power_menu_bubble_width - power_menu_space_right;
-  node->frame.y = screen_height - power_menu_bubble_height - menu_bar_height +
-                  power_menu_clock_height + 5.;
-
-  node->frame.width = power_menu_bubble_width;
-  node->frame.height = power_menu_logout_height;
-}
-
 static const struct zigzag_node_impl implementation = {
     .on_click = zn_power_menu_item_logout_on_click,
-    .set_frame = zn_power_menu_item_logout_set_frame,
     .render = zn_power_menu_item_logout_render,
 };
+
+static void
+zn_power_menu_item_logout_init_frame(
+    struct zigzag_node *node, double screen_width, double screen_height)
+{
+  node->pending.frame.x =
+      screen_width - power_menu_bubble_width - power_menu_space_right;
+  node->pending.frame.y = screen_height - power_menu_bubble_height -
+                          menu_bar_height + power_menu_clock_height + 5.;
+
+  node->pending.frame.width = power_menu_bubble_width;
+  node->pending.frame.height = power_menu_logout_height;
+}
 
 struct zn_power_menu_item_logout *
 zn_power_menu_item_logout_create(
     struct zigzag_layout *zigzag_layout, struct wlr_renderer *renderer)
 {
+  UNUSED(renderer);
   struct zn_power_menu_item_logout *self;
 
   self = zalloc(sizeof *self);
@@ -65,13 +65,17 @@ zn_power_menu_item_logout_create(
   }
 
   struct zigzag_node *zigzag_node =
-      zigzag_node_create(&implementation, zigzag_layout, renderer, true, self);
+      zigzag_node_create(&implementation, zigzag_layout, true, self);
 
   if (zigzag_node == NULL) {
     zn_error("Failed to create a zigzag_node");
     goto err_power_menu_item_logout;
   }
   self->zigzag_node = zigzag_node;
+
+  zn_power_menu_item_logout_init_frame(self->zigzag_node,
+      self->zigzag_node->layout->screen_width,
+      self->zigzag_node->layout->screen_height);
 
   return self;
 

--- a/zen/ui/nodes/vr-button.c
+++ b/zen/ui/nodes/vr-button.c
@@ -118,9 +118,6 @@ zn_vr_button_create(
       self->zigzag_node->layout->screen_width,
       self->zigzag_node->layout->screen_height);
 
-  zigzag_node_update_frame(self->zigzag_node);
-  zigzag_node_update_texture(self->zigzag_node, renderer);
-
   return self;
 
 err_vr_menu:

--- a/zen/ui/nodes/vr-menu/connect-button.c
+++ b/zen/ui/nodes/vr-menu/connect-button.c
@@ -42,38 +42,37 @@ zn_vr_menu_headset_connect_button_render(struct zigzag_node *node, cairo_t *cr)
   return true;
 }
 
+static const struct zigzag_node_impl implementation = {
+    .on_click = zn_vr_menu_headset_connect_button_on_click,
+    .render = zn_vr_menu_headset_connect_button_render,
+};
+
 static void
-zn_vr_menu_headset_connect_button_set_frame(
+zn_vr_menu_headset_connect_button_init_frame(
     struct zigzag_node *node, double screen_width, double screen_height)
 {
   struct zn_vr_menu_headset_connect_button *self = node->user_data;
-  node->frame.x = screen_width - vr_menu_space_right -
-                  (vr_menu_bubble_width - vr_menu_headset_width) / 2 -
-                  vr_menu_headset_connect_button_margin -
-                  vr_menu_headset_connect_button_width;
+  node->pending.frame.x = screen_width - vr_menu_space_right -
+                          (vr_menu_bubble_width - vr_menu_headset_width) / 2 -
+                          vr_menu_headset_connect_button_margin -
+                          vr_menu_headset_connect_button_width;
 
   struct zn_server *server = zn_server_get_singleton();
   struct zn_remote *remote = server->remote;
 
-  node->frame.y =
+  node->pending.frame.y =
       screen_height - menu_bar_height - tip_height - vr_how_to_connect_height -
       (wl_list_length(&remote->peer_list) - self->idx) *
           vr_menu_headset_height +
       (vr_menu_headset_height - vr_menu_headset_connect_button_height) / 2;
 
-  node->frame.width = vr_menu_headset_connect_button_width;
-  node->frame.height = vr_menu_headset_connect_button_height;
+  node->pending.frame.width = vr_menu_headset_connect_button_width;
+  node->pending.frame.height = vr_menu_headset_connect_button_height;
 }
 
-static const struct zigzag_node_impl implementation = {
-    .on_click = zn_vr_menu_headset_connect_button_on_click,
-    .set_frame = zn_vr_menu_headset_connect_button_set_frame,
-    .render = zn_vr_menu_headset_connect_button_render,
-};
-
 struct zn_vr_menu_headset_connect_button *
-zn_vr_menu_headset_connect_button_create(struct zigzag_layout *zigzag_layout,
-    struct wlr_renderer *renderer, struct zn_peer *peer, int idx)
+zn_vr_menu_headset_connect_button_create(
+    struct zigzag_layout *zigzag_layout, struct zn_peer *peer, int idx)
 {
   struct zn_vr_menu_headset_connect_button *self;
 
@@ -86,13 +85,17 @@ zn_vr_menu_headset_connect_button_create(struct zigzag_layout *zigzag_layout,
   self->idx = idx;
 
   struct zigzag_node *zigzag_node =
-      zigzag_node_create(&implementation, zigzag_layout, renderer, true, self);
+      zigzag_node_create(&implementation, zigzag_layout, true, self);
 
   if (zigzag_node == NULL) {
     zn_error("Failed to create a zigzag_node");
     goto err_vr_menu_headset_connect_button;
   }
   self->zigzag_node = zigzag_node;
+
+  zn_vr_menu_headset_connect_button_init_frame(self->zigzag_node,
+      self->zigzag_node->layout->screen_width,
+      self->zigzag_node->layout->screen_height);
 
   return self;
 

--- a/zen/ui/nodes/vr-menu/headset.c
+++ b/zen/ui/nodes/vr-menu/headset.c
@@ -123,9 +123,6 @@ zn_vr_menu_item_headset_create(struct zigzag_layout *zigzag_layout,
       self->zigzag_node->layout->screen_width,
       self->zigzag_node->layout->screen_height);
 
-  zigzag_node_update_frame(self->zigzag_node);
-  zigzag_node_update_texture(self->zigzag_node, renderer);
-
   wl_list_init(&self->link);
 
   return self;

--- a/zen/ui/nodes/vr-modal/headset-dialog.c
+++ b/zen/ui/nodes/vr-modal/headset-dialog.c
@@ -99,7 +99,7 @@ zn_vr_modal_item_headset_dialog_render(struct zigzag_node *node, cairo_t *cr)
 
   zigzag_cairo_draw_node_frame(cr, node,
       (struct zigzag_color){0.0, 0.0, 0.0, 0.0},
-      (struct zigzag_color){1.0, 1.0, 1.0, 1.0}, 1.0, 8.0);
+      (struct zigzag_color){1.0, 1.0, 1.0, 1.0}, 2.0, 8.0);
 
   cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
   cairo_set_font_size(cr, 13);

--- a/zen/ui/nodes/vr-modal/headset-dialog.c
+++ b/zen/ui/nodes/vr-modal/headset-dialog.c
@@ -82,13 +82,12 @@ zn_vr_modal_item_headset_dialog_render_headset_dialog(cairo_t *cr,
 static bool
 zn_vr_modal_item_headset_dialog_render(struct zigzag_node *node, cairo_t *cr)
 {
-  cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 1.0);
   zigzag_cairo_draw_rounded_rectangle(
       cr, 0, 0, node->frame.width, node->frame.height, 8.0);
-  cairo_stroke_preserve(cr);
-  cairo_set_line_width(cr, 1.0);
-  cairo_set_source_rgba(cr, 0.0, 0.0, 0.0, 0.0);
-  cairo_fill(cr);
+
+  zigzag_cairo_draw_node_frame(cr, node,
+      (struct zigzag_color){0.0, 0.0, 0.0, 0.0},
+      (struct zigzag_color){1.0, 1.0, 1.0, 1.0}, 1.0, 8.0);
 
   cairo_set_source_rgba(cr, 1.0, 1.0, 1.0, 0.5);
   cairo_set_font_size(cr, 13);

--- a/zen/ui/zigzag-layout.c
+++ b/zen/ui/zigzag-layout.c
@@ -70,7 +70,7 @@ zn_zigzag_layout_create(struct zn_screen *screen, struct wlr_renderer *renderer)
   }
   self->vr_modal = vr_modal;
 
-  wl_list_insert(&self->zigzag_layout->node_list, &vr_modal->zigzag_node->link);
+  zigzag_layout_add_node(self->zigzag_layout, vr_modal->zigzag_node, renderer);
 
   struct zn_menu_bar *menu_bar = zn_menu_bar_create(zigzag_layout, renderer);
 
@@ -80,7 +80,7 @@ zn_zigzag_layout_create(struct zn_screen *screen, struct wlr_renderer *renderer)
   }
   self->menu_bar = menu_bar;
 
-  wl_list_insert(&self->zigzag_layout->node_list, &menu_bar->zigzag_node->link);
+  zigzag_layout_add_node(self->zigzag_layout, menu_bar->zigzag_node, renderer);
 
   struct zn_server *server = zn_server_get_singleton();
   self->display_system_changed_listener.notify =

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -29,6 +29,9 @@ struct zigzag_layout {
   const struct zigzag_layout_impl *implementation;
 };
 
+void zigzag_layout_add_node(struct zigzag_layout *layout,
+    struct zigzag_node *node, struct wlr_renderer *renderer);
+
 struct zigzag_layout *zigzag_layout_create(
     const struct zigzag_layout_impl *implementation, double screen_width,
     double screen_height, void *user_data);
@@ -39,8 +42,6 @@ typedef bool (*zigzag_node_render_t)(struct zigzag_node *self, cairo_t *cr);
 
 struct zigzag_node_impl {
   void (*on_click)(struct zigzag_node *self, double x, double y);
-  void (*set_frame)(
-      struct zigzag_node *self, double screen_width, double screen_height);
   zigzag_node_render_t render;
 };
 
@@ -57,10 +58,15 @@ struct zigzag_node {
   struct zigzag_layout *layout;
 
   struct wlr_fbox frame;
-  struct wlr_texture *texture;  // nonnull
+  // nonnull after being inserted to layout or another node
+  struct wlr_texture *texture;
 
   struct zigzag_edge_size padding;
   struct zigzag_edge_size margin;
+
+  struct {
+    struct wlr_fbox frame;
+  } pending;
 
   void *user_data;
 
@@ -77,7 +83,7 @@ struct zigzag_node {
 
 struct zigzag_node *zigzag_node_create(
     const struct zigzag_node_impl *implementation, struct zigzag_layout *layout,
-    struct wlr_renderer *renderer, bool visible, void *user_data);
+    bool visible, void *user_data);
 
 void zigzag_node_destroy(struct zigzag_node *self);
 
@@ -86,6 +92,9 @@ cairo_surface_t *zigzag_node_render_cairo_surface(struct zigzag_node *self,
 
 void zigzag_node_update_texture(
     struct zigzag_node *self, struct wlr_renderer *renderer);
+
+void zigzag_node_add_child(struct zigzag_node *parent,
+    struct zigzag_node *child, struct wlr_renderer *renderer);
 
 void zigzag_node_update_frame(struct zigzag_node *self);
 

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -44,11 +44,23 @@ struct zigzag_node_impl {
   zigzag_node_render_t render;
 };
 
+struct zigzag_edge_size {
+  double left, right;
+  double top, bottom;
+};
+
+struct zigzag_color {
+  double r, g, b, a;
+};
+
 struct zigzag_node {
   struct zigzag_layout *layout;
 
   struct wlr_fbox frame;
   struct wlr_texture *texture;  // nonnull
+
+  struct zigzag_edge_size padding;
+  struct zigzag_edge_size margin;
 
   void *user_data;
 
@@ -87,6 +99,10 @@ void zigzag_node_show(struct zigzag_node *self);
 
 struct wlr_texture *zigzag_wlr_texture_from_cairo_surface(
     cairo_surface_t *surface, struct wlr_renderer *renderer);
+
+void zigzag_cairo_draw_node_frame(cairo_t *cr, struct zigzag_node *node,
+    struct zigzag_color background_color, struct zigzag_color border_color,
+    double border_width, double radius);
 
 void zigzag_cairo_draw_text(cairo_t *cr, char *text, double x, double y,
     enum zigzag_anchor horizontal_anchor, enum zigzag_anchor vertical_anchor);

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -112,6 +112,9 @@ void zigzag_node_update_texture(
 void zigzag_node_add_child(struct zigzag_node *parent,
     struct zigzag_node *child, struct wlr_renderer *renderer);
 
+void zigzag_node_child_total_size(
+    struct zigzag_node *parent, double *width, double *height);
+
 void zigzag_node_update_frame(struct zigzag_node *self);
 
 bool zigzag_node_contains_point(struct zigzag_node *self, double x, double y);

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -40,6 +40,18 @@ void zigzag_layout_destroy(struct zigzag_layout *self);
 
 typedef bool (*zigzag_node_render_t)(struct zigzag_node *self, cairo_t *cr);
 
+enum zigzag_reconfigure_direction {
+  ZIGZAG_RECONFIGURE_HORIZONTAL,
+  ZIGZAG_RECONFIGURE_VERTICAL,
+};
+
+enum zigzag_reconfigure_type {
+  ZIGZAG_RECONFIGURE_START, /** left or top*/
+  ZIGZAG_RECONFIGURE_CENTER,
+  ZIGZAG_RECONFIGURE_END,     /** right or left*/
+  ZIGZAG_RECONFIGURE_JUSTIFY, /** space-between */
+};
+
 struct zigzag_node_impl {
   void (*on_click)(struct zigzag_node *self, double x, double y);
   zigzag_node_render_t render;
@@ -89,6 +101,10 @@ void zigzag_node_destroy(struct zigzag_node *self);
 
 cairo_surface_t *zigzag_node_render_cairo_surface(struct zigzag_node *self,
     zigzag_node_render_t render, double width, double height);
+
+void zigzag_node_reconfigure(struct zigzag_node *self,
+    enum zigzag_reconfigure_direction direction,
+    enum zigzag_reconfigure_type type);
 
 void zigzag_node_update_texture(
     struct zigzag_node *self, struct wlr_renderer *renderer);

--- a/zigzag/include/zigzag.h
+++ b/zigzag/include/zigzag.h
@@ -46,10 +46,11 @@ enum zigzag_reconfigure_direction {
 };
 
 enum zigzag_reconfigure_type {
-  ZIGZAG_RECONFIGURE_START, /** left or top*/
+  ZIGZAG_RECONFIGURE_START = 0, /** left or top*/
   ZIGZAG_RECONFIGURE_CENTER,
   ZIGZAG_RECONFIGURE_END,     /** right or left*/
   ZIGZAG_RECONFIGURE_JUSTIFY, /** space-between */
+  ZIGZAG_RECONFIGURE_TYPE_COUNT,
 };
 
 struct zigzag_node_impl {

--- a/zigzag/meson.build
+++ b/zigzag/meson.build
@@ -4,6 +4,7 @@ _zigzag_srcs = [
   'src/cairo_util.c',
   'src/layout.c',
   'src/node.c',
+  'src/reconfigure.c',
 ]
 
 _zigzag_deps = [

--- a/zigzag/src/cairo_util.c
+++ b/zigzag/src/cairo_util.c
@@ -19,6 +19,28 @@ zigzag_wlr_texture_from_cairo_surface(
 }
 
 void
+zigzag_cairo_draw_node_frame(cairo_t *cr, struct zigzag_node *node,
+    struct zigzag_color background_color, struct zigzag_color border_color,
+    double border_width, double radius)
+{
+  cairo_save(cr);
+
+  zigzag_cairo_draw_rounded_rectangle(
+      cr, 0, 0, node->frame.width, node->frame.height, radius);
+
+  cairo_set_source_rgba(cr, background_color.r, background_color.g,
+      background_color.b, background_color.a);
+  cairo_fill_preserve(cr);
+
+  cairo_set_line_width(cr, border_width);
+  cairo_set_source_rgba(
+      cr, border_color.r, border_color.g, border_color.b, border_color.a);
+  cairo_stroke(cr);
+
+  cairo_restore(cr);
+}
+
+void
 zigzag_cairo_draw_text(cairo_t *cr, char *text, double x, double y,
     enum zigzag_anchor horizontal_anchor, enum zigzag_anchor vertical_anchor)
 {

--- a/zigzag/src/layout.c
+++ b/zigzag/src/layout.c
@@ -4,6 +4,15 @@
 #include <zen-common.h>
 #include <zigzag.h>
 
+void
+zigzag_layout_add_node(struct zigzag_layout *layout, struct zigzag_node *node,
+    struct wlr_renderer *renderer)
+{
+  zigzag_node_update_frame(node);
+  zigzag_node_update_texture(node, renderer);
+  wl_list_insert(&layout->node_list, &node->link);
+}
+
 struct zigzag_layout *
 zigzag_layout_create(const struct zigzag_layout_impl *implementation,
     double screen_width, double screen_height, void *user_data)

--- a/zigzag/src/node.c
+++ b/zigzag/src/node.c
@@ -86,6 +86,22 @@ zigzag_node_add_child(struct zigzag_node *parent, struct zigzag_node *child,
   wl_list_insert(&parent->node_list, &child->link);
 }
 
+void
+zigzag_node_child_total_size(
+    struct zigzag_node *parent, double *width, double *height)
+{
+  *width = 0;
+  *height = 0;
+
+  struct zigzag_node *node_iter;
+  wl_list_for_each (node_iter, &parent->node_list, link) {
+    *width += node_iter->frame.width + node_iter->margin.left +
+              node_iter->margin.right;
+    *height += node_iter->frame.height + node_iter->margin.top +
+               node_iter->margin.bottom;
+  }
+}
+
 struct zigzag_node *
 zigzag_node_create(const struct zigzag_node_impl *implementation,
     struct zigzag_layout *layout, bool visible, void *user_data)

--- a/zigzag/src/node.c
+++ b/zigzag/src/node.c
@@ -73,7 +73,9 @@ zigzag_node_update_texture(
     self->texture = original;
     return;
   }
-  wlr_texture_destroy(original);
+  if (original) {
+    wlr_texture_destroy(original);
+  }
   self->layout->implementation->on_damage(self);
 }
 
@@ -132,7 +134,9 @@ zigzag_node_destroy(struct zigzag_node *self)
 {
   wl_list_remove(&self->node_list);
   wl_list_remove(&self->link);
-  wlr_texture_destroy(self->texture);
+  if (self->texture) {
+    wlr_texture_destroy(self->texture);
+  }
   free(self);
 }
 

--- a/zigzag/src/reconfigure.c
+++ b/zigzag/src/reconfigure.c
@@ -44,7 +44,8 @@ zigzag_node_reconfigure_center(
     if (!ctx->prev_node) {
       self->pending.frame.x =
           ctx->parent_node->frame.x +
-          (ctx->parent_node->frame.width - ctx->child_total_size) / 2;
+          (ctx->parent_node->frame.width - ctx->child_total_size) / 2 +
+          self->margin.left;
     } else {
       self->pending.frame.x = ctx->prev_node->frame.x +
                               ctx->prev_node->frame.width +
@@ -54,7 +55,8 @@ zigzag_node_reconfigure_center(
     if (!ctx->prev_node) {
       self->pending.frame.y =
           ctx->parent_node->frame.y +
-          (ctx->parent_node->frame.height - ctx->child_total_size) / 2;
+          (ctx->parent_node->frame.height - ctx->child_total_size) / 2 +
+          self->margin.top;
     } else {
       self->pending.frame.y = ctx->prev_node->frame.y +
                               ctx->prev_node->frame.height +

--- a/zigzag/src/reconfigure.c
+++ b/zigzag/src/reconfigure.c
@@ -151,8 +151,6 @@ zigzag_node_reconfigure(struct zigzag_node *parent,
     enum zigzag_reconfigure_direction direction,
     enum zigzag_reconfigure_type type)
 {
-  UNUSED(type);
-
   if (!zn_assert(!wl_list_empty(&parent->node_list), "node_list is empty")) {
     return;
   }
@@ -160,7 +158,7 @@ zigzag_node_reconfigure(struct zigzag_node *parent,
   double width, height;
   zigzag_node_child_total_size(parent, &width, &height);
 
-  struct zigzag_reconfigure_context ctx = {
+  struct zigzag_reconfigure_context context = {
       .direction = direction,
       .parent_node = parent,
       .child_list_length = wl_list_length(&parent->node_list),
@@ -170,12 +168,11 @@ zigzag_node_reconfigure(struct zigzag_node *parent,
       .index = 0,
   };
 
-  UNUSED(reconfigure);
   struct zigzag_node *node_iter;
   wl_list_for_each_reverse (node_iter, &parent->node_list, link) {
-    reconfigure[type](node_iter, &ctx);
+    reconfigure[type](node_iter, &context);
     zigzag_node_update_frame(node_iter);
-    ++ctx.index;
-    ctx.prev_node = node_iter;
+    ++context.index;
+    context.prev_node = node_iter;
   }
 }

--- a/zigzag/src/reconfigure.c
+++ b/zigzag/src/reconfigure.c
@@ -1,0 +1,195 @@
+#include <zen-common.h>
+#include <zigzag.h>
+
+struct zigzag_reconfigure_context {
+  enum zigzag_reconfigure_direction direction;
+  struct zigzag_node *parent_node;
+  struct zigzag_node *prev_node;
+  int child_list_length;
+  double child_total_size;
+  int index;
+};
+
+static double
+zigzag_node_child_total_size(
+    struct zigzag_node *parent, enum zigzag_reconfigure_direction direction)
+{
+  double sum = 0;
+
+  struct zigzag_node *node_iter;
+  wl_list_for_each (node_iter, &parent->node_list, link) {
+    if (direction == ZIGZAG_RECONFIGURE_HORIZONTAL) {
+      sum += node_iter->frame.width + node_iter->margin.left +
+             node_iter->margin.right;
+    } else {
+      sum += node_iter->frame.height + node_iter->margin.top +
+             node_iter->margin.bottom;
+    }
+  }
+
+  return sum;
+}
+
+static void
+zigzag_node_reconfigure_start(
+    struct zigzag_node *self, struct zigzag_reconfigure_context *ctx)
+{
+  if (ctx->direction == ZIGZAG_RECONFIGURE_HORIZONTAL) {
+    if (!ctx->prev_node) {
+      self->pending.frame.x = ctx->parent_node->frame.x +
+                              ctx->parent_node->padding.left +
+                              self->margin.left;
+    } else {
+      self->pending.frame.x = ctx->prev_node->frame.x +
+                              ctx->prev_node->frame.width +
+                              ctx->prev_node->margin.right + self->margin.left;
+    }
+  } else {
+    if (!ctx->prev_node) {
+      self->pending.frame.y = ctx->parent_node->frame.y +
+                              ctx->parent_node->padding.top + self->margin.top;
+    } else {
+      self->pending.frame.y = ctx->prev_node->frame.y +
+                              ctx->prev_node->frame.height +
+                              ctx->prev_node->margin.bottom + self->margin.top;
+    }
+  }
+}
+
+static void
+zigzag_node_reconfigure_center(
+    struct zigzag_node *self, struct zigzag_reconfigure_context *ctx)
+{
+  if (ctx->direction == ZIGZAG_RECONFIGURE_HORIZONTAL) {
+    if (!ctx->prev_node) {
+      self->pending.frame.x =
+          ctx->parent_node->frame.x +
+          (ctx->parent_node->frame.width - ctx->child_total_size) / 2;
+    } else {
+      self->pending.frame.x = ctx->prev_node->frame.x +
+                              ctx->prev_node->frame.width +
+                              ctx->prev_node->margin.right + self->margin.left;
+    }
+  } else {
+    if (!ctx->prev_node) {
+      self->pending.frame.y =
+          ctx->parent_node->frame.y +
+          (ctx->parent_node->frame.height - ctx->child_total_size) / 2;
+    } else {
+      self->pending.frame.y = ctx->prev_node->frame.y +
+                              ctx->prev_node->frame.height +
+                              ctx->prev_node->margin.bottom + self->margin.top;
+    }
+  }
+}
+
+static void
+zigzag_node_reconfigure_end(
+    struct zigzag_node *self, struct zigzag_reconfigure_context *ctx)
+{
+  if (ctx->direction == ZIGZAG_RECONFIGURE_HORIZONTAL) {
+    if (!ctx->prev_node) {
+      self->pending.frame.x = ctx->parent_node->frame.x +
+                              ctx->parent_node->frame.width -
+                              ctx->parent_node->padding.right -
+                              self->margin.right - ctx->child_total_size;
+    } else {
+      self->pending.frame.x = ctx->prev_node->frame.x +
+                              ctx->prev_node->frame.width +
+                              ctx->prev_node->margin.right + self->margin.left;
+    }
+  } else {
+    if (!ctx->prev_node) {
+      self->pending.frame.y = ctx->parent_node->frame.y +
+                              ctx->parent_node->frame.height -
+                              ctx->parent_node->padding.bottom -
+                              self->margin.bottom - ctx->child_total_size;
+    } else {
+      self->pending.frame.y = ctx->prev_node->frame.y +
+                              ctx->prev_node->frame.height +
+                              ctx->prev_node->margin.bottom + self->margin.top;
+    }
+  }
+}
+
+static void
+zigzag_node_reconfigure_justify(
+    struct zigzag_node *self, struct zigzag_reconfigure_context *ctx)
+{
+  if (ctx->direction == ZIGZAG_RECONFIGURE_HORIZONTAL) {
+    const double space =
+        (ctx->parent_node->frame.width - ctx->child_total_size) /
+        (ctx->child_list_length - 1);
+
+    if (!ctx->prev_node) {
+      self->pending.frame.x = ctx->parent_node->frame.x +
+                              ctx->parent_node->padding.left +
+                              self->margin.left;
+    } else if (ctx->index == ctx->child_list_length - 1) {
+      self->pending.frame.x = ctx->parent_node->frame.x +
+                              ctx->parent_node->frame.width -
+                              ctx->parent_node->padding.right -
+                              self->frame.width - self->margin.right;
+    } else {
+      self->pending.frame.x =
+          ctx->prev_node->frame.x + ctx->prev_node->frame.width +
+          ctx->prev_node->margin.right + space + self->margin.left;
+    }
+  } else {
+    const double space =
+        (ctx->parent_node->frame.height - ctx->child_total_size) /
+        (ctx->child_list_length - 1);
+
+    if (!ctx->prev_node) {
+      self->pending.frame.y = ctx->parent_node->frame.y +
+                              ctx->parent_node->padding.top + self->margin.top;
+    } else if (ctx->index == ctx->child_list_length - 1) {
+      self->pending.frame.y = ctx->parent_node->frame.y +
+                              ctx->parent_node->frame.height -
+                              ctx->parent_node->padding.bottom -
+                              self->frame.height - self->margin.bottom;
+    } else {
+      self->pending.frame.y =
+          ctx->prev_node->frame.y + ctx->prev_node->frame.height +
+          ctx->prev_node->margin.bottom + space + self->margin.top;
+    }
+  }
+}
+
+static void (*reconfigure[])(
+    struct zigzag_node *self, struct zigzag_reconfigure_context *ctx) = {
+    [ZIGZAG_RECONFIGURE_START] = zigzag_node_reconfigure_start,
+    [ZIGZAG_RECONFIGURE_END] = zigzag_node_reconfigure_end,
+    [ZIGZAG_RECONFIGURE_CENTER] = zigzag_node_reconfigure_center,
+    [ZIGZAG_RECONFIGURE_JUSTIFY] = zigzag_node_reconfigure_justify,
+};
+
+void
+zigzag_node_reconfigure(struct zigzag_node *parent,
+    enum zigzag_reconfigure_direction direction,
+    enum zigzag_reconfigure_type type)
+{
+  UNUSED(type);
+
+  if (!zn_assert(!wl_list_empty(&parent->node_list), "node_list is empty")) {
+    return;
+  }
+
+  struct zigzag_reconfigure_context ctx = {
+      .direction = direction,
+      .parent_node = parent,
+      .child_list_length = wl_list_length(&parent->node_list),
+      .child_total_size = zigzag_node_child_total_size(parent, direction),
+      .prev_node = NULL,
+      .index = 0,
+  };
+
+  UNUSED(reconfigure);
+  struct zigzag_node *node_iter;
+  wl_list_for_each_reverse (node_iter, &parent->node_list, link) {
+    reconfigure[type](node_iter, &ctx);
+    zigzag_node_update_frame(node_iter);
+    ++ctx.index;
+    ctx.prev_node = node_iter;
+  }
+}

--- a/zigzag/src/reconfigure.c
+++ b/zigzag/src/reconfigure.c
@@ -10,26 +10,6 @@ struct zigzag_reconfigure_context {
   int index;
 };
 
-static double
-zigzag_node_child_total_size(
-    struct zigzag_node *parent, enum zigzag_reconfigure_direction direction)
-{
-  double sum = 0;
-
-  struct zigzag_node *node_iter;
-  wl_list_for_each (node_iter, &parent->node_list, link) {
-    if (direction == ZIGZAG_RECONFIGURE_HORIZONTAL) {
-      sum += node_iter->frame.width + node_iter->margin.left +
-             node_iter->margin.right;
-    } else {
-      sum += node_iter->frame.height + node_iter->margin.top +
-             node_iter->margin.bottom;
-    }
-  }
-
-  return sum;
-}
-
 static void
 zigzag_node_reconfigure_start(
     struct zigzag_node *self, struct zigzag_reconfigure_context *ctx)
@@ -175,11 +155,15 @@ zigzag_node_reconfigure(struct zigzag_node *parent,
     return;
   }
 
+  double width, height;
+  zigzag_node_child_total_size(parent, &width, &height);
+
   struct zigzag_reconfigure_context ctx = {
       .direction = direction,
       .parent_node = parent,
       .child_list_length = wl_list_length(&parent->node_list),
-      .child_total_size = zigzag_node_child_total_size(parent, direction),
+      .child_total_size =
+          (direction == ZIGZAG_RECONFIGURE_HORIZONTAL) ? width : height,
       .prev_node = NULL,
       .index = 0,
   };

--- a/zigzag/src/reconfigure.c
+++ b/zigzag/src/reconfigure.c
@@ -138,7 +138,7 @@ zigzag_node_reconfigure_justify(
   }
 }
 
-static void (*reconfigure[])(
+static void (*reconfigure[ZIGZAG_RECONFIGURE_TYPE_COUNT])(
     struct zigzag_node *self, struct zigzag_reconfigure_context *ctx) = {
     [ZIGZAG_RECONFIGURE_START] = zigzag_node_reconfigure_start,
     [ZIGZAG_RECONFIGURE_END] = zigzag_node_reconfigure_end,


### PR DESCRIPTION
## Context

I do want something alike HTML flexbox

## Summary

- Add `zigzag_cairo_draw_node_frame`
- Remove `zigzag_node_impl::set_frane`, introduce pending frame
  - And also add `zigzag_node_add_child`, `zigzag_layout_add_node`
    - `zigzag_node::texture` is created when the node is added to layout or other node
- Add `zigzag_node_reconfigure`

## How to check behavior

Use [watasuke102:test/refactor_zigzag](https://github.com/watasuke102/zen/tree/test/refactor-zigzag). Start zen on this branch, you can see some box. Click that, and they are reconfigured.

## Notes

- I'll refactor `vr_modal` later (See #317)
- ~~This PR will open after merging #288 / #308 / #310 (maybe)~~
