### PR TITLE
bump zen-remote version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
 wlr_glew_renderer_req = '0.15.1.1'
-zen_remote_server_req = '0.1.0.27'
+zen_remote_server_req = '0.1.0.28'
 zigen_protocols_req = '0.0.2'
 
 # dependencies


### PR DESCRIPTION
## Context

We need to bump the version of zen-remote to use `zModel`, `zView`, etc.

See https://github.com/zigen-project/zen-remote/pull/69.

## Summary

Bump zen-remote version

## How to check behavior

<!--
If you added a new feature, please write a way for other developers to easily
check the behavior you have changed or added so that they can catch up with the
changes.
-->
