### PR TITLE
Fix zen-remote version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,7 @@ openvr_req = '>= 1.12.5'
 wayland_protocols_req = '>= 1.24'
 wayland_req = '>= 1.18.0'
 wlroots_req = ['>= 0.15', '< 0.16']
-zen_remote_server_req = '0.1.1'
+zen_remote_server_req = '>= 0.1.1'
 zwin_protocols_req = '0.1.0'
 
 glew_proj = subproject(


### PR DESCRIPTION
## Context

I'm going to update the zen-remote version for a minor fix.
zen-remote-server's API won't be changed but because we are currently specifying a specific version of zen-remote, we have to update zen code as well. I'm going to fix this situation.

## Summary

Specify the zen-remote version using the 'greater than' directive.

## How to check the behavior

<!--
If you have added a new feature, please write a way for other developers
to easily check the behavior you have changed or added, so that they can
keep up with the changes.
-->
